### PR TITLE
Show tool-call context in the chat activity line (#22)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Changed
 
-- **Tool activity in the chat now shows what each tool is accessing** - the running indicator includes a compact preview of the call's arguments (the search query, org, file path, GraphQL operation, …) instead of just the bare tool name, for both editor tools and native Rewst tools. Native tools are also labeled "Running Rewst tool: …" to set them apart from the editor's own tools. (#22)
+- **Tool activity in the chat now shows what each tool is accessing** - the running indicator includes a compact preview of the call's arguments (the search query, org, file path, GraphQL operation, …) instead of just the bare tool name. Editor tools surface this through VS Code's native tool UI; native Rewst tools render as a compact, card-like line (🔧 **Rewst tool** · `name`, with the args beneath) that sets them apart from the editor's own tools. (#22)
 
 ## [0.43.1] - 2026-06-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [Unreleased]
+## [0.43.2] - 2026-06-16
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## [Unreleased]
+
+### Changed
+
+- **Tool activity in the chat now shows what each tool is accessing** - the running indicator includes a compact preview of the call's arguments (the search query, org, file path, GraphQL operation, …) instead of just the bare tool name, for both editor tools and native Rewst tools. Native tools are also labeled "Running Rewst tool: …" to set them apart from the editor's own tools. (#22)
+
 ## [0.43.1] - 2026-06-16
 
 ### Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "rewst-buddy",
-	"version": "0.43.0",
+	"version": "0.43.2",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "rewst-buddy",
-			"version": "0.43.1",
+			"version": "0.43.2",
 			"license": "MIT",
 			"devDependencies": {
 				"@0no-co/graphqlsp": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
 	"name": "rewst-buddy",
 	"displayName": "rewst-buddy",
 	"description": "Unofficial community VS Code extension for editing Rewst templates locally. Not affiliated with Rewst LLC.",
-	"version": "0.43.1",
+	"version": "0.43.2",
 	"icon": "media/rewst-buddy.png",
 	"engines": {
 		"vscode": "^1.122.0"

--- a/src/sessions/conversation/conversationEvents.test.ts
+++ b/src/sessions/conversation/conversationEvents.test.ts
@@ -40,7 +40,30 @@ suite('Unit: ConversationEventMapper', () => {
 			status: 'TOOL_CALL_IN_PROGRESS',
 			metadata: { toolCalls: [{ name: 'gitbook_retriever', id: 't1' }] },
 		});
-		assert.deepStrictEqual(events, [{ kind: 'status', label: 'Running tool: gitbook_retriever…', activity: true }]);
+		assert.deepStrictEqual(events, [
+			{ kind: 'status', label: 'Running Rewst tool: gitbook_retriever…', activity: true },
+		]);
+	});
+
+	test('TOOL_CALL_IN_PROGRESS shows a compact preview of the tool args', () => {
+		const events = mapper.map({
+			status: 'TOOL_CALL_IN_PROGRESS',
+			metadata: { toolCalls: [{ name: 'gitbook_retriever', args: { query: 'noop tasks' }, id: 't2' }] },
+		});
+		assert.deepStrictEqual(events, [
+			{ kind: 'status', label: 'Running Rewst tool: gitbook_retriever {"query":"noop tasks"}…', activity: true },
+		]);
+	});
+
+	test('TOOL_CALL_IN_PROGRESS truncates oversized args', () => {
+		const events = mapper.map({
+			status: 'TOOL_CALL_IN_PROGRESS',
+			metadata: { toolCalls: [{ name: 'rewst_graphql', args: { query: 'q'.repeat(500) }, id: 't3' }] },
+		});
+		const label = events[0].kind === 'status' ? events[0].label : '';
+		assert.ok(label.startsWith('Running Rewst tool: rewst_graphql {"query":"qqq'), 'keeps the head of the args');
+		assert.ok(label.endsWith('…'), 'ends with the truncation marker');
+		assert.ok(label.length < 140, `label is bounded, got ${label.length}`);
 	});
 
 	test('ignores bookkeeping statuses', () => {

--- a/src/sessions/conversation/conversationEvents.test.ts
+++ b/src/sessions/conversation/conversationEvents.test.ts
@@ -41,7 +41,12 @@ suite('Unit: ConversationEventMapper', () => {
 			metadata: { toolCalls: [{ name: 'gitbook_retriever', id: 't1' }] },
 		});
 		assert.deepStrictEqual(events, [
-			{ kind: 'status', label: 'Running Rewst tool: gitbook_retriever…', activity: true },
+			{
+				kind: 'status',
+				label: 'Running Rewst tool: gitbook_retriever…',
+				activity: true,
+				tool: { name: 'gitbook_retriever' },
+			},
 		]);
 	});
 
@@ -51,7 +56,12 @@ suite('Unit: ConversationEventMapper', () => {
 			metadata: { toolCalls: [{ name: 'gitbook_retriever', args: { query: 'noop tasks' }, id: 't2' }] },
 		});
 		assert.deepStrictEqual(events, [
-			{ kind: 'status', label: 'Running Rewst tool: gitbook_retriever {"query":"noop tasks"}…', activity: true },
+			{
+				kind: 'status',
+				label: 'Running Rewst tool: gitbook_retriever {"query":"noop tasks"}…',
+				activity: true,
+				tool: { name: 'gitbook_retriever', args: '{"query":"noop tasks"}' },
+			},
 		]);
 	});
 

--- a/src/sessions/conversation/conversationEvents.ts
+++ b/src/sessions/conversation/conversationEvents.ts
@@ -112,6 +112,26 @@ function parseApprovalTools(metadata: Record<string, unknown> | undefined): Appr
 }
 
 /**
+ * Compact, single-line preview of a native tool's arguments for the activity
+ * label, so the chat shows WHAT the tool is accessing — the query, org, path —
+ * not just its name (#22). Returns a leading-space-prefixed string, or '' when
+ * there is nothing useful to show.
+ */
+function formatToolArgs(args: unknown): string {
+	if (args === undefined || args === null) return '';
+	let text: string;
+	try {
+		text = typeof args === 'string' ? args : JSON.stringify(args);
+	} catch {
+		return '';
+	}
+	const oneLine = text.replace(/\s+/g, ' ').trim();
+	if (oneLine === '' || oneLine === '{}' || oneLine === '""') return '';
+	const MAX = 100;
+	return ` ${oneLine.length > MAX ? `${oneLine.slice(0, MAX - 1)}…` : oneLine}`;
+}
+
+/**
  * Stateful mapper: de-duplicates conversation_id announcements and normalizes
  * streaming chunks regardless of whether the server sends deltas or cumulative
  * partial content.
@@ -164,7 +184,12 @@ export class ConversationEventMapper {
 			case 'TOOL_CALL_IN_PROGRESS': {
 				const tools = parseApprovalTools(metadata);
 				if (tools.length > 0) this.lastToolCalls = tools;
-				events.push({ kind: 'status', label: `Running tool: ${tools[0]?.name ?? 'unknown'}…`, activity: true });
+				const call = tools[0];
+				events.push({
+					kind: 'status',
+					label: `Running Rewst tool: ${call?.name ?? 'unknown'}${formatToolArgs(call?.args)}…`,
+					activity: true,
+				});
 				break;
 			}
 			case 'complete': {

--- a/src/sessions/conversation/conversationEvents.ts
+++ b/src/sessions/conversation/conversationEvents.ts
@@ -23,7 +23,10 @@ export type ConversationEvent =
 	| { kind: 'conversation'; conversationId: string }
 	// `activity: true` marks a substantive step (a tool call or a search) worth
 	// surfacing; housekeeping statuses (thinking, summarizing) omit it.
-	| { kind: 'status'; label: string; activity?: boolean }
+	// `tool` carries the native Rewst tool name + compact args so the chat can
+	// render it as a card-like line; `label` stays as the plain-text fallback
+	// and the dedupe key for collapsing back-to-back repeats.
+	| { kind: 'status'; label: string; activity?: boolean; tool?: { name: string; args?: string } }
 	| { kind: 'chunk'; text: string }
 	| {
 			kind: 'complete';
@@ -112,12 +115,11 @@ function parseApprovalTools(metadata: Record<string, unknown> | undefined): Appr
 }
 
 /**
- * Compact, single-line preview of a native tool's arguments for the activity
- * label, so the chat shows WHAT the tool is accessing — the query, org, path —
- * not just its name (#22). Returns a leading-space-prefixed string, or '' when
- * there is nothing useful to show.
+ * Compact, single-line preview of a native tool's arguments, so the chat shows
+ * WHAT the tool is accessing — the query, org, path — not just its name (#22).
+ * Returns the bare compact string, or '' when there is nothing useful to show.
  */
