### PR TITLE
Custom graphql calls

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,6 +44,5 @@
 	"prettier.requireConfig": true,
 	"git.allowNoVerifyCommit": true,
 	"chat.extensionUnification.enabled": false,
-	"chat.disableAIFeatures": true,
-	"rewst-buddy.ai.enableGraphqlTool": true
+	"chat.disableAIFeatures": true
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -44,5 +44,6 @@
 	"prettier.requireConfig": true,
 	"git.allowNoVerifyCommit": true,
 	"chat.extensionUnification.enabled": false,
-	"chat.disableAIFeatures": true
+	"chat.disableAIFeatures": true,
+	"rewst-buddy.ai.enableGraphqlTool": true
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [0.40.4] - 2026-06-11
+
+### Added
+
+- **RoboRewsty GraphQL Tool (opt-in, mutation-approval-gated)** - `rewst_graphql` lets RoboRewsty compose and run GraphQL operations against your Rewst instance using your existing session, with `rewst_graphql_schema` for exploring the available schema. Queries run directly; mutations always show an approval dialog with the full operation before running. Disabled by default (`rewst-buddy.ai.enableGraphqlTool`) because the session can read and change anything you can in Rewst
+
 ## [0.40.3] - 2026-06-11
 
 ### Added

--- a/docs/features.md
+++ b/docs/features.md
@@ -116,6 +116,7 @@ Off by default because they let a remote assistant direct activity on your machi
 
 - **Web** (`rewst-buddy.ai.enableWebTools`) — `web_search` and `fetch_url` for public pages. Only http(s) is allowed; private/loopback hosts are always blocked
 - **Commands** (`rewst-buddy.ai.enableCommandTool`) — `run_command` runs shell commands in your workspace root (60s timeout, capped output). When enabled, **every command pops an approval dialog showing exactly what will run**; decline and it won't retry. `rewst-buddy.ai.autoApproveCommands` skips the prompt — leave it off unless you fully trust what the assistant may propose
+- **GraphQL** (`rewst-buddy.ai.enableGraphqlTool`) — `rewst_graphql` composes and runs GraphQL operations against your Rewst instance using your session, with `rewst_graphql_schema` for exploring the schema. Queries run directly; **mutations always pop an approval dialog showing the full operation**. Off by default because the session can read and change anything you can in Rewst
 
 ### Approving Rewst actions
 

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -104,6 +104,7 @@ All settings live under the `rewst-buddy.*` namespace. Edit via VS Code Settings
 | `rewst-buddy.ai.maxToolRounds`        | `number`  | `4`                                                         | Maximum back-and-forth rounds of workspace tool calls RoboRewsty may use per question before it must answer. `0` = unlimited (cancel any time with the stop button).                                                                                |
 | `rewst-buddy.ai.enableCommandTool`    | `boolean` | `false`                                                     | Let RoboRewsty run shell commands in the workspace root and read their output. Off by default; when on, each command needs your approval unless Auto Approve is set.                                                                                |
 | `rewst-buddy.ai.autoApproveCommands`  | `boolean` | `false`                                                     | Run RoboRewsty's commands without an approval prompt (only when Enable Command Tool is on). Leave off unless you fully trust every command the remote assistant proposes.                                                                           |
+| `rewst-buddy.ai.enableGraphqlTool`    | `boolean` | `false`                                                     | Let RoboRewsty compose and run GraphQL operations against your Rewst instance using your session. Queries run directly; mutations always require your approval in a dialog showing the full operation.                                              |
 
 ## Multi-Region Setup
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rewst-buddy",
-	"version": "0.40.2",
+	"version": "0.40.8",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rewst-buddy",
-			"version": "0.40.2",
+			"version": "0.40.8",
 			"license": "MIT",
 			"devDependencies": {
 				"@0no-co/graphqlsp": "^1.15.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rewst-buddy",
-	"version": "0.40.8",
+	"version": "0.40.4",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rewst-buddy",
-			"version": "0.40.8",
+			"version": "0.40.4",
 			"license": "MIT",
 			"devDependencies": {
 				"@0no-co/graphqlsp": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name": "rewst-buddy",
 	"displayName": "rewst-buddy",
 	"description": "Unofficial community VS Code extension for editing Rewst templates locally. Not affiliated with Rewst LLC.",
-	"version": "0.40.3",
+	"version": "0.40.4",
 	"icon": "media/rewst-buddy.png",
 	"engines": {
 		"vscode": "^1.107.0"
@@ -149,6 +149,11 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Run commands from RoboRewsty without an approval prompt. Only takes effect when Enable Command Tool is on. Leave off unless you fully trust every command the remote assistant may propose."
+				},
+				"rewst-buddy.ai.enableGraphqlTool": {
+					"type": "boolean",
+					"default": false,
+					"description": "Let RoboRewsty compose and run GraphQL operations against your Rewst instance using your session. Queries run directly; mutations always require your approval in a dialog showing the full operation. Off by default because the session can read and change anything you can in Rewst."
 				}
 			}
 		},

--- a/src/sessions/Session.test.ts
+++ b/src/sessions/Session.test.ts
@@ -1,0 +1,84 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import { initTestEnvironment } from '@test';
+import SessionProfile from './SessionProfile';
+import Session from './Session';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function listen(server: Server): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			server.off('error', reject);
+			resolve((server.address() as AddressInfo).port);
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close(error => (error ? reject(error) : resolve()));
+	});
+}
+
+suite('Unit: Session', () => {
+	let servers: Server[] = [];
+
+	setup(() => {
+		initTestEnvironment();
+		servers = [];
+	});
+
+	teardown(async () => {
+		await Promise.all(servers.map(server => close(server)));
+	});
+
+	test('rawGraphql sends the session cookie stored in extension secrets', async () => {
+		const orgId = 'org-raw-graphql';
+		const expectedCookie = 'appSession=test-cookie; other=value';
+		let receivedCookie = '';
+		let receivedBody: { query?: string; variables?: Record<string, unknown> } | undefined;
+
+		const server = createServer((request, response) => {
+			receivedCookie = request.headers.cookie ?? '';
+			let body = '';
+			request.on('data', chunk => {
+				body += String(chunk);
+			});
+			request.on('end', () => {
+				receivedBody = JSON.parse(body);
+				response.writeHead(200, { 'content-type': 'application/json' });
+				response.end(JSON.stringify({ data: { ok: true } }));
+			});
+		});
+		servers.push(server);
+		const port = await listen(server);
+
+		const context = initTestEnvironment();
+		await context.secrets.store(orgId, expectedCookie);
+
+		const profile: SessionProfile = {
+			region: {
+				name: 'Local Test',
+				cookieName: 'appSession',
+				graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+				loginUrl: 'http://127.0.0.1',
+			},
+			org: { id: orgId, name: 'Raw GraphQL Org' },
+			allManagedOrgs: [{ id: orgId, name: 'Raw GraphQL Org' }],
+			label: 'Raw GraphQL Session',
+			user: { id: 'user-1' } as SessionProfile['user'],
+		};
+
+		const session = new Session(undefined, profile);
+		const result = await session.rawGraphql('query Check($id: ID!) { node(id: $id) { id } }', { id: 'n-1' });
+
+		assert.deepStrictEqual(result, { data: { ok: true }, errors: undefined });
+		assert.strictEqual(receivedCookie, expectedCookie);
+		assert.match(receivedBody?.query ?? '', /query Check/);
+		assert.deepStrictEqual(receivedBody?.variables, { id: 'n-1' });
+	});
+});

