### PR TITLE
Release v0.39.1: Fix duplicate template entries in sync engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.39.1] - 2026-04-03
+
+### Fixed
+
+- **Template Index Deduplication** - Fixed `templateIdIndex` accumulating duplicate entries on every sync operation (save, auto-fetch, metadata update), causing duplicate items in template QuickPick and wasted memory in providers
+- **Org Template Links Loading** - Added missing `loadIfNotAlready()` guard to `getOrgTemplateLinks()`, preventing potential empty results when called before links are loaded
+
 ## [0.39.0] - 2026-03-26
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name": "rewst-buddy",
 	"displayName": "rewst-buddy",
 	"description": "Buddy for Rewst (Templates)",
-	"version": "0.39.0",
+	"version": "0.39.1",
 	"icon": "media/rewst-buddy.png",
 	"engines": {
 		"vscode": "^1.107.0"

--- a/src/models/LinkManager.test.ts
+++ b/src/models/LinkManager.test.ts
@@ -129,6 +129,79 @@ suite('Unit: LinkManager', () => {
 			assert.strictEqual(links.length, 0);
 		});
 
+		test('should not create duplicates when same link is re-added', () => {
+			const uri = vscode.Uri.file('/test/file.txt');
+			const link: TemplateLink = {
+				uriString: uri.toString(),
+				org: { id: 'org-1', name: 'Test Org' },
+				type: 'Template',
+				template: { id: 'template-1', name: 'Test', updatedAt: '2024-01-01' } as any,
+				bodyHash: 'hash-v1',
+			};
+
+			LinkManager.addLink(link);
+			assert.strictEqual(LinkManager.getTemplateLinkFromId('template-1').length, 1);
+
+			link.bodyHash = 'hash-v2';
+			LinkManager.addLink(link);
+			assert.strictEqual(LinkManager.getTemplateLinkFromId('template-1').length, 1);
+
+			link.bodyHash = 'hash-v3';
+			LinkManager.addLink(link);
+			const result = LinkManager.getTemplateLinkFromId('template-1');
+			assert.strictEqual(result.length, 1);
+			assert.strictEqual(result[0].bodyHash, 'hash-v3');
+		});
+
+		test('should preserve both entries when same template has different URIs after re-add', () => {
+			const templateId = 'shared-template';
+			const uri1 = vscode.Uri.file('/test/file1.txt');
+			const uri2 = vscode.Uri.file('/test/file2.txt');
+
+			const link1: TemplateLink = {
+				uriString: uri1.toString(),
+				org: { id: 'org-1', name: 'Test Org' },
+				type: 'Template',
+				template: { id: templateId, name: 'Shared', updatedAt: '' } as any,
+				bodyHash: 'hash1',
+			};
+
+			const link2: TemplateLink = {
+				uriString: uri2.toString(),
+				org: { id: 'org-1', name: 'Test Org' },
+				type: 'Template',
+				template: { id: templateId, name: 'Shared', updatedAt: '' } as any,
+				bodyHash: 'hash2',
+			};
+
+			LinkManager.addLink(link1);
+			LinkManager.addLink(link2);
+			assert.strictEqual(LinkManager.getTemplateLinkFromId(templateId).length, 2);
+
+			link1.bodyHash = 'hash1-updated';
+			LinkManager.addLink(link1);
+			assert.strictEqual(LinkManager.getTemplateLinkFromId(templateId).length, 2);
+		});
+
+		test('should not grow index across repeated sync cycles', () => {
+			const uri = vscode.Uri.file('/test/synced.txt');
+			const link: TemplateLink = {
+				uriString: uri.toString(),
+				org: { id: 'org-1', name: 'Test Org' },
+				type: 'Template',
+				template: { id: 'sync-template', name: 'Synced', updatedAt: '' } as any,
+				bodyHash: 'hash',
+			};
+
+			for (let i = 0; i < 10; i++) {
+				link.bodyHash = `hash-cycle-${i}`;
+				LinkManager.addLink(link);
+			}
+
+			assert.strictEqual(LinkManager.getTemplateLinkFromId('sync-template').length, 1);
+			assert.strictEqual(LinkManager.getAllTemplateLinks().length, 1);
+		});
+
 		test('should update index when link is removed', () => {
 			const templateId = 'template-to-remove';
 			const uri = vscode.Uri.file('/test/file.txt');

--- a/src/models/LinkManager.ts
+++ b/src/models/LinkManager.ts
@@ -285,6 +285,7 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 	}
 
 	getOrgTemplateLinks(org: Org): TemplateLink[] {
+		this.loadIfNotAlready();
 		const links = this.getOrgLinks(org);
 		return links.filter(l => l.type == 'Template') as TemplateLink[];
 	}

--- a/src/models/LinkManager.ts
+++ b/src/models/LinkManager.ts
@@ -113,8 +113,9 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 
 	private addToTemplateIndex(link: TemplateLink): void {
 		const existing = this.templateIdIndex.get(link.template.id) ?? [];
-		existing.push(link);
-		this.templateIdIndex.set(link.template.id, existing);
+		const filtered = existing.filter(l => l.uriString !== link.uriString);
+		filtered.push(link);
+		this.templateIdIndex.set(link.template.id, filtered);
 	}
 
 	private removeFromTemplateIndex(link: TemplateLink): void {


### PR DESCRIPTION
## Summary

- Fix `templateIdIndex` accumulating duplicate entries on every sync operation (save, auto-fetch, metadata update) by filtering existing entries by URI before pushing
- Add missing `loadIfNotAlready()` guard to `getOrgTemplateLinks()`
- Add 3 regression tests for deduplication behavior

## Test plan

- [x] All 100 unit tests pass (`npm run test:unit`)
- [ ] Verify no duplicate entries appear in template QuickPick after repeated sync cycles
- [ ] Verify multi-file links to the same template still work correctly