### PR TITLE
Diff View on Changes

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -26,10 +26,7 @@ vsc-extension-quickstart.md
 
 # Test files
 **/.vscode-test.*
-
-# Only include the bundled entrypoint, exclude all other dist artifacts
-dist/**
-!dist/extension.js
+**/*.map
 
 # TypeScript source (keep only compiled)
 **/*.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rewst-buddy",
-	"version": "0.36.0",
+	"version": "0.37.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rewst-buddy",
-			"version": "0.36.0",
+			"version": "0.37.1",
 			"license": "MIT",
 			"devDependencies": {
 				"@0no-co/graphqlsp": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name": "rewst-buddy",
 	"displayName": "rewst-buddy",
 	"description": "Buddy for Rewst (Templates)",
-	"version": "0.37.1",
+	"version": "0.37.0",
 	"icon": "media/rewst-buddy.png",
 	"engines": {
 		"vscode": "^1.107.0"

--- a/src/commands/template/sync/SyncTemplate.ts
+++ b/src/commands/template/sync/SyncTemplate.ts
@@ -26,7 +26,7 @@ export class SyncTemplate extends GenericCommand {
 		log.debug('SyncTemplate: syncing', document.uri.fsPath);
 
 		try {
-			await SyncManager.syncTemplate(document);
+			await SyncManager.syncTemplate(document, { showDiff: true });
 			log.notifyInfo('SUCCESS: Synced template');
 		} catch (e) {
 			log.notifyError('Failed to sync template:', e);

--- a/src/commands/template/sync/SyncTemplate.ts
+++ b/src/commands/template/sync/SyncTemplate.ts
@@ -26,8 +26,10 @@ export class SyncTemplate extends GenericCommand {
 		log.debug('SyncTemplate: syncing', document.uri.fsPath);
 
 		try {
-			await SyncManager.syncTemplate(document, { showDiff: true });
-			log.notifyInfo('SUCCESS: Synced template');
+			const uploaded = await SyncManager.syncTemplate(document, { showDiff: true });
+			if (uploaded) {
+				log.notifyInfo('SUCCESS: Synced template');
+			}
 		} catch (e) {
 			log.notifyError('Failed to sync template:', e);
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,12 @@
 import { CommandInitiater } from '@commands';
 import { extPrefix, context as globalVSContext } from '@global';
 import { LinkManager, SyncManager, SyncOnSaveManager, TemplateMetadataStore } from '@models';
-import { TemplateDefinitionProvider, TemplateHoverProvider } from './providers';
+import {
+	REWST_REMOTE_SCHEME,
+	remoteContentProvider,
+	TemplateDefinitionProvider,
+	TemplateHoverProvider,
+} from './providers';
 import { Server } from '@server';
 import { SessionManager } from '@sessions';
 import { RewstViewProvider, SessionTreeDataProvider, StatusBar } from '@ui';
@@ -38,6 +43,11 @@ export async function activate(context: vscode.ExtensionContext) {
 	context.subscriptions.push(new StatusBar());
 
 	CommandInitiater.registerCommands();
+
+	// Register content provider for remote template diff views
+	context.subscriptions.push(
+		vscode.workspace.registerTextDocumentContentProvider(REWST_REMOTE_SCHEME, remoteContentProvider),
+	);
 
 	// Register DefinitionProvider for template({{guid}}) navigation
 	context.subscriptions.push(

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -173,19 +173,20 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		}
 	}
 
-	async syncTemplate(doc: vscode.TextDocument, options?: { showDiff?: boolean }) {
+	async syncTemplate(doc: vscode.TextDocument, options?: { showDiff?: boolean }): Promise<boolean> {
 		log.trace('syncTemplate: starting', doc.uri.fsPath);
 		const uriKey = doc.uri.toString();
 
 		if (this.syncingUris.has(uriKey)) {
 			log.debug('syncTemplate: already in progress, skipping');
-			return;
+			return false;
 		}
 
 		this.syncingUris.add(uriKey);
 		try {
-			await this.syncTemplateInternal(doc, options?.showDiff ?? false);
+			const uploaded = await this.syncTemplateInternal(doc, options?.showDiff ?? false);
 			log.trace('syncTemplate: completed successfully');
+			return uploaded;
 		} catch (e) {
 			throw log.error('syncTemplate: failed', e);
 		} finally {
@@ -193,7 +194,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		}
 	}
 
-	private async syncTemplateInternal(doc: vscode.TextDocument, showDiff: boolean) {
+	private async syncTemplateInternal(doc: vscode.TextDocument, showDiff: boolean): Promise<boolean> {
 		log.trace('syncTemplateInternal: starting');
 
 		if (doc.isUntitled) {
@@ -255,13 +256,13 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 					org: session.profile.org,
 				};
 				this.addLink(templateLink, doc.uri);
-				break;
+				return false;
 			}
 
 			case 'download-remote':
 				log.debug('syncTemplateInternal: downloading remote (local empty)');
 				await this.applyTemplateToDocument(doc, session, remoteTemplate);
-				break;
+				return true;
 
 			case 'upload-local':
 				log.debug('syncTemplateInternal: uploading local changes (in sync)');
@@ -274,16 +275,16 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 					);
 					if (!confirmed) {
 						log.debug('syncTemplateInternal: upload cancelled by user after diff review');
-						return;
+						return false;
 					}
 				}
 				await this.updateTemplateBody(doc);
-				break;
+				return true;
 
 			case 'conflict':
 				log.debug('syncTemplateInternal: conflict detected');
 				await this.handleConflict(doc, session, remoteTemplate);
-				break;
+				return true;
 		}
 	}
 

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -1,7 +1,7 @@
 import type { SessionChangeEvent } from '@events';
 import { FolderLink, Link, TemplateLink } from '@models';
 import { FullTemplateFragment, Session, SessionManager } from '@sessions';
-import { getHash, log, makeUniqueUri, writeTextFile } from '@utils';
+import { getHash, log, makeUniqueUri, showUploadDiff, writeTextFile } from '@utils';
 import vscode, { Uri } from 'vscode';
 import { LinkManager } from './LinkManager';
 import { SyncOnSaveManager } from './SyncOnSaveManager';
@@ -173,7 +173,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		}
 	}
 
-	async syncTemplate(doc: vscode.TextDocument) {
+	async syncTemplate(doc: vscode.TextDocument, options?: { showDiff?: boolean }) {
 		log.trace('syncTemplate: starting', doc.uri.fsPath);
 		const uriKey = doc.uri.toString();
 
@@ -184,7 +184,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 
 		this.syncingUris.add(uriKey);
 		try {
-			await this.syncTemplateInternal(doc);
+			await this.syncTemplateInternal(doc, options?.showDiff ?? false);
 			log.trace('syncTemplate: completed successfully');
 		} catch (e) {
 			throw log.error('syncTemplate: failed', e);
@@ -193,7 +193,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		}
 	}
 
-	private async syncTemplateInternal(doc: vscode.TextDocument) {
+	private async syncTemplateInternal(doc: vscode.TextDocument, showDiff: boolean) {
 		log.trace('syncTemplateInternal: starting');
 
 		if (doc.isUntitled) {
@@ -265,6 +265,18 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 
 			case 'upload-local':
 				log.debug('syncTemplateInternal: uploading local changes (in sync)');
+				if (showDiff) {
+					const confirmed = await showUploadDiff(
+						doc,
+						remoteTemplate.body,
+						link.template.name,
+						link.template.id,
+					);
+					if (!confirmed) {
+						log.debug('syncTemplateInternal: upload cancelled by user after diff review');
+						return;
+					}
+				}
 				await this.updateTemplateBody(doc);
 				break;
 

--- a/src/providers/RewstRemoteContentProvider.ts
+++ b/src/providers/RewstRemoteContentProvider.ts
@@ -1,0 +1,35 @@
+import vscode from 'vscode';
+
+export const REWST_REMOTE_SCHEME = 'rewst-remote';
+
+/**
+ * Provides in-memory content for remote Rewst templates.
+ * Used to display remote template content as a readonly virtual document
+ * in the diff editor when previewing local changes before uploading.
+ */
+export class RewstRemoteContentProvider implements vscode.TextDocumentContentProvider {
+	private readonly contents = new Map<string, string>();
+
+	private readonly onDidChangeEmitter = new vscode.EventEmitter<vscode.Uri>();
+	readonly onDidChange = this.onDidChangeEmitter.event;
+
+	set(uri: vscode.Uri, content: string): void {
+		this.contents.set(uri.toString(), content);
+		this.onDidChangeEmitter.fire(uri);
+	}
+
+	delete(uri: vscode.Uri): void {
+		this.contents.delete(uri.toString());
+	}
+
+	provideTextDocumentContent(uri: vscode.Uri): string {
+		return this.contents.get(uri.toString()) ?? '';
+	}
+
+	dispose(): void {
+		this.onDidChangeEmitter.dispose();
+		this.contents.clear();
+	}
+}
+
+export const remoteContentProvider = new RewstRemoteContentProvider();

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,2 +1,3 @@
 export { TemplateDefinitionProvider } from './TemplateDefinitionProvider';
 export { TemplateHoverProvider } from './TemplateHoverProvider';