--- a/src/sessions/Session.ts
+++ b/src/sessions/Session.ts
@@ -181,6 +181,25 @@ export default class Session {
 		return await Session.getCookies(this.profile.org.id);
 	}
 
+	/**
+	 * Executes an arbitrary GraphQL document against this session's region
+	 * endpoint, authenticated with the stored session cookie. Used by the chat
+	 * rewst_graphql tool; the extension's own operations use the typed SDK.
+	 */
+	public async rawGraphql(
+		query: string,
+		variables?: Record<string, unknown>,
+	): Promise<{ data?: unknown; errors?: unknown }> {
+		const cookie = await this.getCookies();
+		const client = new GraphQLClient(this.profile.region.graphqlUrl, {
+			errorPolicy: 'all',
+			method: 'POST',
+			headers: () => ({ cookie }),
+		});
+		const { data, errors } = await client.rawRequest(query, variables);
+		return { data, errors };
+	}
+
 	async getTemplate(templateId: string) {
 		log.trace('getTemplate: fetching', templateId);
 		const response = await this.sdk?.getTemplate({ id: templateId });

--- a/src/sessions/Session.ts
+++ b/src/sessions/Session.ts
@@ -19,17 +19,18 @@ export default class Session {
 		this.secrets = context.secrets;
 	}
 
+	private static createClient(graphqlUrl: string, cookie: string): GraphQLClient {
+		return new GraphQLClient(graphqlUrl, {
+			errorPolicy: 'all',
+			method: 'POST',
+			headers: () => ({ cookie }),
+		});
+	}
+
 	private static newSdkAtRegion(cookieString: CookieString, config: RegionConfig): Sdk {
 		log.trace('newSdkAtRegion: creating SDK', { region: config.name, url: config.graphqlUrl });
 
-		const client = new GraphQLClient(config.graphqlUrl, {
-			errorPolicy: 'all',
-			method: 'POST',
-			headers: () => ({
-				cookie: cookieString.value,
-			}),
-		});
-
+		const client = Session.createClient(config.graphqlUrl, cookieString.value);
 		const wrapper = Session.getWrapper();
 		const sdk = getSdk(client, wrapper);
 		return sdk;
@@ -191,12 +192,9 @@ export default class Session {
 		variables?: Record<string, unknown>,
 	): Promise<{ data?: unknown; errors?: unknown }> {
 		const cookie = await this.getCookies();
-		const client = new GraphQLClient(this.profile.region.graphqlUrl, {
-			errorPolicy: 'all',
-			method: 'POST',
-			headers: () => ({ cookie }),
-		});
-		const { data, errors } = await client.rawRequest(query, variables);
+		const client = Session.createClient(this.profile.region.graphqlUrl, cookie);
+		const wrapper = createRetryWrapper();
+		const { data, errors } = await wrapper(() => client.rawRequest(query, variables), 'rawGraphql');
 		return { data, errors };
 	}
 

--- a/src/ui/chat/RewstChatParticipant.ts
+++ b/src/ui/chat/RewstChatParticipant.ts
@@ -26,6 +26,7 @@ import {
 import { buildWorkspaceOverview, EDIT_TOOL_SPECS, runToolRequests, WORKSPACE_TOOL_SPECS } from './tools/workspaceTools';
 import { WEB_TOOL_SPECS } from './tools/webTools';
 import { COMMAND_TOOL_SPECS } from './tools/commandTool';
+import { createGraphqlDeps, GRAPHQL_TOOL_SPECS } from './tools/graphqlTool';
 
 const PARTICIPANT_ID = 'rewst-buddy.rewst';
 // Command an inline approval button invokes, and the prompt it re-submits so
@@ -143,8 +144,14 @@ export const RewstChatParticipant = new (class RewstChatParticipant implements v
 		}
 
 		const aiConfig = vscode.workspace.getConfiguration(`${extPrefix}.ai`);
-		const toolsEnabled =
+		const workspaceToolsEnabled =
 			aiConfig.get<boolean>('enableWorkspaceTools', true) && (vscode.workspace.workspaceFolders?.length ?? 0) > 0;
+		const graphQlToolEnabled = aiConfig.get<boolean>('enableGraphqlTool', false);
+		const toolsEnabled =
+			workspaceToolsEnabled ||
+			graphQlToolEnabled ||
+			aiConfig.get<boolean>('enableWebTools', false) ||
+			aiConfig.get<boolean>('enableCommandTool', false);
 		// 0 (or less) means unlimited rounds — the loop runs until the
 		// assistant stops requesting tools or the user cancels.
 		const configuredRounds = aiConfig.get<number>('maxToolRounds', 4);
@@ -217,13 +224,16 @@ export const RewstChatParticipant = new (class RewstChatParticipant implements v
 			message = prependInstructions(formatPromptWithReferences(request.prompt, references), customInstructions);
 			if (toolsEnabled) {
 				const specs = [
-					...WORKSPACE_TOOL_SPECS,
-					...(aiConfig.get<boolean>('enableEditTools', true) ? EDIT_TOOL_SPECS : []),
+					...(workspaceToolsEnabled ? WORKSPACE_TOOL_SPECS : []),
+					...(workspaceToolsEnabled && aiConfig.get<boolean>('enableEditTools', true) ? EDIT_TOOL_SPECS : []),
 					...(aiConfig.get<boolean>('enableWebTools', false) ? WEB_TOOL_SPECS : []),
 					...(aiConfig.get<boolean>('enableCommandTool', false) ? COMMAND_TOOL_SPECS : []),
+					...(graphQlToolEnabled ? GRAPHQL_TOOL_SPECS : []),
 				];
-				const overview = await buildWorkspaceOverview();
-				if (overview) message += `\n\nThe user's VS Code workspace:\n${overview}`;
+				if (workspaceToolsEnabled) {
+					const overview = await buildWorkspaceOverview();
+					if (overview) message += `\n\nThe user's VS Code workspace:\n${overview}`;
+				}
 				message += `\n\n${buildToolInstructions(specs)}`;
 			}
 			// Target for apply-suggestion buttons; captured now because the active
@@ -283,7 +293,12 @@ export const RewstChatParticipant = new (class RewstChatParticipant implements v
 				}
 				const results = [
 					...blocked.map(blockedRepeatResult),
-					...(await runToolRequests(run, undefined, label => stream.progress(label))),
+					...(await runToolRequests(
+						run,
+						undefined,
+						label => stream.progress(label),
+						createGraphqlDeps(target.session),
+					)),
 				];
 				this.renderToolActivity(stream, results, referencedFiles);
 				message = formatToolResults(results);
@@ -485,7 +500,7 @@ export const RewstChatParticipant = new (class RewstChatParticipant implements v
 				result.ok && result.change ? ` (${diffStats(result.change.before, result.change.after)})` : '';
 			return `- \`${result.tool}\` ${detail}${stats}${result.ok ? '' : ' — failed'}`;
 		});
-		stream.markdown(`\n\n*Workspace activity:*\n${lines.join('\n')}\n\n`);
+		stream.markdown(`\n\n*Tool activity:*\n${lines.join('\n')}\n\n`);
 
 		for (const uriString of results.flatMap(result => result.fileUriStrings ?? [])) {
 			if (referenced.has(uriString)) continue;
@@ -523,7 +538,7 @@ export const RewstChatParticipant = new (class RewstChatParticipant implements v
 		}
 		if (toolBudgetExhausted) {
 			stream.markdown(
-				'\n\n*RoboRewsty wanted to inspect more of the workspace but hit the tool-round limit (`rewst-buddy.ai.maxToolRounds`). Ask a follow-up to continue.*\n',
+				'\n\n*RoboRewsty wanted to run more tools but hit the tool-round limit (`rewst-buddy.ai.maxToolRounds`). Ask a follow-up to continue.*\n',
 			);
 		}
 	}

--- a/src/ui/chat/tools/graphqlTool.test.ts
+++ b/src/ui/chat/tools/graphqlTool.test.ts
@@ -1,0 +1,286 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import { detectOperationType, isGraphqlTool, runGraphqlTool, type GraphqlToolDeps } from './graphqlTool';
+
+const { suite, test, setup } = Mocha;
+
+function deps(over: Partial<GraphqlToolDeps> = {}): GraphqlToolDeps {
+	return {
+		isEnabled: () => true,
+		confirmMutation: async () => true,
+		execute: async () => ({ data: { ok: true } }),
+		...over,
+	};
+}
+
+suite('Unit: graphqlTool', () => {
+	setup(() => {
+		initTestEnvironment();
+	});
+
+	test('isGraphqlTool recognizes rewst_graphql', () => {
+		assert.ok(isGraphqlTool('rewst_graphql'));
+		assert.ok(isGraphqlTool('rewst_graphql_schema'));
+		assert.ok(!isGraphqlTool('read_file'));
+	});
+
+	suite('detectOperationType()', () => {
+		test('named and anonymous queries', () => {
+			assert.strictEqual(detectOperationType('query Foo { user { id } }'), 'query');
+			assert.strictEqual(detectOperationType('{ user { id } }'), 'query');
+		});
+
+		test('mutations, including after fragments and queries', () => {
+			assert.strictEqual(detectOperationType('mutation Update { updateTemplate { id } }'), 'mutation');
+			assert.strictEqual(
+				detectOperationType('query A { user { id } }\nmutation B { deleteTemplate { id } }'),
+				'mutation',
+			);
+		});
+
+		test('subscriptions are detected', () => {
+			assert.strictEqual(detectOperationType('subscription S { conversationMessage { id } }'), 'subscription');
+		});
+
+		test('keywords inside strings, comments, and selections do not count', () => {
+			assert.strictEqual(detectOperationType('query Q { search(term: "mutation") { id } }'), 'query');
+			assert.strictEqual(detectOperationType('# mutation in a comment\nquery Q { user { id } }'), 'query');
+			assert.strictEqual(detectOperationType('{ mutation { id } }'), 'query');
+		});
+	});
+
+	test('fails when the tool is disabled or deps are missing', async () => {
+		await assert.rejects(
+			runGraphqlTool(
+				{ tool: 'rewst_graphql', args: { query: '{ user { id } }' } },
+				deps({ isEnabled: () => false }),
+			),
+			/enableGraphqlTool/,
+		);
+		await assert.rejects(
+			runGraphqlTool({ tool: 'rewst_graphql', args: { query: '{ user { id } }' } }, undefined),
+			/enableGraphqlTool/,
+		);
+	});
+
+	test('requires a query argument', async () => {
+		await assert.rejects(runGraphqlTool({ tool: 'rewst_graphql', args: {} }, deps()), /requires a "query"/);
+		await assert.rejects(
+			runGraphqlTool({ tool: 'rewst_graphql', args: { query: '  ' } }, deps()),
+			/requires a "query"/,
+		);
+	});
+
+	test('rejects non-object variables', async () => {
+		await assert.rejects(
+			runGraphqlTool({ tool: 'rewst_graphql', args: { query: '{ user { id } }', variables: [1] } }, deps()),
+			/must be a JSON object/,
+		);
+	});
+
+	test('rejects subscriptions', async () => {
+		await assert.rejects(
+			runGraphqlTool({ tool: 'rewst_graphql', args: { query: 'subscription S { x }' } }, deps()),
+			/does not support subscriptions/,
+		);
+	});
+
+	test('runs queries without confirmation and passes variables through', async () => {
+		let confirms = 0;
+		const calls: { query: string; variables?: Record<string, unknown> }[] = [];
+		const output = await runGraphqlTool(
+			{
+				tool: 'rewst_graphql',
+				args: { query: 'query T($id: ID!) { template(id: $id) { name } }', variables: { id: 't-1' } },
+			},
+			deps({
+				confirmMutation: async () => {
+					confirms++;
+					return true;
+				},
+				execute: async (query, variables) => {
+					calls.push({ query, variables });
+					return { data: { template: { name: 'My Template' } } };
+				},
+			}),
+		);
+		assert.strictEqual(confirms, 0);
+		assert.strictEqual(calls.length, 1);
+		assert.deepStrictEqual(calls[0].variables, { id: 't-1' });
+		assert.match(output, /My Template/);
+	});
+
+	test('asks for confirmation before running a mutation', async () => {
+		let confirmed = '';
+		const output = await runGraphqlTool(
+			{
+				tool: 'rewst_graphql',
+				args: { query: 'mutation U($id: ID!) { updateTemplate(id: $id) { id } }', variables: { id: 't-1' } },
+			},
+			deps({
+				confirmMutation: async operation => {
+					confirmed = operation;
+					return true;
+				},
+			}),
+		);
+		assert.match(confirmed, /mutation U/);
+		assert.match(confirmed, /"id": "t-1"/);
+		assert.match(output, /"ok": true/);
+	});
+
+	test('does not run a declined mutation', async () => {
+		let ran = false;
+		await assert.rejects(
+			runGraphqlTool(
+				{ tool: 'rewst_graphql', args: { query: 'mutation D { deleteTemplate { id } }' } },
+				deps({
+					confirmMutation: async () => false,
+					execute: async () => {
+						ran = true;
+						return {};
+					},
+				}),
+			),
+			/declined this mutation/,
+		);
+		assert.strictEqual(ran, false);
+	});
+
+	test('includes GraphQL errors in the output', async () => {
+		const output = await runGraphqlTool(
+			{ tool: 'rewst_graphql', args: { query: '{ nope }' } },
+			deps({ execute: async () => ({ data: null, errors: [{ message: 'Cannot query field "nope"' }] }) }),
+		);
+		assert.match(output, /Cannot query field/);
+		assert.ok(!output.includes('"data"'));
+	});
+
+	test('truncates oversized responses', async () => {
+		const output = await runGraphqlTool(
+			{ tool: 'rewst_graphql', args: { query: '{ big }' } },
+			deps({ execute: async () => ({ data: { big: 'x'.repeat(20_000) } }) }),
+		);
+		assert.ok(output.length < 9_000);
+		assert.match(output, /output truncated/);
+	});
+
+	suite('rewst_graphql_schema', () => {
+		test('lists root operation fields', async () => {
+			const output = await runGraphqlTool(
+				{ tool: 'rewst_graphql_schema', args: {} },
+				deps({
+					execute: async (_query, variables) => {
+						assert.deepStrictEqual(variables, { includeDeprecated: false });
+						return {
+							data: {
+								__schema: {
+									queryType: {
+										name: 'Query',
+										fields: [
+											{
+												name: 'templates',
+												args: [
+													{
+														name: 'orgId',
+														type: {
+															kind: 'NON_NULL',
+															ofType: { kind: 'SCALAR', name: 'ID' },
+														},
+													},
+												],
+												type: { kind: 'LIST', ofType: { kind: 'OBJECT', name: 'Template' } },
+											},
+										],
+									},
+									mutationType: { name: 'Mutation', fields: [] },
+								},
+							},
+						};
+					},
+				}),
+			);
+			assert.match(output, /## Query \(Query\)/);
+			assert.match(output, /templates\(orgId: ID!\): \[Template\]/);
+			assert.match(output, /typeName/);
+		});
+
+		test('inspects a named type', async () => {
+			const output = await runGraphqlTool(
+				{ tool: 'rewst_graphql_schema', args: { typeName: 'TemplateInput', includeDeprecated: true } },
+				deps({
+					execute: async (_query, variables) => {
+						assert.deepStrictEqual(variables, { typeName: 'TemplateInput', includeDeprecated: true });
+						return {
+							data: {
+								__type: {
+									kind: 'INPUT_OBJECT',
+									name: 'TemplateInput',
+									inputFields: [
+										{
+											name: 'name',
+											type: { kind: 'NON_NULL', ofType: { kind: 'SCALAR', name: 'String' } },
+										},
+										{ name: 'body', type: { kind: 'SCALAR', name: 'String' } },
+									],
+								},
+							},
+						};
+					},
+				}),
+			);
+			assert.match(output, /TemplateInput \(INPUT_OBJECT\)/);
+			assert.match(output, /name: String!/);
+			assert.match(output, /body: String/);
+		});
+
+		test('searches type names and root operation fields', async () => {
+			const output = await runGraphqlTool(
+				{ tool: 'rewst_graphql_schema', args: { search: 'template' } },
+				deps({
+					execute: async () => ({
+						data: {
+							__schema: {
+								types: [
+									{ name: 'Template', kind: 'OBJECT' },
+									{ name: 'Workflow', kind: 'OBJECT' },
+								],
+								queryType: {
+									name: 'Query',
+									fields: [
+										{ name: 'template', args: [], type: { kind: 'OBJECT', name: 'Template' } },
+									],
+								},
+								mutationType: {
+									name: 'Mutation',
+									fields: [
+										{
+											name: 'updateTemplate',
+											args: [],
+											type: { kind: 'OBJECT', name: 'Template' },
+										},
+									],
+								},
+							},
+						},
+					}),
+				}),
+			);
+			assert.match(output, /type Template \(OBJECT\)/);
+			assert.match(output, /Query\.template: Template/);
+			assert.match(output, /Mutation\.updateTemplate: Template/);
+		});
+
+		test('validates schema arguments', async () => {
+			await assert.rejects(
+				runGraphqlTool({ tool: 'rewst_graphql_schema', args: { typeName: '', search: 'x' } }, deps()),
+				/typeName/,
+			);
+			await assert.rejects(
+				runGraphqlTool({ tool: 'rewst_graphql_schema', args: { typeName: 'A', search: 'B' } }, deps()),
+				/either "typeName" or "search"/,
+			);
+		});
+	});
+});

--- a/src/ui/chat/tools/graphqlTool.ts
+++ b/src/ui/chat/tools/graphqlTool.ts
@@ -228,7 +228,7 @@ function formatResult(result: { data?: unknown; errors?: unknown }): string {
 	if (result.data !== undefined && result.data !== null) body.data = result.data;
 	if (Array.isArray(result.errors) ? result.errors.length > 0 : result.errors != null) body.errors = result.errors;
 	const text = Object.keys(body).length > 0 ? JSON.stringify(body, null, 1) : '(empty response)';
-	return text.length > MAX_OUTPUT_CHARS ? text.slice(0, MAX_OUTPUT_CHARS) + '\n…(output truncated)' : text;
+	return formatResultText(text);
 }
 
 function unwrapType(type: GraphqlTypeRef | null | undefined): string {

--- a/src/ui/chat/tools/graphqlTool.ts
+++ b/src/ui/chat/tools/graphqlTool.ts
@@ -1,0 +1,417 @@
+import { extPrefix } from '@global';
+import type { Session } from '@sessions';
+import vscode from 'vscode';
+import type { ToolRequest, ToolSpec } from './toolProtocol';
+
+/**
+ * rewst_graphql lets RoboRewsty compose and run GraphQL operations against the
+ * user's own Rewst instance, authenticated with their session cookie. The
+ * assistant already knows Rewst's domain; this gives it live access to the
+ * same API the extension itself uses.
+ *
+ *   - Off by default (rewst-buddy.ai.enableGraphqlTool): the session can read
+ *     and change anything the user can in Rewst.
+ *   - Queries run directly once enabled; mutations always require explicit
+ *     user approval in a modal showing the full operation — there is no
+ *     auto-approve escape hatch.
+ *   - Subscriptions are rejected (the tool protocol is request/response).
+ */
+
+const MAX_OUTPUT_CHARS = 8_000;
+
+export const GRAPHQL_TOOL_SPECS: ToolSpec[] = [
+	{
+		name: 'rewst_graphql_schema',
+		args: '{"typeName"?: string, "search"?: string, "includeDeprecated"?: boolean}',
+		description:
+			'Inspect the Rewst GraphQL schema with the user session before composing operations. With no args, lists root Query/Mutation/Subscription fields. Use typeName to inspect fields/input fields/enum values for one type. Use search to find matching type names and root operation fields.',
+	},
+	{
+		name: 'rewst_graphql',
+		args: '{"query": string, "variables"?: object}',
+		description:
+			"Run a GraphQL operation against the user's Rewst instance with their session. Prefer rewst_graphql_schema first when you are unsure about field names or arguments. Queries run directly and return JSON data. Mutations require the user's approval before running, so keep them minimal and explain what you intend to change. Subscriptions are not supported.",
+	},
+];
+
+const GRAPHQL_TOOL_NAMES = new Set(GRAPHQL_TOOL_SPECS.map(spec => spec.name));
+
+export function isGraphqlTool(name: string): boolean {
+	return GRAPHQL_TOOL_NAMES.has(name);
+}
+
+export interface GraphqlToolDeps {
+	isEnabled(): boolean;
+	/** Shows the mutation approval modal; returns true to run. */
+	confirmMutation(operation: string): Promise<boolean>;
+	execute(query: string, variables?: Record<string, unknown>): Promise<{ data?: unknown; errors?: unknown }>;
+}
+
+interface GraphqlTypeRef {
+	kind?: string | null;
+	name?: string | null;
+	ofType?: GraphqlTypeRef | null;
+}
+
+interface GraphqlArg {
+	name?: string | null;
+	type?: GraphqlTypeRef | null;
+	defaultValue?: string | null;
+}
+
+interface GraphqlField {
+	name?: string | null;
+	type?: GraphqlTypeRef | null;
+	args?: GraphqlArg[] | null;
+}
+
+interface GraphqlEnumValue {
+	name?: string | null;
+	isDeprecated?: boolean | null;
+}
+
+interface GraphqlTypeDetails {
+	kind?: string | null;
+	name?: string | null;
+	description?: string | null;
+	fields?: GraphqlField[] | null;
+	inputFields?: GraphqlArg[] | null;
+	enumValues?: GraphqlEnumValue[] | null;
+	possibleTypes?: { name?: string | null }[] | null;
+}
+
+interface GraphqlRootSchema {
+	queryType?: GraphqlTypeDetails | null;
+	mutationType?: GraphqlTypeDetails | null;
+	subscriptionType?: GraphqlTypeDetails | null;
+}
+
+const TYPE_REF_FRAGMENT = `{
+	kind
+	name
+	ofType {
+		kind
+		name
+		ofType {
+			kind
+			name
+			ofType {
+				kind
+				name
+				ofType {
+					kind
+					name
+				}
+			}
+		}
+	}
+}`;
+
+const ROOT_SCHEMA_QUERY = `query RewstBuddyRootSchema($includeDeprecated: Boolean!) {
+	__schema {
+		queryType {
+			name
+			fields(includeDeprecated: $includeDeprecated) {
+				name
+				args { name type ${TYPE_REF_FRAGMENT} defaultValue }
+				type ${TYPE_REF_FRAGMENT}
+			}
+		}
+		mutationType {
+			name
+			fields(includeDeprecated: $includeDeprecated) {
+				name
+				args { name type ${TYPE_REF_FRAGMENT} defaultValue }
+				type ${TYPE_REF_FRAGMENT}
+			}
+		}
+		subscriptionType {
+			name
+			fields(includeDeprecated: $includeDeprecated) {
+				name
+				args { name type ${TYPE_REF_FRAGMENT} defaultValue }
+				type ${TYPE_REF_FRAGMENT}
+			}
+		}
+	}
+}`;
+
+const TYPE_DETAILS_QUERY = `query RewstBuddyTypeDetails($typeName: String!, $includeDeprecated: Boolean!) {
+	__type(name: $typeName) {
+		kind
+		name
+		description
+		fields(includeDeprecated: $includeDeprecated) {
+			name
+			args { name type ${TYPE_REF_FRAGMENT} defaultValue }
+			type ${TYPE_REF_FRAGMENT}
+		}
+		inputFields { name type ${TYPE_REF_FRAGMENT} defaultValue }
+		enumValues(includeDeprecated: $includeDeprecated) { name isDeprecated }
+		possibleTypes { name }
+	}
+}`;
+
+const TYPE_NAMES_QUERY = `query RewstBuddySchemaTypeNames($includeDeprecated: Boolean!) {
+	__schema {
+		types { name kind }
+		queryType {
+			name
+			fields(includeDeprecated: $includeDeprecated) {
+				name
+				args { name type ${TYPE_REF_FRAGMENT} }
+				type ${TYPE_REF_FRAGMENT}
+			}
+		}
+		mutationType {
+			name
+			fields(includeDeprecated: $includeDeprecated) {
+				name
+				args { name type ${TYPE_REF_FRAGMENT} }
+				type ${TYPE_REF_FRAGMENT}
+			}
+		}
+		subscriptionType {
+			name
+			fields(includeDeprecated: $includeDeprecated) {
+				name
+				args { name type ${TYPE_REF_FRAGMENT} }
+				type ${TYPE_REF_FRAGMENT}
+			}
+		}
+	}
+}`;
+
+/** Binds the tool to the chat's session so operations hit the right org/region. */
+export function createGraphqlDeps(session: Session): GraphqlToolDeps {
+	return {
+		isEnabled: () => vscode.workspace.getConfiguration(`${extPrefix}.ai`).get<boolean>('enableGraphqlTool', false),
+		confirmMutation: async operation => {
+			const choice = await vscode.window.showWarningMessage(
+				'RoboRewsty wants to run a GraphQL mutation on your Rewst instance:',
+				{ modal: true, detail: operation },
+				'Run',
+			);
+			return choice === 'Run';
+		},
+		execute: (query, variables) => session.rawGraphql(query, variables),
+	};
+}
+
+/**
+ * Classifies a GraphQL document by its top-level operations. Comments and
+ * string literals are stripped first so keywords inside them don't count;
+ * a bare `{...}` selection set is an anonymous query. Any mutation makes the
+ * whole document a mutation (mixed documents get the stricter gate).
+ */
+export function detectOperationType(document: string): 'query' | 'mutation' | 'subscription' {
+	const cleaned = document
+		.replace(/"""[\s\S]*?"""/g, ' ')
+		.replace(/"(?:\\.|[^"\\])*"/g, ' ')
+		.replace(/#[^\n]*/g, ' ');
+
+	let depth = 0;
+	let type: 'query' | 'mutation' = 'query';
+	for (const token of cleaned.match(/[A-Za-z_][A-Za-z0-9_]*|[{}]/g) ?? []) {
+		if (token === '{') depth++;
+		else if (token === '}') depth = Math.max(0, depth - 1);
+		else if (depth === 0) {
+			if (token === 'subscription') return 'subscription';
+			if (token === 'mutation') type = 'mutation';
+		}
+	}
+	return type;
+}
+
+function formatResult(result: { data?: unknown; errors?: unknown }): string {
+	const body: Record<string, unknown> = {};
+	if (result.data !== undefined && result.data !== null) body.data = result.data;
+	if (Array.isArray(result.errors) ? result.errors.length > 0 : result.errors != null) body.errors = result.errors;
+	const text = Object.keys(body).length > 0 ? JSON.stringify(body, null, 1) : '(empty response)';
+	return text.length > MAX_OUTPUT_CHARS ? text.slice(0, MAX_OUTPUT_CHARS) + '\n…(output truncated)' : text;
+}
+
+function unwrapType(type: GraphqlTypeRef | null | undefined): string {
+	if (!type) return 'Unknown';
+	if (type.kind === 'NON_NULL') return `${unwrapType(type.ofType)}!`;
+	if (type.kind === 'LIST') return `[${unwrapType(type.ofType)}]`;
+	return type.name ?? 'Unknown';
+}
+
+function formatArgs(args: GraphqlArg[] | null | undefined): string {
+	if (!args || args.length === 0) return '';
+	return `(${args.map(arg => `${arg.name}: ${unwrapType(arg.type)}`).join(', ')})`;
+}
+
+function formatField(field: GraphqlField): string {
+	return `${field.name}${formatArgs(field.args)}: ${unwrapType(field.type)}`;
+}
+
+function formatFields(fields: GraphqlField[] | null | undefined, cap: number): string[] {
+	const usable = (fields ?? []).filter(field => typeof field.name === 'string');
+	const lines = usable.slice(0, cap).map(field => `- ${formatField(field)}`);
+	if (usable.length > cap)
+		lines.push(`...(showing first ${cap} of ${usable.length}; use search or typeName to narrow)`);
+	return lines;
+}
+
+function schemaFromResult(result: { data?: unknown }): GraphqlRootSchema | undefined {
+	const data = result.data as { __schema?: GraphqlRootSchema } | undefined;
+	return data?.__schema;
+}
+
+function typeFromResult(result: { data?: unknown }): GraphqlTypeDetails | undefined {
+	const data = result.data as { __type?: GraphqlTypeDetails | null } | undefined;
+	return data?.__type ?? undefined;
+}
+
+function formatRootSchema(schema: GraphqlRootSchema): string {
+	const sections: string[] = [];
+	const roots: [string, GraphqlTypeDetails | null | undefined, number][] = [
+		['Query', schema.queryType, 80],
+		['Mutation', schema.mutationType, 80],
+		['Subscription', schema.subscriptionType, 40],
+	];
+	for (const [label, type, cap] of roots) {
+		if (!type) continue;
+		const lines = formatFields(type.fields, cap);
+		sections.push(`## ${label} (${type.name ?? 'unknown'})\n${lines.length ? lines.join('\n') : '(no fields)'}`);
+	}
+	sections.push(
+		'Use rewst_graphql_schema with {"typeName": "TypeName"} to inspect return/input types, or {"search": "term"} to find likely operations.',
+	);
+	return sections.join('\n\n');
+}
+
+function formatTypeDetails(type: GraphqlTypeDetails | undefined, typeName: string): string {
+	if (!type) return `Type not found: ${typeName}`;
+	const sections = [`## ${type.name ?? typeName} (${type.kind ?? 'UNKNOWN'})`];
+	if (type.fields?.length) sections.push(`Fields:\n${formatFields(type.fields, 120).join('\n')}`);
+	if (type.inputFields?.length) {
+		const lines = type.inputFields
+			.slice(0, 120)
+			.map(
+				field =>
+					`- ${field.name}: ${unwrapType(field.type)}${field.defaultValue ? ` = ${field.defaultValue}` : ''}`,
+			);
+		if (type.inputFields.length > 120) lines.push(`...(showing first 120 of ${type.inputFields.length})`);
+		sections.push(`Input fields:\n${lines.join('\n')}`);
+	}
+	if (type.enumValues?.length) {
+		const lines = type.enumValues
+			.slice(0, 160)
+			.map(value => `- ${value.name}${value.isDeprecated ? ' (deprecated)' : ''}`);
+		if (type.enumValues.length > 160) lines.push(`...(showing first 160 of ${type.enumValues.length})`);
+		sections.push(`Enum values:\n${lines.join('\n')}`);
+	}
+	if (type.possibleTypes?.length) {
+		sections.push(`Possible types:\n${type.possibleTypes.map(possible => `- ${possible.name}`).join('\n')}`);
+	}
+	if (sections.length === 1) sections.push('(no fields, input fields, enum values, or possible types)');
+	return sections.join('\n\n');
+}
+
+function formatSchemaSearch(schema: GraphqlRootSchema & { types?: GraphqlTypeDetails[] }, term: string): string {
+	const needle = term.toLowerCase();
+	const typeMatches = (schema.types ?? [])
+		.filter(type => type.name && !type.name.startsWith('__') && type.name.toLowerCase().includes(needle))
+		.slice(0, 80)
+		.map(type => `- type ${type.name} (${type.kind ?? 'UNKNOWN'})`);
+	const fieldMatches: string[] = [];
+	const roots: [string, GraphqlTypeDetails | null | undefined][] = [
+		['Query', schema.queryType],
+		['Mutation', schema.mutationType],
+		['Subscription', schema.subscriptionType],
+	];
+	for (const [label, type] of roots) {
+		for (const field of type?.fields ?? []) {
+			if (field.name?.toLowerCase().includes(needle)) fieldMatches.push(`- ${label}.${formatField(field)}`);
+			if (fieldMatches.length >= 80) break;
+		}
+	}
+	const sections = [`Search: ${term}`];
+	sections.push(`Types:\n${typeMatches.length ? typeMatches.join('\n') : '(none)'}`);
+	sections.push(`Root fields:\n${fieldMatches.length ? fieldMatches.join('\n') : '(none)'}`);
+	sections.push('Use rewst_graphql_schema with {"typeName": "TypeName"} for details before calling rewst_graphql.');
+	return sections.join('\n\n');
+}
+
+async function runSchemaTool(request: ToolRequest, deps: GraphqlToolDeps): Promise<string> {
+	const includeDeprecated = request.args.includeDeprecated === true;
+	const typeName = request.args.typeName;
+	const search = request.args.search;
+	if (typeName !== undefined && (typeof typeName !== 'string' || typeName.trim().length === 0)) {
+		throw new Error('rewst_graphql_schema "typeName" must be a non-empty string when provided.');
+	}
+	if (search !== undefined && (typeof search !== 'string' || search.trim().length === 0)) {
+		throw new Error('rewst_graphql_schema "search" must be a non-empty string when provided.');
+	}
+	if (typeName !== undefined && search !== undefined) {
+		throw new Error('rewst_graphql_schema accepts either "typeName" or "search", not both.');
+	}
+
+	if (typeof typeName === 'string') {
+		return formatResultText(
+			formatTypeDetails(
+				typeFromResult(await deps.execute(TYPE_DETAILS_QUERY, { typeName, includeDeprecated })),
+				typeName,
+			),
+		);
+	}
+	if (typeof search === 'string') {
+		const result = await deps.execute(TYPE_NAMES_QUERY, { includeDeprecated });
+		return formatResultText(
+			formatSchemaSearch(
+				(schemaFromResult(result) ?? {}) as GraphqlRootSchema & { types?: GraphqlTypeDetails[] },
+				search,
+			),
+		);
+	}
+	return formatResultText(
+		formatRootSchema(schemaFromResult(await deps.execute(ROOT_SCHEMA_QUERY, { includeDeprecated })) ?? {}),
+	);
+}
+
+function formatResultText(text: string): string {
+	return text.length > MAX_OUTPUT_CHARS ? text.slice(0, MAX_OUTPUT_CHARS) + '\n…(output truncated)' : text;
+}
+
+export async function runGraphqlTool(request: ToolRequest, deps: GraphqlToolDeps | undefined): Promise<string> {
+	if (!deps || !deps.isEnabled()) {
+		throw new Error(
+			'GraphQL tools are disabled. The user can enable them with the rewst-buddy.ai.enableGraphqlTool setting.',
+		);
+	}
+
+	if (request.tool === 'rewst_graphql_schema') {
+		return runSchemaTool(request, deps);
+	}
+
+	const query = request.args.query;
+	if (typeof query !== 'string' || query.trim().length === 0) {
+		throw new Error('rewst_graphql requires a "query" argument containing a GraphQL document.');
+	}
+	const rawVariables = request.args.variables;
+	if (
+		rawVariables !== undefined &&
+		(typeof rawVariables !== 'object' || rawVariables === null || Array.isArray(rawVariables))
+	) {
+		throw new Error('rewst_graphql "variables" must be a JSON object when provided.');
+	}
+	const variables = rawVariables as Record<string, unknown> | undefined;
+
+	const kind = detectOperationType(query);
+	if (kind === 'subscription') {
+		throw new Error('rewst_graphql does not support subscriptions; use a query or mutation.');
+	}
+	if (kind === 'mutation') {
+		const summary = variables
+			? `${query.trim()}\n\nVariables:\n${JSON.stringify(variables, null, 2)}`
+			: query.trim();
+		if (!(await deps.confirmMutation(summary))) {
+			throw new Error('The user declined this mutation. Do not retry it; ask what they would prefer.');
+		}
+	}
+
+	return formatResult(await deps.execute(query, variables));
+}

--- a/src/ui/chat/tools/toolProtocol.test.ts
+++ b/src/ui/chat/tools/toolProtocol.test.ts
@@ -83,8 +83,18 @@ suite('Unit: toolProtocol', () => {
 				{ name: 'list_files', args: '{}', description: 'List files.' },
 			]);
 			assert.ok(text.includes('rewst-tool'));
-			assert.ok(text.includes('read_file — args: {"path": string}'));
+			assert.ok(text.includes('read_file - args: {"path": string}'));
 			assert.ok(text.includes('list_files'));
+		});
+
+		test('adds explicit GraphQL guidance when GraphQL tools are available', () => {
+			const text = buildToolInstructions([
+				{ name: 'rewst_graphql_schema', args: '{}', description: 'Inspect schema.' },
+				{ name: 'rewst_graphql', args: '{"query": string}', description: 'Run GraphQL.' },
+			]);
+			assert.ok(text.includes('session-authenticated GraphQL action'));
+			assert.ok(text.includes('Use rewst_graphql_schema first'));
+			assert.ok(text.includes('then call rewst_graphql'));
 		});
 	});
 

--- a/src/ui/chat/tools/toolProtocol.test.ts
+++ b/src/ui/chat/tools/toolProtocol.test.ts
@@ -83,7 +83,7 @@ suite('Unit: toolProtocol', () => {
 				{ name: 'list_files', args: '{}', description: 'List files.' },
 			]);
 			assert.ok(text.includes('rewst-tool'));
-			assert.ok(text.includes('read_file - args: {"path": string}'));
+			assert.ok(text.includes('read_file — args: {"path": string}'));
 			assert.ok(text.includes('list_files'));
 		});
 

