### PR TITLE
Lazy-load template metadata: prioritize linked orgs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## [0.39.2] - 2026-04-03
+
+### Changed
+
+- **Lazy Template Metadata Loading** - Template metadata now loads only for orgs with existing template links first, deferring all other orgs (30s at startup, 5s on session events). For a user with links in 3 of 60 orgs, this reduces immediate API calls from 60 to 3.
+
+### Fixed
+
+- **Silent Reload Drop** - Template metadata reload requests were silently ignored when triggered during an active load; now queues and retries after the current load completes
+- **Stale Write Protection** - In-flight API responses could write data into a cleared metadata store (e.g., if sessions were cleared mid-load); a generation counter now prevents this
+
 ## [0.39.1] - 2026-04-03
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name": "rewst-buddy",
 	"displayName": "rewst-buddy",
 	"description": "Buddy for Rewst (Templates)",
-	"version": "0.39.1",
+	"version": "0.39.2",
 	"icon": "media/rewst-buddy.png",
 	"engines": {
 		"vscode": "^1.107.0"

--- a/src/models/TemplateMetadataStore.test.ts
+++ b/src/models/TemplateMetadataStore.test.ts
@@ -1,209 +1,366 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment, createMockSession, Fixtures } from '@test';
+import vscode from 'vscode';
+import { LinkManager, TemplateLink, TemplateMetadataStore } from '@models';
 import { SessionManager } from '@sessions';
-import { TemplateMetadataStore } from './TemplateMetadataStore';
+import { initTestEnvironment, createMockSession, Fixtures } from '@test';
 
 const { suite, test, setup, teardown } = Mocha;
+
+function makeTemplateLink(orgId: string, orgName: string, templateId: string): TemplateLink {
+	return {
+		uriString: vscode.Uri.file(`/test/${templateId}.txt`).toString(),
+		org: { id: orgId, name: orgName },
+		type: 'Template',
+		template: { id: templateId, name: `Template ${templateId}`, updatedAt: '' } as any,
+		bodyHash: 'hash',
+	};
+}
 
 suite('Unit: TemplateMetadataStore', () => {
 	setup(() => {
 		initTestEnvironment();
 		SessionManager._resetForTesting();
-		TemplateMetadataStore.dispose();
+		LinkManager._resetForTesting();
+		TemplateMetadataStore._resetForTesting();
 	});
 
 	teardown(() => {
+		TemplateMetadataStore._resetForTesting();
 		SessionManager._resetForTesting();
-		TemplateMetadataStore.dispose();
+		LinkManager._resetForTesting();
 	});
 
-	test('should load templates from a single session', async () => {
-		// Create test org and templates
-		const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Test Org 1' });
-		const templates = [
-			Fixtures.template({ id: 'template-1', name: 'Template 1', orgId: org1.id }),
-			Fixtures.template({ id: 'template-2', name: 'Template 2', orgId: org1.id }),
-			Fixtures.template({ id: 'template-3', name: 'Template 3', orgId: org1.id }),
-		];
+	suite('basic loading', () => {
+		test('should load templates from a single session with linked org', async () => {
+			const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Test Org 1' });
+			const templates = [
+				Fixtures.template({ id: 'template-1', name: 'Template 1', orgId: org1.id }),
+				Fixtures.template({ id: 'template-2', name: 'Template 2', orgId: org1.id }),
+				Fixtures.template({ id: 'template-3', name: 'Template 3', orgId: org1.id }),
+			];
 
-		// Create mock session with templates
-		const { session, wrapper } = createMockSession({
-			profile: { org: org1, allManagedOrgs: [org1] },
+			const { session, wrapper } = createMockSession({
+				profile: { org: org1, allManagedOrgs: [org1] },
+			});
+
+			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery(templates) });
+			LinkManager.addLink(makeTemplateLink(org1.id, org1.name, 'existing-link'));
+			SessionManager._setSessionsForTesting([session]);
+
+			TemplateMetadataStore.init();
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 1);
+
+			const meta1 = TemplateMetadataStore.getTemplateMetadata('template-1');
+			assert.ok(meta1, 'Template 1 metadata should exist');
+			assert.strictEqual(meta1?.template.name, 'Template 1');
+			assert.strictEqual(meta1?.org.id, org1.id);
+
+			const meta2 = TemplateMetadataStore.getTemplateMetadata('template-2');
+			assert.ok(meta2, 'Template 2 metadata should exist');
+			assert.strictEqual(meta2?.template.name, 'Template 2');
 		});
 
-		wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery(templates) });
+		test('should load templates from multiple sessions with linked orgs', async () => {
+			const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Org 1' });
+			const org2 = Fixtures.orgModel({ id: 'org-2', name: 'Org 2' });
 
-		// Set the session
-		SessionManager._setSessionsForTesting([session]);
+			const org1Templates = [
+				Fixtures.template({ id: 'template-1-1', name: 'Org 1 Template 1', orgId: org1.id }),
+				Fixtures.template({ id: 'template-1-2', name: 'Org 1 Template 2', orgId: org1.id }),
+			];
 
-		// Initialize the store (this triggers loading)
-		TemplateMetadataStore.init();
+			const org2Templates = [Fixtures.template({ id: 'template-2-1', name: 'Org 2 Template 1', orgId: org2.id })];
 
-		// Wait for async loading to complete
-		await new Promise(resolve => setTimeout(resolve, 100));
+			const { session: session1, wrapper: wrapper1 } = createMockSession({
+				profile: { org: org1, allManagedOrgs: [org1] },
+			});
+			wrapper1.when('listTemplates', { data: Fixtures.listTemplatesQuery(org1Templates) });
 
-		// Verify templates were loaded
-		assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 1);
+			const { session: session2, wrapper: wrapper2 } = createMockSession({
+				profile: { org: org2, allManagedOrgs: [org2] },
+			});
+			wrapper2.when('listTemplates', { data: Fixtures.listTemplatesQuery(org2Templates) });
 
-		// Verify we can retrieve templates
-		const meta1 = TemplateMetadataStore.getTemplateMetadata('template-1');
-		assert.ok(meta1, 'Template 1 metadata should exist');
-		assert.strictEqual(meta1?.template.name, 'Template 1');
-		assert.strictEqual(meta1?.org.id, org1.id);
+			LinkManager.addLink(makeTemplateLink(org1.id, org1.name, 'link-org1'));
+			LinkManager.addLink(makeTemplateLink(org2.id, org2.name, 'link-org2'));
+			SessionManager._setSessionsForTesting([session1, session2]);
 
-		const meta2 = TemplateMetadataStore.getTemplateMetadata('template-2');
-		assert.ok(meta2, 'Template 2 metadata should exist');
-		assert.strictEqual(meta2?.template.name, 'Template 2');
+			TemplateMetadataStore.init();
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			assert.strictEqual(wrapper1.getCallsFor('listTemplates').length, 1);
+			assert.strictEqual(wrapper2.getCallsFor('listTemplates').length, 1);
+
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('template-1-1')?.template.name,
+				'Org 1 Template 1',
+			);
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('template-1-2')?.template.name,
+				'Org 1 Template 2',
+			);
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('template-2-1')?.template.name,
+				'Org 2 Template 1',
+			);
+		});
+
+		test('should return undefined for unknown template ID', () => {
+			const result = TemplateMetadataStore.getTemplateMetadata('nonexistent');
+			assert.strictEqual(result, undefined);
+		});
+
+		test('should handle SDK errors gracefully', async () => {
+			const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });
+
+			const { session, wrapper } = createMockSession({
+				profile: { org, allManagedOrgs: [org] },
+			});
+
+			wrapper.when('listTemplates', {
+				error: Fixtures.networkError('Failed to load templates'),
+			});
+
+			LinkManager.addLink(makeTemplateLink(org.id, org.name, 'link-1'));
+			SessionManager._setSessionsForTesting([session]);
+			TemplateMetadataStore.init();
+
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 1);
+			assert.strictEqual(TemplateMetadataStore.getTemplateMetadata('any-id'), undefined);
+		});
 	});
 