+export { REWST_REMOTE_SCHEME, remoteContentProvider, RewstRemoteContentProvider } from './RewstRemoteContentProvider';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -10,4 +10,5 @@ export { parseCookieString } from './parseCookieString';
 export { requireUnlinked } from './requireUnlinked';
 export { getTemplateURLParams, TemplateURLParams } from './templateUrl';
 export { uriExists } from './uriExists';
+export { showUploadDiff } from './showUploadDiff';
 export { writeTextFile } from './writeTextFile';

--- a/src/utils/showUploadDiff.ts
+++ b/src/utils/showUploadDiff.ts
@@ -1,0 +1,56 @@
+import vscode from 'vscode';
+import { REWST_REMOTE_SCHEME, remoteContentProvider } from '../providers/RewstRemoteContentProvider';
+
+/**
+ * Opens a diff editor showing the current Rewst remote content (left/readonly)
+ * vs the local file (right), then asks the user to confirm or cancel the upload.
+ *
+ * Only used for manual syncs — sync-on-save skips this step.
+ *
+ * @returns true if the user confirmed the upload, false if they cancelled
+ */
+export async function showUploadDiff(
+	localDoc: vscode.TextDocument,
+	remoteBody: string,
+	templateName: string,
+	templateId: string,
+): Promise<boolean> {
+	const remoteUri = vscode.Uri.parse(`${REWST_REMOTE_SCHEME}://templates/${templateId}`);
+	remoteContentProvider.set(remoteUri, remoteBody);
+
+	try {
+		await vscode.commands.executeCommand(
+			'vscode.diff',
+			remoteUri,
+			localDoc.uri,
+			`${templateName}: Rewst (remote) ↔ Local`,
+			{ preview: true },
+		);
+
+		const choice = await vscode.window.showInformationMessage(
+			`Upload your local changes to "${templateName}" in Rewst?`,
+			{ modal: false },
+			'Upload',
+			'Cancel',
+		);
+
+		return choice === 'Upload';
+	} finally {
+		remoteContentProvider.delete(remoteUri);
+
+		// Close the diff tab now that the user has made a decision
+		for (const group of vscode.window.tabGroups.all) {
+			for (const tab of group.tabs) {
+				if (tab.input instanceof vscode.TabInputTextDiff) {
+					const input = tab.input as vscode.TabInputTextDiff;
+					if (
+						input.original.toString() === remoteUri.toString() &&
+						input.modified.toString() === localDoc.uri.toString()
+					) {
+						await vscode.window.tabGroups.close(tab);
+					}
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
These updates allow the extension to have diff sync view when there have been changes to the file and a sync is being attempted.

This will not display a diff view when a file has auto save enabled, this will only display the diff view for a file that has auto save off and is being uploaded and has changes to the file.

Once approved, the sync will carry on and upload to rewst as normal.