--- a/src/ui/chat/tools/toolProtocol.ts
+++ b/src/ui/chat/tools/toolProtocol.ts
@@ -6,7 +6,7 @@
  * instructions appended to the user's message describe local tools and ask it to
  * request them via fenced ```rewst-tool JSON blocks. The participant parses
  * those blocks out of each answer, executes the tools locally, and sends the
- * results back as the next turn of the same conversation - looping until the
+ * results back as the next turn of the same conversation — looping until the
  * assistant produces an answer with no tool requests.
  */
 
@@ -59,7 +59,7 @@ const FENCE = /```rewst-tool[^\n]*\n([\s\S]*?)```/g;
  * knows the tools exist and how to call them.
  */
 export function buildToolInstructions(specs: ToolSpec[]): string {
-	const lines = specs.map(spec => `- ${spec.name} - args: ${spec.args}. ${spec.description}`);
+	const lines = specs.map(spec => `- ${spec.name} — args: ${spec.args}. ${spec.description}`);
 	const hasGraphqlTools = specs.some(spec => spec.name === 'rewst_graphql');
 	const graphqlNote = hasGraphqlTools
 		? [
@@ -79,7 +79,7 @@ export function buildToolInstructions(specs: ToolSpec[]): string {
 		...lines,
 		...graphqlNote,
 		'',
-		`Rules: when you need tool information, reply with ONLY rewst-tool blocks (up to ${MAX_REQUESTS_PER_TURN} per reply) and no other prose; the editor runs them and sends the results back to you. After receiving results you may request more tools or give your final answer. Never guess at file contents, workspace structure, or live Rewst data when a tool can check it. Long results are cut off with a note saying how to continue (e.g. read_file startLine/endLine for the next chunk); never repeat a request you already made - identical repeats are rejected.`,
+		`Rules: when you need tool information, reply with ONLY rewst-tool blocks (up to ${MAX_REQUESTS_PER_TURN} per reply) and no other prose; the editor runs them and sends the results back to you. After receiving results you may request more tools or give your final answer. Never guess at file contents, workspace structure, or live Rewst data when a tool can check it. Long results are cut off with a note saying how to continue (e.g. read_file startLine/endLine for the next chunk); never repeat a request you already made — identical repeats are rejected.`,
 	].join('\n');
 }
 
@@ -142,7 +142,7 @@ const EDIT_TOOL_NAMES = new Set(['edit_file', 'write_file']);
 /**
  * Guards the tool loop against cycles: duplicate requests within one reply
  * are dropped, and a request identical to one already executed in an earlier
- * round is blocked with a nudge instead of re-run - unless a file edit
+ * round is blocked with a nudge instead of re-run — unless a file edit
  * happened since (the workspace may have changed). Edit tools are never
  * blocked; repeating an identical edit fails naturally ("find" won't match).
  */
@@ -183,7 +183,7 @@ export function blockedRepeatResult(request: ToolRequest): ToolResult {
 		argsLabel,
 		ok: false,
 		output:
-			'You already ran this exact request and received its result. Do not repeat identical calls - ' +
+			'You already ran this exact request and received its result. Do not repeat identical calls — ' +
 			'request a specific line range or a different file, or stop and give your final answer based on what you have.',
 	};
 }

--- a/src/ui/chat/tools/toolProtocol.ts
+++ b/src/ui/chat/tools/toolProtocol.ts
@@ -1,12 +1,12 @@
 /**
  * Client-side tool protocol for the @rewst chat participant.
  *
- * RoboRewsty's agent runs server-side and knows nothing about VS Code, so the
- * extension teaches it a convention instead: instructions appended to the
- * user's message describe local workspace tools and ask the assistant to
+ * RoboRewsty's agent runs server-side and knows nothing about VS Code or the
+ * user's active Rewst session, so the extension teaches it a convention:
+ * instructions appended to the user's message describe local tools and ask it to
  * request them via fenced ```rewst-tool JSON blocks. The participant parses
  * those blocks out of each answer, executes the tools locally, and sends the
