### PR TITLE
Require CodeRabbit approval before merge

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -1,0 +1,7 @@
+# yaml-language-server: $schema=https://storage.googleapis.com/coderabbit_public_assets/schema.v2.json
+# CodeRabbit submits a Request Changes review while it has unresolved comments
+# and approves once they're resolved. Paired with the main-branch ruleset
+# (1 required approval + conversation resolution), this makes CodeRabbit's
+# approval a merge requirement.
+reviews:
+  request_changes_workflow: true


### PR DESCRIPTION
## Summary

- Add `.coderabbit.yaml` enabling `reviews.request_changes_workflow`: CodeRabbit submits a **Request Changes** review while it has unresolved comments and **approves** once they're resolved
- Paired with a new `main` ruleset (created via API alongside this PR): require a pull request, 1 approving review, and conversation resolution before merging — making CodeRabbit's approval the effective merge gate (authors can't approve their own PRs)
- Repo admin retains bypass as an escape hatch if CodeRabbit is unavailable

## Test plan

- [x] CodeRabbit reviews this PR and its approval satisfies the required review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated code review workflow configuration to enforce resolution of review comments before approval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->