-function formatToolArgs(args: unknown): string {
+function compactToolArgs(args: unknown): string {
 	if (args === undefined || args === null) return '';
 	let text: string;
 	try {
@@ -128,7 +130,7 @@ function formatToolArgs(args: unknown): string {
 	const oneLine = text.replace(/\s+/g, ' ').trim();
 	if (oneLine === '' || oneLine === '{}' || oneLine === '""') return '';
 	const MAX = 100;
-	return ` ${oneLine.length > MAX ? `${oneLine.slice(0, MAX - 1)}…` : oneLine}`;
+	return oneLine.length > MAX ? `${oneLine.slice(0, MAX - 1)}…` : oneLine;
 }
 
 /**
@@ -184,11 +186,13 @@ export class ConversationEventMapper {
 			case 'TOOL_CALL_IN_PROGRESS': {
 				const tools = parseApprovalTools(metadata);
 				if (tools.length > 0) this.lastToolCalls = tools;
-				const call = tools[0];
+				const name = tools[0]?.name ?? 'unknown';
+				const args = compactToolArgs(tools[0]?.args);
 				events.push({
 					kind: 'status',
-					label: `Running Rewst tool: ${call?.name ?? 'unknown'}${formatToolArgs(call?.args)}…`,
+					label: `Running Rewst tool: ${name}${args ? ` ${args}` : ''}…`,
 					activity: true,
+					tool: args ? { name, args } : { name },
 				});
 				break;
 			}

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
@@ -622,8 +622,8 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 		{ kind: 'status', label: 'Thinking…' }, // housekeeping (no activity flag) → hidden
 		{ kind: 'status', label: 'Summarizing conversation…' }, // housekeeping → hidden
 		{ kind: 'status', label: 'Searching documentation…', activity: true },
-		{ kind: 'status', label: 'Running tool: listOrgVariable…', activity: true },
-		{ kind: 'status', label: 'Running tool: listOrgVariable…', activity: true }, // back-to-back dup → collapsed
+		{ kind: 'status', label: 'Running Rewst tool: listOrgVariable…', activity: true },
+		{ kind: 'status', label: 'Running Rewst tool: listOrgVariable…', activity: true }, // back-to-back dup → collapsed
 		{ kind: 'chunk', text: 'the answer' },
 		{ kind: 'complete', content: 'the answer', sources: [], conversationId: 'conv-1' },
 	];
@@ -637,7 +637,7 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 		assert.ok(!out.includes('Summarizing'), 'housekeeping summarizing is not shown');
 		assert.ok(out.includes('> _Searching documentation…_'), 'searches are surfaced');
 		assert.strictEqual(
-			out.split('> _Running tool: listOrgVariable…_').length - 1,
+			out.split('> _Running Rewst tool: listOrgVariable…_').length - 1,
 			1,
 			'a repeated tool label collapses to one line',
 		);

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
@@ -622,8 +622,19 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 		{ kind: 'status', label: 'Thinking…' }, // housekeeping (no activity flag) → hidden
 		{ kind: 'status', label: 'Summarizing conversation…' }, // housekeeping → hidden
 		{ kind: 'status', label: 'Searching documentation…', activity: true },
-		{ kind: 'status', label: 'Running Rewst tool: listOrgVariable…', activity: true },
-		{ kind: 'status', label: 'Running Rewst tool: listOrgVariable…', activity: true }, // back-to-back dup → collapsed
+		{
+			kind: 'status',
+			label: 'Running Rewst tool: listOrgVariable…',
+			activity: true,
+			tool: { name: 'listOrgVariable' },
+		},
+		// back-to-back dup → collapsed
+		{
+			kind: 'status',
+			label: 'Running Rewst tool: listOrgVariable…',
+			activity: true,
+			tool: { name: 'listOrgVariable' },
+		},
 		{ kind: 'chunk', text: 'the answer' },
 		{ kind: 'complete', content: 'the answer', sources: [], conversationId: 'conv-1' },
 	];
@@ -636,8 +647,9 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 		assert.ok(!out.includes('Thinking…'), 'housekeeping thinking is not shown');
 		assert.ok(!out.includes('Summarizing'), 'housekeeping summarizing is not shown');
 		assert.ok(out.includes('> _Searching documentation…_'), 'searches are surfaced');
+		assert.ok(out.includes('🔧 **Rewst tool** · `listOrgVariable`'), 'native tool renders card-like');
 		assert.strictEqual(
-			out.split('> _Running Rewst tool: listOrgVariable…_').length - 1,
+			out.split('🔧 **Rewst tool** · `listOrgVariable`').length - 1,
 			1,
 			'a repeated tool label collapses to one line',
 		);

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.ts
@@ -71,6 +71,21 @@ function safeJson(value: unknown): string {
 	}
 }
 
+/**
+ * Native Rewst tools run server-side, so they can't be true VS Code tool cards
+ * (no invocation round-trip). A tool status renders as a compact card-like
+ * blockquote — tool name, then its args on a second line — to read as close to
+ * VS Code's native tool pills as plain markdown allows; other activity (a doc
+ * search) stays a plain italic line (#22).
+ */
+function formatActivityLine(status: { label: string; tool?: { name: string; args?: string } }): string {
+	if (status.tool) {
+		const args = status.tool.args ? `\n> \`${status.tool.args}\`` : '';
+		return `\n\n> 🔧 **Rewst tool** · \`${status.tool.name}\`${args}\n`;
+	}
+	return `\n\n> _${status.label}_\n`;
+}
+
 async function confirmApprovalModal(tools: ApprovalTool[]): Promise<ApprovalChoice> {
 	const detail = tools
 		.map(tool => (tool.args === undefined ? tool.name : `${tool.name}\n${truncate(safeJson(tool.args), 500)}`))
@@ -234,15 +249,18 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 		// Surfaces substantive activity (searches, native tool calls) as unobtrusive
 		// blockquote lines so a multi-step turn is legible. Housekeeping statuses
 		// (thinking, summarizing) are filtered out by the caller (event.activity).
-		const emitStatus = (label: string, gate: ChunkGate): void => {
-			if (!showActivity || label === lastStatusLabel) return;
-			lastStatusLabel = label;
+		const emitStatus = (
+			status: { label: string; tool?: { name: string; args?: string } },
+			gate: ChunkGate,
+		): void => {
+			if (!showActivity || status.label === lastStatusLabel) return;
+			lastStatusLabel = status.label;
 			// Drain the gate's already-safe answer text first so the activity line
 			// stays ordered after it (gate.push('') keeps any partial fence held).
 			emitText(gate.push(''));
 			// Activity lines are meta, not answer text: report directly so they
 			// never enter emittedText (continuity and saved-answer stay clean).
-			progress.report(new vscode.LanguageModelTextPart(`\n\n> _${label}_\n`));
+			progress.report(new vscode.LanguageModelTextPart(formatActivityLine(status)));
 			needsSeparator = true;
 		};
 		const storeContinuity = (calls: readonly vscode.LanguageModelToolCallPart[]): void => {
@@ -314,7 +332,7 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 								break;
 							case 'status':
 								// Only surface real steps; skip thinking/summarizing churn.
-								if (event.activity) emitStatus(event.label, gate);
+								if (event.activity) emitStatus(event, gate);
 								break;
 							case 'conversation':
 								conversationId = event.conversationId;

--- a/src/ui/chat/model/lmTools.ts
+++ b/src/ui/chat/model/lmTools.ts
@@ -3,7 +3,7 @@ import { SessionManager, type Session } from '@sessions';
 import { log } from '@utils';
 import vscode from 'vscode';
 import { createGraphqlDeps, GRAPHQL_TOOL_SPECS } from '../tools/graphqlTool';
-import type { ToolSpec } from '../tools/toolProtocol';
+import { describeRequestBrief, type ToolSpec } from '../tools/toolProtocol';
 import { runToolRequests, WORKSPACE_TOOL_SPECS } from '../tools/workspaceTools';
 import { WEB_TOOL_SPECS } from '../tools/webTools';
 
@@ -224,6 +224,11 @@ export const LmToolRegistry = new (class LmToolRegistry implements vscode.Dispos
 
 	private makeTool(name: string): vscode.LanguageModelTool<Record<string, unknown>> {
 		return {
+			// Surface what the tool is accessing (its args) in the chat's running
+			// indicator instead of just the bare tool name (#22).
+			prepareInvocation: async options => ({
+				invocationMessage: describeRequestBrief({ tool: name, args: options.input ?? {} }),
+			}),
 			invoke: async (options, _token) => {
 				const session = resolveGraphqlSession();
 				const [result] = await runToolRequests(

--- a/src/ui/chat/tools/toolProtocol.test.ts
+++ b/src/ui/chat/tools/toolProtocol.test.ts
@@ -4,6 +4,7 @@ import { initTestEnvironment } from '@test';
 import {
 	buildToolInstructions,
 	describeRequest,
+	describeRequestBrief,
 	MAX_REQUESTS_PER_TURN,
 	parseToolRequests,
 	stripToolRequestBlocks,
@@ -98,6 +99,22 @@ suite('Unit: toolProtocol', () => {
 		test('omits empty args and includes non-empty args', () => {
 			assert.strictEqual(describeRequest({ tool: 'list_files', args: {} }), 'list_files');
 			assert.strictEqual(describeRequest({ tool: 'read_file', args: { path: 'a' } }), 'read_file {"path":"a"}');
+		});
+	});
+
+	suite('describeRequestBrief()', () => {
+		test('passes short labels through unchanged', () => {
+			assert.strictEqual(
+				describeRequestBrief({ tool: 'read_file', args: { path: 'a' } }),
+				'read_file {"path":"a"}',
+			);
+		});
+
+		test('truncates labels past the cap with an ellipsis', () => {
+			const brief = describeRequestBrief({ tool: 'rewst_graphql', args: { query: 'q'.repeat(300) } }, 40);
+			assert.strictEqual(brief.length, 40);
+			assert.ok(brief.startsWith('rewst_graphql {"query":"qqq'));
+			assert.ok(brief.endsWith('…'));
 		});
 	});
 });

--- a/src/ui/chat/tools/toolProtocol.test.ts
+++ b/src/ui/chat/tools/toolProtocol.test.ts
@@ -116,5 +116,11 @@ suite('Unit: toolProtocol', () => {
 			assert.ok(brief.startsWith('rewst_graphql {"query":"qqq'));
 			assert.ok(brief.endsWith('…'));
 		});
+
+		test('never exceeds a non-positive or tiny cap', () => {
+			assert.strictEqual(describeRequestBrief({ tool: 'read_file', args: { path: 'a' } }, 0), '');
+			assert.strictEqual(describeRequestBrief({ tool: 'read_file', args: { path: 'a' } }, -5), '');
+			assert.strictEqual(describeRequestBrief({ tool: 'read_file', args: { path: 'a' } }, 1), '…');
+		});
 	});
 });

--- a/src/ui/chat/tools/toolProtocol.ts
+++ b/src/ui/chat/tools/toolProtocol.ts
@@ -130,7 +130,10 @@ export function describeRequest(request: ToolRequest): string {
  */
 export function describeRequestBrief(request: ToolRequest, maxLength = 140): string {
 	const full = describeRequest(request);
-	return full.length > maxLength ? `${full.slice(0, maxLength - 1)}…` : full;
+	if (maxLength <= 0) return '';
+	if (full.length <= maxLength) return full;
+	if (maxLength === 1) return '…';
+	return `${full.slice(0, maxLength - 1)}…`;
 }
 
 /** Reads a non-empty string tool argument, or undefined if absent/wrong type. */

--- a/src/ui/chat/tools/toolProtocol.ts
+++ b/src/ui/chat/tools/toolProtocol.ts
@@ -124,6 +124,15 @@ export function describeRequest(request: ToolRequest): string {
 	return json === '{}' ? request.tool : `${request.tool} ${json}`;
 }
 
+/**
+ * Length-capped {@link describeRequest} for the chat's tool-invocation label, so
+ * the user sees what an editor tool is accessing without an unbounded args dump (#22).
+ */
+export function describeRequestBrief(request: ToolRequest, maxLength = 140): string {
+	const full = describeRequest(request);
+	return full.length > maxLength ? `${full.slice(0, maxLength - 1)}…` : full;
+}
+
 /** Reads a non-empty string tool argument, or undefined if absent/wrong type. */
 export function asStringArg(args: Record<string, unknown>, key: string): string | undefined {
 	const value = args[key];


### PR DESCRIPTION
## Addresses #22

Tool activity in the chat showed only *which* tool ran ("Running tool: …"), not *what* it was accessing — across both native Rewst tools and the editor's own tools. This adds a compact, length-capped preview of each call's arguments so the activity line says what's being looked up.

### Changes

**Native Rewst tools** (`conversationEvents.ts`, `TOOL_CALL_IN_PROGRESS`): the status label now includes the parsed `args` and is relabeled **`Running Rewst tool: <name> <args>…`**. The "Rewst tool" wording also distinguishes server-side native tools from the editor's tools (same native-vs-editor theme as #20). Args are formatted defensively — skips empty/`{}`, collapses whitespace, truncates at 100 chars.

**Editor tools** (`lmTools.ts`): `makeTool` now supplies `prepareInvocation`, so VS Code's running indicator shows `<name> <args>` (via `describeRequestBrief`) instead of a bare tool name.

`describeRequestBrief` (new, in `toolProtocol.ts`) caps the editor label length; it reuses the existing `describeRequest`.

### Tests

- `conversationEvents.test.ts`: native label now `Running Rewst tool: …`; new cases for the args preview and oversized-arg truncation.
- `toolProtocol.test.ts`: `describeRequestBrief` passthrough + truncation.
- `RoboRewstyChatModelProvider.test.ts`: activity fixture updated to the new native label.
- 317 unit tests passing; type-check clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Changed**
  * Updated chat tool activity rendering to include compact previews of call arguments rather than only the tool name.
  * Native tool activity is now labeled with a “Running Rewst tool:” prefix and shown in a card-like layout separating the tool name from an arguments snippet.
  * Argument previews are single-line and truncate with an ellipsis when too long.

* **Tests**
  * Updated and added unit tests to verify the new labels, preview inclusion, collapsing behavior, and truncation.

* **Documentation**
  * Refreshed the Unreleased changelog entry and bumped the extension version to 0.43.2.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->