### PR TITLE
Extract shared link cleanup primitives

### DIFF
--- a/src/models/LinkManager.test.ts
+++ b/src/models/LinkManager.test.ts
@@ -97,7 +97,8 @@ suite('Unit: LinkManager', () => {
 
 	suite('getTemplateLinkFromId()', () => {
 		test('should find links by template ID', () => {
-			const templateId = '550e8400-e29b-41d4-a716-446655440000';
+			const templateId1 = '550e8400-e29b-41d4-a716-446655440000';
+			const templateId2 = '660e8400-e29b-41d4-a716-446655440001';
 			const uri1 = vscode.Uri.file('/test/file1.txt');
 			const uri2 = vscode.Uri.file('/test/file2.txt');
 
@@ -105,7 +106,7 @@ suite('Unit: LinkManager', () => {
 				uriString: uri1.toString(),
 				org: { id: 'org-1', name: 'Test Org' },
 				type: 'Template',
-				template: { id: templateId, name: 'Shared Template', updatedAt: '' } as any,
+				template: { id: templateId1, name: 'Template 1', updatedAt: '' } as any,
 				bodyHash: 'hash1',
 			};
 
@@ -113,7 +114,34 @@ suite('Unit: LinkManager', () => {
 				uriString: uri2.toString(),
 				org: { id: 'org-1', name: 'Test Org' },
 				type: 'Template',
-				template: { id: templateId, name: 'Shared Template', updatedAt: '' } as any,
+				template: { id: templateId2, name: 'Template 2', updatedAt: '' } as any,
+				bodyHash: 'hash2',
+			};
+
+			LinkManager.addLink(link1);
+			LinkManager.addLink(link2);
+
+			assert.strictEqual(LinkManager.getTemplateLinkFromId(templateId1).length, 1);
+			assert.strictEqual(LinkManager.getTemplateLinkFromId(templateId2).length, 1);
+		});
+
+		test('should replace duplicate links for same template ID and URI', () => {
+			const templateId = '550e8400-e29b-41d4-a716-446655440000';
+			const uri = vscode.Uri.file('/test/file1.txt');
+
+			const link1: TemplateLink = {
+				uriString: uri.toString(),
+				org: { id: 'org-1', name: 'Test Org' },
+				type: 'Template',
+				template: { id: templateId, name: 'Template', updatedAt: '' } as any,
+				bodyHash: 'hash1',
+			};
+
+			const link2: TemplateLink = {
+				uriString: uri.toString(),
+				org: { id: 'org-1', name: 'Test Org' },
+				type: 'Template',
+				template: { id: templateId, name: 'Template', updatedAt: '' } as any,
 				bodyHash: 'hash2',
 			};
 
@@ -121,7 +149,8 @@ suite('Unit: LinkManager', () => {
 			LinkManager.addLink(link2);
 
 			const links = LinkManager.getTemplateLinkFromId(templateId);
-			assert.strictEqual(links.length, 2);
+			assert.strictEqual(links.length, 1);
+			assert.strictEqual(links[0].bodyHash, 'hash2'); // Updated to latest
 		});
 
 		test('should return empty array for unknown template ID', () => {
@@ -241,6 +270,57 @@ suite('Unit: LinkManager', () => {
 
 			const uris = LinkManager.getAllUris();
 			assert.strictEqual(uris.length, 2);
+		});
+	});
+
+	suite('purgeDuplicates()', () => {
+		test('should remove duplicate links keeping the most recent', async () => {
+			const templateId = 'dup-template-id';
+			const uri1 = vscode.Uri.file('/test/file1.txt');
+			const uri2 = vscode.Uri.file('/test/file2.txt');
+
+			const olderLink: TemplateLink = {
+				uriString: uri1.toString(),
+				org: { id: 'org-1', name: 'Org' },
+				type: 'Template',
+				template: { id: templateId, name: 'Template', updatedAt: '2024-01-01T00:00:00Z' } as any,
+				bodyHash: 'old-hash',
+			};
+
+			const newerLink: TemplateLink = {
+				uriString: uri2.toString(),
+				org: { id: 'org-1', name: 'Org' },
+				type: 'Template',
+				template: { id: templateId, name: 'Template', updatedAt: '2024-06-01T00:00:00Z' } as any,
+				bodyHash: 'new-hash',
+			};
+
+			LinkManager.addLink(olderLink);
+			LinkManager.addLink(newerLink);
+
+			const removed = await LinkManager.purgeDuplicates();
+
+			assert.strictEqual(removed, 1);
+			// The newer link should survive
+			assert.strictEqual(LinkManager.isLinked(uri2), true);
+			assert.strictEqual(LinkManager.isLinked(uri1), false);
+			const surviving = LinkManager.getTemplateLinkFromId(templateId);
+			assert.strictEqual(surviving.length, 1);
+			assert.strictEqual(surviving[0].bodyHash, 'new-hash');
+		});
+
+		test('should return 0 when no duplicates exist', async () => {
+			const link: TemplateLink = {
+				uriString: vscode.Uri.file('/test/file.txt').toString(),
+				org: { id: 'org-1', name: 'Org' },
+				type: 'Template',
+				template: { id: 'unique-id', name: 'T', updatedAt: '' } as any,
+				bodyHash: 'h',
+			};
+
+			LinkManager.addLink(link);
+			const removed = await LinkManager.purgeDuplicates();
+			assert.strictEqual(removed, 0);
 		});
 	});
 

--- a/src/models/LinkManager.ts
+++ b/src/models/LinkManager.ts
@@ -11,6 +11,9 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 	private templateIdIndex = new Map<string, TemplateLink[]>();
 	loaded = false;
 
+	/** URIs removed during loadLinks dedup — files still on disk, waiting for purgeDuplicates to delete them */
+	private pendingOrphanUris: string[] = [];
+
 	private readonly linksSavedEmitter = new vscode.EventEmitter<LinksSavedEvent>();
 	readonly onLinksSaved = this.linksSavedEmitter.event;
 
@@ -35,7 +38,7 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 	_resetForTesting(): void {
 		this.linkMap.clear();
 		this.templateIdIndex.clear();
-		this.loaded = false;
+		this.loaded = true; // State is loaded (just empty) — prevents loadLinks from re-triggering
 		this.batchMode = false;
 	}
 
@@ -113,7 +116,12 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 
 	private addToTemplateIndex(link: TemplateLink): void {
 		const existing = this.templateIdIndex.get(link.template.id) ?? [];
-		existing.push(link);
+		const idx = existing.findIndex(l => l.uriString === link.uriString);
+		if (idx >= 0) {
+			existing[idx] = link;
+		} else {
+			existing.push(link);
+		}
 		this.templateIdIndex.set(link.template.id, existing);
 	}
 
@@ -221,9 +229,41 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 		this.linkMap.clear();
 		this.templateIdIndex.clear();
 
-		this.beginBatch();
+		// Deduplicate: keep only the most recently updated link per template ID
+		const bestByTemplateId = new Map<string, TemplateLink>();
+		const duplicateUris: string[] = [];
 
 		for (const link of links) {
+			if (link.type === 'Template') {
+				const tl = link as TemplateLink;
+				const existing = bestByTemplateId.get(tl.template.id);
+				if (existing) {
+					// Keep whichever has the more recent updatedAt
+					if (tl.template.updatedAt > existing.template.updatedAt) {
+						duplicateUris.push(existing.uriString);
+						bestByTemplateId.set(tl.template.id, tl);
+					} else {
+						duplicateUris.push(tl.uriString);
+					}
+					continue;
+				}
+				bestByTemplateId.set(tl.template.id, tl);
+			}
+		}
+
+		const duplicateSet = new Set(duplicateUris);
+		const deduped = links.filter(l => !duplicateSet.has(l.uriString));
+
+		if (duplicateUris.length > 0) {
+			log.info(
+				`LinkManager.loadLinks: removed ${duplicateUris.length} duplicate template links (kept most recent)`,
+			);
+			this.pendingOrphanUris = duplicateUris;
+		}
+
+		this.beginBatch();
+
+		for (const link of deduped) {
 			// Migrate old TemplateLinks: ensure bodyHash exists, clear template.body
 			if (link.type === 'Template') {
 				const templateLink = link as TemplateLink;
@@ -297,6 +337,66 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 	getAllUris(): vscode.Uri[] {
 		this.loadIfNotAlready();
 		return Array.from(this.linkMap.keys()).map(uri => vscode.Uri.parse(uri));
+	}
+
+	/**
+	 * Remove duplicate links for the same template ID at runtime.
+	 * Keeps the link with the most recent updatedAt, removes extras and deletes their orphaned files.
+	 */
+	async purgeDuplicates(): Promise<number> {
+		this.loadIfNotAlready();
+
+		// Collect all URIs whose files need deleting:
+		// 1. Orphans from loadLinks dedup (links already removed, files still on disk)
+		const filesToDelete = [...this.pendingOrphanUris];
+		this.pendingOrphanUris = [];
+
+		// 2. Runtime duplicates still in linkMap
+		const bestByTemplateId = new Map<string, TemplateLink>();
+		for (const link of this.linkMap.values()) {
+			if (link.type !== 'Template') continue;
+			const tl = link as TemplateLink;
+			const existing = bestByTemplateId.get(tl.template.id);
+			if (!existing || tl.template.updatedAt > existing.template.updatedAt) {
+				bestByTemplateId.set(tl.template.id, tl);
+			}
+		}
+
+		const toRemove: TemplateLink[] = [];
+		for (const link of this.linkMap.values()) {
+			if (link.type !== 'Template') continue;
+			const tl = link as TemplateLink;
+			const best = bestByTemplateId.get(tl.template.id);
+			if (best && tl.uriString !== best.uriString) {
+				toRemove.push(tl);
+			}
+		}
+
+		// Remove runtime duplicate links and queue their files for deletion
+		if (toRemove.length > 0) {
+			this.beginBatch();
+			for (const link of toRemove) {
+				this.removeLink(link.uriString);
+				filesToDelete.push(link.uriString);
+			}
+			await this.endBatch();
+		}
+
+		// Delete all orphaned files from disk
+		for (const uriString of filesToDelete) {
+			try {
+				await vscode.workspace.fs.delete(vscode.Uri.parse(uriString));
+				log.debug('LinkManager.purgeDuplicates: deleted file', uriString);
+			} catch {
+				log.trace('LinkManager.purgeDuplicates: file already gone', uriString);
+			}
+		}
+
+		if (filesToDelete.length > 0) {
+			log.info(`LinkManager.purgeDuplicates: cleaned up ${filesToDelete.length} orphaned files`);
+		}
+
+		return filesToDelete.length;
 	}
 
 	getAllTemplateLinks(): TemplateLink[] {


### PR DESCRIPTION
## Summary

Extract the shared LinkManager cleanup and dedupe primitives used by follow-up link-management work.

## Includes

- dedupe handling while loading links
- purgeDuplicates() support
- template index replacement for duplicate URI entries
- unit tests for duplicate behavior

## Notes

This is the base PR for the follow-up branches:
- avoid-dupes-only
- validate-and-purge-links