- * results back as the next turn of the same conversation — looping until the
+ * results back as the next turn of the same conversation - looping until the
  * assistant produces an answer with no tool requests.
  */
 
@@ -59,10 +59,17 @@ const FENCE = /```rewst-tool[^\n]*\n([\s\S]*?)```/g;
  * knows the tools exist and how to call them.
  */
 export function buildToolInstructions(specs: ToolSpec[]): string {
-	const lines = specs.map(spec => `- ${spec.name} — args: ${spec.args}. ${spec.description}`);
+	const lines = specs.map(spec => `- ${spec.name} - args: ${spec.args}. ${spec.description}`);
+	const hasGraphqlTools = specs.some(spec => spec.name === 'rewst_graphql');
+	const graphqlNote = hasGraphqlTools
+		? [
+				'',
+				'GraphQL: you have a session-authenticated GraphQL action. Use rewst_graphql_schema first when you need field names, argument names, input types, enum values, or root Query/Mutation fields; then call rewst_graphql with the final operation and variables.',
+			]
+		: [];
 	return [
 		'---',
-		"You can inspect the user's VS Code workspace with local tools. To call one, reply with a fenced code block tagged rewst-tool containing JSON:",
+		"You can use local tools supplied by the user's VS Code extension. To call one, reply with a fenced code block tagged rewst-tool containing JSON:",
 		'',
 		'```rewst-tool',
 		'{"tool": "read_file", "args": {"path": "src/example.jinja"}}',
@@ -70,8 +77,9 @@ export function buildToolInstructions(specs: ToolSpec[]): string {
 		'',
 		'Available tools:',
 		...lines,
+		...graphqlNote,
 		'',
-		`Rules: when you need workspace information, reply with ONLY rewst-tool blocks (up to ${MAX_REQUESTS_PER_TURN} per reply) and no other prose; the editor runs them and sends the results back to you. After receiving results you may request more tools or give your final answer. Never guess at file contents or structure — use the tools to look. Long results are cut off with a note saying how to continue (e.g. read_file startLine/endLine for the next chunk); never repeat a request you already made — identical repeats are rejected.`,
+		`Rules: when you need tool information, reply with ONLY rewst-tool blocks (up to ${MAX_REQUESTS_PER_TURN} per reply) and no other prose; the editor runs them and sends the results back to you. After receiving results you may request more tools or give your final answer. Never guess at file contents, workspace structure, or live Rewst data when a tool can check it. Long results are cut off with a note saying how to continue (e.g. read_file startLine/endLine for the next chunk); never repeat a request you already made - identical repeats are rejected.`,
 	].join('\n');
 }
 
@@ -134,7 +142,7 @@ const EDIT_TOOL_NAMES = new Set(['edit_file', 'write_file']);
 /**
  * Guards the tool loop against cycles: duplicate requests within one reply
  * are dropped, and a request identical to one already executed in an earlier
- * round is blocked with a nudge instead of re-run — unless a file edit
+ * round is blocked with a nudge instead of re-run - unless a file edit
  * happened since (the workspace may have changed). Edit tools are never
  * blocked; repeating an identical edit fails naturally ("find" won't match).
  */
@@ -175,7 +183,7 @@ export function blockedRepeatResult(request: ToolRequest): ToolResult {
 		argsLabel,
 		ok: false,
 		output:
-			'You already ran this exact request and received its result. Do not repeat identical calls — ' +
+			'You already ran this exact request and received its result. Do not repeat identical calls - ' +
 			'request a specific line range or a different file, or stop and give your final answer based on what you have.',
 	};
 }