-	test('should load templates from multiple sessions with different orgs', async () => {
-		// Create orgs and templates
-		const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Org 1' });
-		const org2 = Fixtures.orgModel({ id: 'org-2', name: 'Org 2' });
+	suite('priority loading', () => {
+		test('should load linked orgs immediately and defer non-linked orgs', async () => {
+			const linkedOrg = Fixtures.orgModel({ id: 'linked-org', name: 'Linked Org' });
+			const unlinkedOrg = Fixtures.orgModel({ id: 'unlinked-org', name: 'Unlinked Org' });
 
-		const org1Templates = [
-			Fixtures.template({ id: 'template-1-1', name: 'Org 1 Template 1', orgId: org1.id }),
-			Fixtures.template({ id: 'template-1-2', name: 'Org 1 Template 2', orgId: org1.id }),
-		];
+			const linkedTemplate = Fixtures.template({ id: 'linked-t1', name: 'Linked Template', orgId: linkedOrg.id });
+			const unlinkedTemplate = Fixtures.template({
+				id: 'unlinked-t1',
+				name: 'Unlinked Template',
+				orgId: unlinkedOrg.id,
+			});
 
-		const org2Templates = [Fixtures.template({ id: 'template-2-1', name: 'Org 2 Template 1', orgId: org2.id })];
+			const { session, wrapper } = createMockSession({
+				profile: {
+					org: linkedOrg,
+					allManagedOrgs: [linkedOrg, unlinkedOrg],
+				},
+			});
 
-		// Create two mock sessions
-		const { session: session1, wrapper: wrapper1 } = createMockSession({
-			profile: { org: org1, allManagedOrgs: [org1] },
+			wrapper.when('listTemplates', (vars: any) => {
+				if (vars.orgId === linkedOrg.id) {
+					return { data: Fixtures.listTemplatesQuery([linkedTemplate]) };
+				}
+				return { data: Fixtures.listTemplatesQuery([unlinkedTemplate]) };
+			});
+
+			LinkManager.addLink(makeTemplateLink(linkedOrg.id, linkedOrg.name, 'existing-link'));
+			SessionManager._setSessionsForTesting([session]);
+
+			TemplateMetadataStore.init();
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			const linkedMeta = TemplateMetadataStore.getTemplateMetadata('linked-t1');
+			assert.ok(linkedMeta, 'Linked org template should be loaded immediately');
+			assert.strictEqual(linkedMeta!.template.name, 'Linked Template');
+
+			const unlinkedMeta = TemplateMetadataStore.getTemplateMetadata('unlinked-t1');
+			assert.strictEqual(unlinkedMeta, undefined, 'Unlinked org template should not be loaded yet');
+
+			const calls = wrapper.getCallsFor('listTemplates');
+			assert.strictEqual(calls.length, 1, 'Only linked org should have been called so far');
+			assert.strictEqual(calls[0].variables.orgId, linkedOrg.id);
 		});
-		wrapper1.when('listTemplates', { data: Fixtures.listTemplatesQuery(org1Templates) });
 
-		const { session: session2, wrapper: wrapper2 } = createMockSession({
-			profile: { org: org2, allManagedOrgs: [org2] },
+		test('should defer all orgs when none have links', async () => {
+			const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Org 1' });
+			const org2 = Fixtures.orgModel({ id: 'org-2', name: 'Org 2' });
+
+			const { session, wrapper } = createMockSession({
+				profile: {
+					org: org1,
+					allManagedOrgs: [org1, org2],
+				},
+			});
+
+			wrapper.when('listTemplates', (vars: any) => {
+				return { data: Fixtures.listTemplatesQuery([Fixtures.template({ orgId: vars.orgId })]) };
+			});
+
+			SessionManager._setSessionsForTesting([session]);
+			TemplateMetadataStore.init();
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			const calls = wrapper.getCallsFor('listTemplates');
+			assert.strictEqual(calls.length, 0, 'No orgs should load immediately when none have links');
 		});
-		wrapper2.when('listTemplates', { data: Fixtures.listTemplatesQuery(org2Templates) });
 
-		// Set both sessions
-		SessionManager._setSessionsForTesting([session1, session2]);
+		test('should handle session with multiple managed orgs (only linked ones load first)', async () => {
+			const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Primary Org' });
+			const org2 = Fixtures.orgModel({ id: 'org-2', name: 'Managed Org 1' });
+			const org3 = Fixtures.orgModel({ id: 'org-3', name: 'Managed Org 2' });
 
-		// Initialize the store
-		TemplateMetadataStore.init();
+			const { session, wrapper } = createMockSession({
+				profile: {
+					org: org1,
+					allManagedOrgs: [org1, org2, org3],
+				},
+			});
 
-		// Wait for async loading
-		await new Promise(resolve => setTimeout(resolve, 100));
+			wrapper.when('listTemplates', (vars: any) => {
+				const templates = [
+					Fixtures.template({ id: `t-${vars.orgId}`, name: `T ${vars.orgId}`, orgId: vars.orgId }),
+				];
+				return { data: Fixtures.listTemplatesQuery(templates) };
+			});
 
-		// Verify both sessions were queried
-		assert.strictEqual(wrapper1.getCallsFor('listTemplates').length, 1);
-		assert.strictEqual(wrapper2.getCallsFor('listTemplates').length, 1);
+			LinkManager.addLink(makeTemplateLink(org1.id, org1.name, 'link-org1'));
+			LinkManager.addLink(makeTemplateLink(org3.id, org3.name, 'link-org3'));
+			SessionManager._setSessionsForTesting([session]);
+			TemplateMetadataStore.init();
 
-		// Verify all templates are available
-		const meta1_1 = TemplateMetadataStore.getTemplateMetadata('template-1-1');
-		assert.strictEqual(meta1_1?.template.name, 'Org 1 Template 1');
-		assert.strictEqual(meta1_1?.org.id, org1.id);
+			await new Promise(resolve => setTimeout(resolve, 100));
 
-		const meta1_2 = TemplateMetadataStore.getTemplateMetadata('template-1-2');
-		assert.strictEqual(meta1_2?.template.name, 'Org 1 Template 2');
+			// Only linked orgs (org1, org3) should have loaded immediately
+			const calls = wrapper.getCallsFor('listTemplates');
+			assert.strictEqual(calls.length, 2, 'Only 2 linked orgs should load immediately');
+			const calledOrgIds = calls.map((c: any) => c.variables.orgId).sort();
+			assert.deepStrictEqual(calledOrgIds, [org1.id, org3.id].sort());
 
-		const meta2_1 = TemplateMetadataStore.getTemplateMetadata('template-2-1');
-		assert.strictEqual(meta2_1?.template.name, 'Org 2 Template 1');
-		assert.strictEqual(meta2_1?.org.id, org2.id);
+			assert.ok(TemplateMetadataStore.getTemplateMetadata(`t-${org1.id}`));
+			assert.ok(TemplateMetadataStore.getTemplateMetadata(`t-${org3.id}`));
+			assert.strictEqual(TemplateMetadataStore.getTemplateMetadata(`t-${org2.id}`), undefined);
+		});
 	});
 
-	test('should handle sessions with multiple managed orgs', async () => {
-		// Create multiple orgs
-		const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Primary Org' });
-		const org2 = Fixtures.orgModel({ id: 'org-2', name: 'Managed Org 1' });
-		const org3 = Fixtures.orgModel({ id: 'org-3', name: 'Managed Org 2' });
+	suite('generation counter (stale write protection)', () => {
+		test('should discard results from stale loads after reset', async () => {
+			const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });
+			const template = Fixtures.template({ id: 't1', name: 'Template 1', orgId: org.id });
 
-		const org1Templates = [Fixtures.template({ id: 't1', name: 'T1', orgId: org1.id })];
-		const org2Templates = [Fixtures.template({ id: 't2', name: 'T2', orgId: org2.id })];
-		const org3Templates = [Fixtures.template({ id: 't3', name: 'T3', orgId: org3.id })];
+			const { session, wrapper } = createMockSession({
+				profile: { org, allManagedOrgs: [org] },
+			});
 
-		// Create session that manages all three orgs
-		const { session, wrapper } = createMockSession({
-			profile: {
-				org: org1,
-				allManagedOrgs: [org1, org2, org3],
-			},
+			LinkManager.addLink(makeTemplateLink(org.id, org.name, 'link-1'));
+			wrapper.when('listTemplates', {
+				data: Fixtures.listTemplatesQuery([template]),
+				delay: 200,
+			});
+
+			SessionManager._setSessionsForTesting([session]);
+			TemplateMetadataStore.init();
+
+			// Reset while load is in flight
+			await new Promise(resolve => setTimeout(resolve, 50));
+			TemplateMetadataStore._resetForTesting();
+
+			// Wait for the delayed response to arrive
+			await new Promise(resolve => setTimeout(resolve, 300));
+
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('t1'),
+				undefined,
+				'Stale load results should be discarded after reset',
+			);
 		});
-
-		// Configure wrapper to return different templates for each org
-		wrapper.when('listTemplates', vars => {
-			if (vars.orgId === org1.id) {
-				return { data: Fixtures.listTemplatesQuery(org1Templates) };
-			} else if (vars.orgId === org2.id) {
-				return { data: Fixtures.listTemplatesQuery(org2Templates) };
-			} else if (vars.orgId === org3.id) {
-				return { data: Fixtures.listTemplatesQuery(org3Templates) };
-			}
-			return { data: Fixtures.listTemplatesQuery([]) };
-		});
-
-		SessionManager._setSessionsForTesting([session]);
-		TemplateMetadataStore.init();
-
-		// Wait for async loading
-		await new Promise(resolve => setTimeout(resolve, 100));
-
-		// Should have queried all three orgs
-		assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 3);
-
-		// Verify templates from all orgs are available
-		assert.strictEqual(TemplateMetadataStore.getTemplateMetadata('t1')?.template.name, 'T1');
-		assert.strictEqual(TemplateMetadataStore.getTemplateMetadata('t2')?.template.name, 'T2');
-		assert.strictEqual(TemplateMetadataStore.getTemplateMetadata('t3')?.template.name, 'T3');
 	});
 
-	test('should clear all templates when sessions are cleared', async () => {
-		const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });
-		const templates = [Fixtures.template({ id: 'template-1', name: 'Template 1', orgId: org.id })];
+	suite('pendingReload', () => {
+		test('should reload after current load finishes when triggered during loading', async () => {
+			const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });
 
-		const { session, wrapper } = createMockSession({
-			profile: { org, allManagedOrgs: [org] },
+			const { session, wrapper } = createMockSession({
+				profile: { org, allManagedOrgs: [org] },
+			});
+
+			LinkManager.addLink(makeTemplateLink(org.id, org.name, 'link-1'));
+
+			let callCount = 0;
+			wrapper.when('listTemplates', () => {
+				callCount++;
+				return {
+					data: Fixtures.listTemplatesQuery([
+						Fixtures.template({ id: `t-${callCount}`, name: `Template ${callCount}`, orgId: org.id }),
+					]),
+					delay: callCount === 1 ? 100 : 0,
+				};
+			});
+
+			SessionManager._setSessionsForTesting([session]);
+			TemplateMetadataStore.init();
+
+			// Fire a session saved event while first load is in progress
+			await new Promise(resolve => setTimeout(resolve, 20));
+			SessionManager._setSessionsForTesting([session]);
+
+			// Wait for both loads to complete
+			await new Promise(resolve => setTimeout(resolve, 300));
+
+			const calls = wrapper.getCallsFor('listTemplates');
+			assert.ok(calls.length >= 2, `Expected at least 2 listTemplates calls, got ${calls.length}`);
 		});
-		wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery(templates) });
-
-		SessionManager._setSessionsForTesting([session]);
-		TemplateMetadataStore.init();
-
-		await new Promise(resolve => setTimeout(resolve, 100));
-
-		// Verify template is loaded
-		assert.ok(TemplateMetadataStore.getTemplateMetadata('template-1'), 'Template should be loaded');
-
-		// Clear sessions
-		SessionManager._resetForTesting();
-
-		// Template should be cleared
-		assert.strictEqual(
-			TemplateMetadataStore.getTemplateMetadata('template-1'),
-			undefined,
-			'Template should be cleared',
-		);
 	});
 
-	test('should handle SDK errors gracefully', async () => {
-		const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });
+	suite('session change handling', () => {
+		test('should clear metadata when sessions are cleared', async () => {
+			const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });
+			const templates = [Fixtures.template({ id: 'template-1', name: 'Template 1', orgId: org.id })];
 
-		const { session, wrapper } = createMockSession({
-			profile: { org, allManagedOrgs: [org] },
+			const { session, wrapper } = createMockSession({
+				profile: { org, allManagedOrgs: [org] },
+			});
+			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery(templates) });
+
+			LinkManager.addLink(makeTemplateLink(org.id, org.name, 'link-1'));
+			SessionManager._setSessionsForTesting([session]);
+			TemplateMetadataStore.init();
+
+			await new Promise(resolve => setTimeout(resolve, 100));
+			assert.ok(TemplateMetadataStore.getTemplateMetadata('template-1'), 'Template should be loaded');
+
+			SessionManager.clearProfiles();
+
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('template-1'),
+				undefined,
+				'Template should be cleared after sessions cleared',
+			);
 		});
+	});
 
-		// Configure wrapper to return an error
-		wrapper.when('listTemplates', {
-			error: Fixtures.networkError('Failed to load templates'),
+	suite('dispose()', () => {
+		test('should clear indexes on dispose', async () => {
+			const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });
+			const template = Fixtures.template({ id: 't1', name: 'Template 1', orgId: org.id });
+
+			const { session, wrapper } = createMockSession({
+				profile: { org, allManagedOrgs: [org] },
+			});
+
+			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery([template]) });
+			LinkManager.addLink(makeTemplateLink(org.id, org.name, 'link-1'));
+			SessionManager._setSessionsForTesting([session]);
+
+			TemplateMetadataStore.init();
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			assert.ok(TemplateMetadataStore.getTemplateMetadata('t1'), 'Template should be loaded before dispose');
+
+			TemplateMetadataStore.dispose();
+
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('t1'),
+				undefined,
+				'Template should be cleared after dispose',
+			);
 		});