--- a/src/ui/chat/tools/workspaceTools.test.ts
+++ b/src/ui/chat/tools/workspaceTools.test.ts
@@ -3,6 +3,7 @@ import * as Mocha from 'mocha';
 import { initTestEnvironment } from '@test';
 import type { TemplateLink } from '@models';
 import vscode from 'vscode';
+import type { GraphqlToolDeps } from './graphqlTool';
 import { buildWorkspaceOverview, resolveWorkspaceUri, runToolRequests, type WorkspaceToolDeps } from './workspaceTools';
 
 const { suite, test, setup } = Mocha;
@@ -283,6 +284,34 @@ suite('Unit: workspaceTools', () => {
 			assert.strictEqual(result.ok, false);
 			assert.match(result.output, /Unknown tool "delete_everything"/);
 			assert.match(result.output, /read_file/);
+		});
+
+		test('routes rewst_graphql through GraphQL deps', async () => {
+			const calls: { query: string; variables?: Record<string, unknown> }[] = [];
+			const graphqlDeps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async (query, variables) => {
+					calls.push({ query, variables });
+					return { data: { user: { id: 'u-1' } } };
+				},
+			};
+			const [result] = await runToolRequests(
+				[
+					{
+						tool: 'rewst_graphql',
+						args: { query: 'query U($id: ID!) { user(id: $id) { id } }', variables: { id: 'u-1' } },
+					},
+				],
+				deps(),
+				undefined,
+				graphqlDeps,
+			);
+			assert.strictEqual(result.ok, true);
+			assert.match(result.output, /"u-1"/);
+			assert.deepStrictEqual(calls, [
+				{ query: 'query U($id: ID!) { user(id: $id) { id } }', variables: { id: 'u-1' } },
+			]);
 		});
 
 		test('reports progress per request', async () => {

--- a/src/ui/chat/tools/workspaceTools.ts
+++ b/src/ui/chat/tools/workspaceTools.ts
@@ -12,6 +12,7 @@ import {
 	type ToolSpec,
 } from './toolProtocol';
 import { isCommandTool, runCommandTool } from './commandTool';
+import { isGraphqlTool, runGraphqlTool, type GraphqlToolDeps } from './graphqlTool';
 import { isWebTool, runWebTool } from './webTools';
 
 /**
@@ -433,13 +434,14 @@ export async function runToolRequests(
 	requests: ToolRequest[],
 	deps: WorkspaceToolDeps = defaultDeps,
 	onProgress?: (label: string) => void,
+	graphqlDeps?: GraphqlToolDeps,
 ): Promise<ToolResult[]> {
 	const results: ToolResult[] = [];
 	for (const request of requests) {
 		onProgress?.(`Running ${describeRequest(request)}…`);
 		const argsLabel = JSON.stringify(request.args) === '{}' ? '' : JSON.stringify(request.args);
 		try {
-			const outcome = await runTool(request, deps);
+			const outcome = await runTool(request, deps, graphqlDeps);
 			results.push({ tool: request.tool, argsLabel, ok: true, ...outcome });
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
@@ -450,7 +452,11 @@ export async function runToolRequests(
 	return results;
 }
 
-async function runTool(request: ToolRequest, deps: WorkspaceToolDeps): Promise<ToolOutcome> {
+async function runTool(
+	request: ToolRequest,
+	deps: WorkspaceToolDeps,
+	graphqlDeps?: GraphqlToolDeps,
+): Promise<ToolOutcome> {
 	switch (request.tool) {
 		case 'list_files':
 			return { output: await listFiles(request.args, deps) };
@@ -477,6 +483,7 @@ async function runTool(request: ToolRequest, deps: WorkspaceToolDeps): Promise<T
 		default: {
 			if (isWebTool(request.tool)) return { output: await runWebTool(request) };
 			if (isCommandTool(request.tool)) return { output: await runCommandTool(request) };
+			if (isGraphqlTool(request.tool)) return { output: await runGraphqlTool(request, graphqlDeps) };
 			const names = [...WORKSPACE_TOOL_SPECS, ...EDIT_TOOL_SPECS].map(s => s.name).join(', ');
 			throw new Error(`Unknown tool "${request.tool}". Available: ${names}.`);
 		}


### PR DESCRIPTION
Add session-authenticated GraphQL tool for RoboRewsty.

Gives RoboRewsty an opt-in ability to query your Rewst instance directly.

New rewst_graphql tool — RoboRewsty can compose and run GraphQL operations against Rewst using your existing session, plus a companion rewst_graphql_schema tool for exploring the available schema.
Safety gating — the whole feature is off by default behind a new setting, rewst-buddy.ai.enableGraphqlTool, because the session can read and change anything you can in Rewst. Queries run directly; mutations always show an approval dialog with the full operation before running.
Tool wiring — workspace tools and the workspace overview are now individually gated by enableWorkspaceTools, so the GraphQL tool can be enabled on its own. The chat's activity list was renamed from "Workspace activity" to "Tool activity" to reflect non-workspace tools.