-
-		SessionManager._setSessionsForTesting([session]);
-		TemplateMetadataStore.init();
-
-		await new Promise(resolve => setTimeout(resolve, 100));
-
-		// Should have attempted to call listTemplates
-		assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 1);
-
-		// But no templates should be loaded (error was handled gracefully)
-		assert.strictEqual(
-			TemplateMetadataStore.getTemplateMetadata('any-id'),
-			undefined,
-			'No templates should be loaded after error',
-		);
 	});
 });

--- a/src/models/TemplateMetadataStore.test.ts
+++ b/src/models/TemplateMetadataStore.test.ts
@@ -309,6 +309,137 @@ suite('Unit: TemplateMetadataStore', () => {
 		});
 	});
 
+	suite('deferred timer', () => {
+		test('should load deferred orgs after timer fires', async () => {
+			const linkedOrg = Fixtures.orgModel({ id: 'linked-org', name: 'Linked Org' });
+			const deferredOrg = Fixtures.orgModel({ id: 'deferred-org', name: 'Deferred Org' });
+
+			const linkedTemplate = Fixtures.template({ id: 'linked-t1', name: 'Linked Template', orgId: linkedOrg.id });
+			const deferredTemplate = Fixtures.template({
+				id: 'deferred-t1',
+				name: 'Deferred Template',
+				orgId: deferredOrg.id,
+			});
+
+			const { session, wrapper } = createMockSession({
+				profile: { org: linkedOrg, allManagedOrgs: [linkedOrg, deferredOrg] },
+			});
+
+			wrapper.when('listTemplates', (vars: any) => {
+				if (vars.orgId === linkedOrg.id) {
+					return { data: Fixtures.listTemplatesQuery([linkedTemplate]) };
+				}
+				return { data: Fixtures.listTemplatesQuery([deferredTemplate]) };
+			});
+
+			LinkManager.addLink(makeTemplateLink(linkedOrg.id, linkedOrg.name, 'link-1'));
+			TemplateMetadataStore._setDeferredDelayForTesting(200);
+			SessionManager._setSessionsForTesting([session]);
+
+			TemplateMetadataStore.init();
+
+			// Wait for priority load only
+			await new Promise(resolve => setTimeout(resolve, 50));
+			assert.ok(
+				TemplateMetadataStore.getTemplateMetadata('linked-t1'),
+				'Linked template should load immediately',
+			);
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('deferred-t1'),
+				undefined,
+				'Deferred template should not be loaded yet',
+			);
+
+			// Wait for deferred timer (200ms) to fire and complete
+			await new Promise(resolve => setTimeout(resolve, 300));
+			assert.ok(
+				TemplateMetadataStore.getTemplateMetadata('deferred-t1'),
+				'Deferred template should load after timer fires',
+			);
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('deferred-t1')!.template.name,
+				'Deferred Template',
+			);
+		});
+
+		test('should discard stale deferred load when generation changes before timer fires', async () => {
+			const linkedOrg = Fixtures.orgModel({ id: 'linked-org', name: 'Linked Org' });
+			const deferredOrg = Fixtures.orgModel({ id: 'deferred-org', name: 'Deferred Org' });
+
+			const { session, wrapper } = createMockSession({
+				profile: { org: linkedOrg, allManagedOrgs: [linkedOrg, deferredOrg] },
+			});
+
+			wrapper.when('listTemplates', (vars: any) => {
+				return {
+					data: Fixtures.listTemplatesQuery([
+						Fixtures.template({ id: `t-${vars.orgId}`, name: `T ${vars.orgId}`, orgId: vars.orgId }),
+					]),
+				};
+			});
+
+			LinkManager.addLink(makeTemplateLink(linkedOrg.id, linkedOrg.name, 'link-1'));
+			TemplateMetadataStore._setDeferredDelayForTesting(100);
+			SessionManager._setSessionsForTesting([session]);
+
+			TemplateMetadataStore.init();
+			await new Promise(resolve => setTimeout(resolve, 50));
+
+			// Clear sessions before deferred timer fires — increments generation
+			SessionManager.clearProfiles();
+
+			// Wait for deferred timer to fire
+			await new Promise(resolve => setTimeout(resolve, 200));
+
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata(`t-${deferredOrg.id}`),
+				undefined,
+				'Deferred load should be discarded after generation change',
+			);
+		});
+
+		test('should not leak data when dispose is called with pending deferred timer', async () => {
+			const linkedOrg = Fixtures.orgModel({ id: 'linked-org', name: 'Linked Org' });
+			const deferredOrg = Fixtures.orgModel({ id: 'deferred-org', name: 'Deferred Org' });
+
+			const { session, wrapper } = createMockSession({
+				profile: { org: linkedOrg, allManagedOrgs: [linkedOrg, deferredOrg] },
+			});
+
+			wrapper.when('listTemplates', (vars: any) => {
+				return {
+					data: Fixtures.listTemplatesQuery([
+						Fixtures.template({ id: `t-${vars.orgId}`, name: `T ${vars.orgId}`, orgId: vars.orgId }),
+					]),
+				};
+			});
+
+			LinkManager.addLink(makeTemplateLink(linkedOrg.id, linkedOrg.name, 'link-1'));
+			TemplateMetadataStore._setDeferredDelayForTesting(100);
+			SessionManager._setSessionsForTesting([session]);
+
+			TemplateMetadataStore.init();
+			await new Promise(resolve => setTimeout(resolve, 50));
+
+			// Dispose before deferred timer fires
+			TemplateMetadataStore.dispose();
+
+			// Wait past when the deferred timer would have fired
+			await new Promise(resolve => setTimeout(resolve, 200));
+
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata(`t-${linkedOrg.id}`),
+				undefined,
+				'Linked org data should be cleared after dispose',
+			);
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata(`t-${deferredOrg.id}`),
+				undefined,
+				'Deferred org should not leak data after dispose',
+			);
+		});
+	});
+
 	suite('session change handling', () => {
 		test('should clear metadata when sessions are cleared', async () => {
 			const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });

--- a/src/models/TemplateMetadataStore.ts
+++ b/src/models/TemplateMetadataStore.ts
@@ -2,6 +2,7 @@ import type { SessionChangeEvent } from '@events';
 import { SessionManager, TemplateFragment } from '@sessions';
 import { log } from '@utils';
 import vscode from 'vscode';
+import { LinkManager } from './LinkManager';
 import { Org } from './types';
 
 export interface TemplateMetadata {
@@ -9,20 +10,31 @@ export interface TemplateMetadata {
 	org: Org;
 }
 
+interface OrgSession {
+	org: Org;
+	session: ReturnType<typeof SessionManager.getActiveSessions>[0];
+}
+
+const DEFERRED_DELAY_STARTUP_MS = 30_000;
+const DEFERRED_DELAY_SESSION_EVENT_MS = 5_000;
+
 export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 	private templateIndex = new Map<string, TemplateMetadata>();
 	private orgIndex = new Map<string, Set<string>>();
 	private disposables: vscode.Disposable[] = [];
 	private loading = false;
+	private pendingReload = false;
+	private loadGeneration = 0;
+	private deferredTimer: ReturnType<typeof setTimeout> | undefined;
 
 	init(): _ {
 		this.disposables.push(SessionManager.onSessionChange(e => this.handleSessionChange(e)));
-		// Load templates for any existing sessions
-		this.loadAllSessionTemplates();
+		this.loadAllSessionTemplates(DEFERRED_DELAY_STARTUP_MS);
 		return this;
 	}
 
 	dispose(): void {
+		this.clearDeferredTimer();
 		this.disposables.forEach(d => d.dispose());
 		this.templateIndex.clear();
 		this.orgIndex.clear();
@@ -34,7 +46,7 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 
 	private handleSessionChange(event: SessionChangeEvent): void {
 		if (event.type === 'saved') {
-			this.loadAllSessionTemplates();
+			this.loadAllSessionTemplates(DEFERRED_DELAY_SESSION_EVENT_MS);
 		} else if (event.type === 'cleared') {
 			this.clearAll();
 		}
@@ -42,46 +54,85 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 
 	private clearAll(): void {
 		log.debug('TemplateMetadataStore: clearing all metadata');
+		this.loadGeneration++;
+		this.clearDeferredTimer();
 		this.templateIndex.clear();
 		this.orgIndex.clear();
 	}
 
-	private async loadAllSessionTemplates(): Promise<void> {
+	private clearDeferredTimer(): void {
+		if (this.deferredTimer !== undefined) {
+			clearTimeout(this.deferredTimer);
+			this.deferredTimer = undefined;
+		}
+	}
+
+	private collectOrgSessionMap(): Map<string, OrgSession> {
+		const sessions = SessionManager.getActiveSessions();
+		const orgSessionMap = new Map<string, OrgSession>();
+		for (const session of sessions) {
+			for (const org of session.profile.allManagedOrgs) {
+				if (!orgSessionMap.has(org.id)) {
+					orgSessionMap.set(org.id, { org, session });
+				}
+			}
+		}
+		return orgSessionMap;
+	}
+
+	private async loadAllSessionTemplates(deferredDelayMs: number): Promise<void> {
 		if (this.loading) {
-			log.trace('TemplateMetadataStore: already loading, skipping');
+			this.pendingReload = true;
+			log.trace('TemplateMetadataStore: already loading, will reload after');
 			return;
 		}
 
 		this.loading = true;
+		const generation = ++this.loadGeneration;
+		this.clearDeferredTimer();
+
 		try {
-			const sessions = SessionManager.getActiveSessions();
-			if (sessions.length === 0) {
+			const orgSessionMap = this.collectOrgSessionMap();
+			if (orgSessionMap.size === 0) {
 				log.trace('TemplateMetadataStore: no active sessions');
 				return;
 			}
 
-			log.debug('TemplateMetadataStore: loading templates for sessions', sessions.length);
+			const linkedOrgIds = new Set(LinkManager.getAllTemplateLinks().map(l => l.org.id));
 
-			// Collect all orgs from all sessions (including managed orgs)
-			const orgSessionMap = new Map<string, { org: Org; session: (typeof sessions)[0] }>();
-			for (const session of sessions) {
-				for (const org of session.profile.allManagedOrgs) {
-					if (!orgSessionMap.has(org.id)) {
-						orgSessionMap.set(org.id, { org, session });
-					}
+			const priorityOrgs: OrgSession[] = [];
+			const deferredOrgs: OrgSession[] = [];
+
+			for (const entry of orgSessionMap.values()) {
+				if (linkedOrgIds.has(entry.org.id)) {
+					priorityOrgs.push(entry);
+				} else {
+					deferredOrgs.push(entry);
 				}
 			}
 
-			// Load templates in parallel with chunking (5 concurrent requests)
-			const orgs = Array.from(orgSessionMap.values());
-			const chunkSize = 5;
+			log.debug('TemplateMetadataStore: loading templates', {
+				priority: priorityOrgs.length,
+				deferred: deferredOrgs.length,
+			});
 
-			for (let i = 0; i < orgs.length; i += chunkSize) {
-				const chunk = orgs.slice(i, i + chunkSize);
-				await Promise.all(chunk.map(({ org, session }) => this.loadOrgTemplates(org, session)));
+			await this.loadOrgChunks(priorityOrgs, generation);
+
+			if (generation !== this.loadGeneration) return;
+
+			if (deferredOrgs.length > 0) {
+				this.deferredTimer = setTimeout(() => {
+					this.deferredTimer = undefined;
+					this.loadOrgChunks(deferredOrgs, generation).then(() => {
+						log.debug('TemplateMetadataStore: deferred load complete', {
+							templateCount: this.templateIndex.size,
+							orgCount: this.orgIndex.size,
+						});
+					});
+				}, deferredDelayMs);
 			}
 
-			log.debug('TemplateMetadataStore: loaded templates', {
+			log.debug('TemplateMetadataStore: priority load complete', {
 				templateCount: this.templateIndex.size,
 				orgCount: this.orgIndex.size,
 			});
@@ -89,23 +140,38 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 			log.error('TemplateMetadataStore: failed to load templates', error);
 		} finally {
 			this.loading = false;
+			if (this.pendingReload) {
+				this.pendingReload = false;
+				this.loadAllSessionTemplates(DEFERRED_DELAY_SESSION_EVENT_MS);
+			}
+		}
+	}
+
+	private async loadOrgChunks(orgs: OrgSession[], generation: number): Promise<void> {
+		const chunkSize = 5;
+		for (let i = 0; i < orgs.length; i += chunkSize) {
+			if (generation !== this.loadGeneration) return;
+			const chunk = orgs.slice(i, i + chunkSize);
+			await Promise.all(chunk.map(({ org, session }) => this.loadOrgTemplates(org, session, generation)));
 		}
 	}
 
 	private async loadOrgTemplates(
 		org: Org,
 		session: ReturnType<typeof SessionManager.getActiveSessions>[0],
+		generation: number,
 	): Promise<void> {
 		try {
 			log.trace('TemplateMetadataStore: loading templates for org', org.name);
 			const response = await session.sdk?.listTemplates({ orgId: org.id });
+
+			if (generation !== this.loadGeneration) return;
 
 			if (!response?.templates) {
 				log.trace('TemplateMetadataStore: no templates found for org', org.name);
 				return;
 			}
 
-			// Clear existing templates for this org before adding new ones
 			this.clearOrgTemplates(org.id);
 
 			const templateIds = new Set<string>();
@@ -132,5 +198,16 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 			}
 			this.orgIndex.delete(orgId);
 		}
+	}
+
+	_resetForTesting(): void {
+		this.clearDeferredTimer();
+		this.disposables.forEach(d => d.dispose());
+		this.disposables = [];
+		this.templateIndex.clear();
+		this.orgIndex.clear();
+		this.loading = false;
+		this.pendingReload = false;
+		this.loadGeneration++;
 	}
 })();

--- a/src/models/TemplateMetadataStore.ts
+++ b/src/models/TemplateMetadataStore.ts
@@ -26,6 +26,7 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 	private pendingReload = false;
 	private loadGeneration = 0;
 	private deferredTimer: ReturnType<typeof setTimeout> | undefined;
+	private deferredDelayOverride: number | undefined;
 
 	init(): _ {
 		this.disposables.push(SessionManager.onSessionChange(e => this.handleSessionChange(e)));
@@ -34,10 +35,14 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 	}
 
 	dispose(): void {
+		this.loadGeneration++;
 		this.clearDeferredTimer();
 		this.disposables.forEach(d => d.dispose());
+		this.disposables = [];
 		this.templateIndex.clear();
 		this.orgIndex.clear();
+		this.loading = false;
+		this.pendingReload = false;
 	}
 
 	getTemplateMetadata(templateId: string): TemplateMetadata | undefined {
@@ -121,15 +126,21 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 			if (generation !== this.loadGeneration) return;
 
 			if (deferredOrgs.length > 0) {
+				const delay = this.deferredDelayOverride ?? deferredDelayMs;
 				this.deferredTimer = setTimeout(() => {
 					this.deferredTimer = undefined;
-					this.loadOrgChunks(deferredOrgs, generation).then(() => {
-						log.debug('TemplateMetadataStore: deferred load complete', {
-							templateCount: this.templateIndex.size,
-							orgCount: this.orgIndex.size,
+					if (generation !== this.loadGeneration) return;
+					this.loadOrgChunks(deferredOrgs, generation)
+						.then(() => {
+							log.debug('TemplateMetadataStore: deferred load complete', {
+								templateCount: this.templateIndex.size,
+								orgCount: this.orgIndex.size,
+							});
+						})
+						.catch(error => {
+							log.error('TemplateMetadataStore: deferred load failed', error);
 						});
-					});
-				}, deferredDelayMs);
+				}, delay);
 			}
 
 			log.debug('TemplateMetadataStore: priority load complete', {
@@ -162,8 +173,12 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 		generation: number,
 	): Promise<void> {
 		try {
+			if (!session.sdk) {
+				log.warn('TemplateMetadataStore: no SDK available for org', org.name);
+				return;
+			}
 			log.trace('TemplateMetadataStore: loading templates for org', org.name);
-			const response = await session.sdk?.listTemplates({ orgId: org.id });
+			const response = await session.sdk.listTemplates({ orgId: org.id });
 
 			if (generation !== this.loadGeneration) return;
 
@@ -200,6 +215,10 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 		}
 	}
 
+	_setDeferredDelayForTesting(ms: number): void {
+		this.deferredDelayOverride = ms;
+	}
+
 	_resetForTesting(): void {
 		this.clearDeferredTimer();
 		this.disposables.forEach(d => d.dispose());
@@ -209,5 +228,6 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 		this.loading = false;
 		this.pendingReload = false;
 		this.loadGeneration++;
+		this.deferredDelayOverride = undefined;
 	}
 })();


### PR DESCRIPTION
## Summary

- **Priority loading**: `TemplateMetadataStore` now loads templates only for orgs that have existing template links first, deferring all other orgs (30s on startup, 5s on session events). For a user with links in 3 of 60 orgs, this reduces immediate API calls from 60 to 3.
- **Fixes silent-drop bug**: Previously, if `loadAllSessionTemplates` was called while already loading, the new request was silently ignored. Now a `pendingReload` flag ensures it re-triggers after the current load completes.
- **Stale write protection**: A generation counter prevents in-flight API responses from writing into a cleared store (e.g., if sessions are cleared mid-load).
- **Review fixes**: Added `.catch()` on deferred timer promise, fixed `dispose()` to increment generation counter, explicit SDK null check, and 3 new deferred timer tests.

## Test plan

- [x] All 109 unit tests pass (`npm run test:unit`)
- [x] No IDE diagnostics / type errors
- [ ] Manual: start extension with saved sessions → linked-org hover works immediately
- [ ] Manual: hover over template from non-linked org → shows "Unknown template" initially, resolves after deferred load
- [ ] Manual: clear sessions during background load → no errors, metadata clears