### PR TITLE
Persist conversation map and cache workspace overview

### DIFF
--- a/changelog.d/38.md
+++ b/changelog.d/38.md
@@ -1,0 +1,8 @@
+---
+category: Changed
+pr: 38
+---
+
+- **Chat continuity survives a window reload** - the conversation map that lets a chat reuse one warm backend conversation (instead of re-shipping its whole transcript plus the engineering directive every turn) was in-memory only, so reloading the window forced every existing chat to downgrade to a stateless, full-transcript turn. It is now persisted to workspace storage (debounced, fire-and-forget) and restored on activation; stale server-side conversations still fall back cleanly through the existing error→downgrade path.
+- **Workspace overview is no longer re-scanned every turn** - the first-message workspace overview (a `readDirectory` scan) was rebuilt before every backend call; it is now cached, removing a filesystem round-trip from the front of each turn. Freshness is event-driven — the cache is invalidated when a top-level workspace file is created/removed/renamed, when the linked-template set changes, or when workspace folders change — with a TTL backstop for changes no event reports, and overlapping turns share a single in-flight scan.
+- **Prompt assembly is memoized** - the engineering directive, native-tool reminder, and tool-instruction text are pure functions of the permitted-tool set but were rebuilt (heavy string assembly) every turn; they are now cached per tool set, which is stable across a chat.

--- a/docs/features.md
+++ b/docs/features.md
@@ -90,6 +90,7 @@ Talk to Rewst's AI assistant directly from VS Code's chat — as its own model, 
 - **Multi-turn** — follow-up questions are grounded in the visible VS Code chat transcript, so Restore Checkpoint and edited history naturally remove rolled-back turns from the assistant's context
 - **Resume** — `Rewst Buddy: Resume Rewst AI Conversation` (command palette) lists your recent Rewst conversations (the same history as the Rewst web app) and opens the picked transcript
 - **Lives in Rewst** — each turn is processed through a transient Rewst conversation; the extension keeps the latest successful one and cleans up older transient conversations
+- **Fast follow-ups** — a follow-up reuses the same warm Rewst conversation instead of re-sending the whole transcript, and that link is remembered across window reloads, so picking an earlier chat back up stays quick rather than starting from scratch
 - **Organization** — each Cage-Free Rewsty model is tied to a session's organization; pick the org by picking the model
 - **Latency** — full answers typically take 20–40 seconds. Cancel any time with the stop button
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,12 +7,14 @@ import { SessionManager } from '@sessions';
 import {
 	BundleTreeDataProvider,
 	ContextUsageStatusBar,
+	conversationMap,
 	LmToolRegistry,
 	ProposedContentProvider,
 	RewstViewProvider,
 	RoboRewstyChatModelProvider,
 	SessionTreeDataProvider,
 	StatusBar,
+	type PersistedConversationMap,
 } from '@ui';
 import { log } from '@utils';
 import vscode from 'vscode';
@@ -62,6 +64,13 @@ export async function activate(context: vscode.ExtensionContext) {
 	);
 	context.subscriptions.push(TemplateBundleManager.init());
 	context.subscriptions.push(Server.init());
+	// Persist chat continuity across window reloads so warm conversations are
+	// reused instead of every chat re-shipping its full transcript statelessly.
+	const conversationMapKey = 'RewstConversationMap';
+	conversationMap.hydrate({
+		load: () => context.workspaceState.get<PersistedConversationMap>(conversationMapKey),
+		save: state => void context.workspaceState.update(conversationMapKey, state),
+	});
 	context.subscriptions.push(new RoboRewstyChatModelProvider().init());
 	context.subscriptions.push(LmToolRegistry.init());
 	context.subscriptions.push(ProposedContentProvider.init());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -69,7 +69,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	const conversationMapKey = 'RewstConversationMap';
 	conversationMap.hydrate({
 		load: () => context.workspaceState.get<PersistedConversationMap>(conversationMapKey),
-		save: state => void context.workspaceState.update(conversationMapKey, state),
+		save: state =>
+			void Promise.resolve(context.workspaceState.update(conversationMapKey, state)).catch(error =>
+				log.debug('conversationMap: persist failed', error),
+			),
 	});
 	context.subscriptions.push(new RoboRewstyChatModelProvider().init());
 	context.subscriptions.push(LmToolRegistry.init());

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.ts
@@ -12,7 +12,7 @@ import { log } from '@utils';
 import vscode from 'vscode';
 import { ChunkGate } from '../tools/chunkGate';
 import { stripToolRequestBlocks } from '../tools/toolProtocol';
-import { buildWorkspaceOverview } from '../tools/workspaceTools';
+import { createCachedWorkspaceOverview, wireWorkspaceOverviewInvalidation } from '../tools/workspaceTools';
 import { prependInstructions } from '../promptContext';
 import { buildEngineeringDirective, buildNativeToolReminder } from './engineeringDirective';
 import { conversationMap, nextTurnKey, prefixKey, spineDepth } from './conversationMap';
@@ -55,6 +55,8 @@ export interface ProviderDeps {
 	sessionForOrg(orgId: string): Session;
 	confirmApproval(tools: ApprovalTool[]): Promise<ApprovalChoice>;
 	workspaceOverview(): Promise<string | undefined>;
+	/** Marks the cached workspace overview stale; absent in tests (no-op). */
+	invalidateOverview?(): void;
 	workspaceRoot(): string | undefined;
 	aiConfig(): { customInstructions: string; conversationType: string; showActivity: boolean };
 	toolSettings(): AiToolSettings;
@@ -103,12 +105,15 @@ async function confirmApprovalModal(tools: ApprovalTool[]): Promise<ApprovalChoi
 	return 'cancel';
 }
 
+const defaultOverviewCache = createCachedWorkspaceOverview();
+
 export const defaultProviderDeps: ProviderDeps = {
 	ask: askRewstAi,
 	sessions: () => SessionManager.getActiveSessions(),
 	sessionForOrg: orgId => SessionManager.getSessionForOrg(orgId),
 	confirmApproval: confirmApprovalModal,
-	workspaceOverview: () => buildWorkspaceOverview(),
+	workspaceOverview: () => defaultOverviewCache.get(),
+	invalidateOverview: () => defaultOverviewCache.invalidate(),
 	workspaceRoot: () => vscode.workspace.workspaceFolders?.[0]?.uri.fsPath,
 	aiConfig: () => {
 		const config = vscode.workspace.getConfiguration(`${extPrefix}.ai`);
@@ -136,14 +141,61 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 
 	private registration: vscode.Disposable | undefined;
 	private sessionListener: vscode.Disposable | undefined;
+	private overviewInvalidation: vscode.Disposable | undefined;
+
+	// The directive, native-tool reminder, and tool-instruction text are pure
+	// functions of the permitted-tool set, but get rebuilt (heavy string
+	// assembly) every turn. Memoize by a sorted tool-name key; the set is stable
+	// across a chat, so these almost always hit.
+	private directiveCache = new Map<string, string>();
+	private nativeReminderCache = new Map<string, string>();
+	private toolInstructionsCache = new Map<string, string>();
 
 	constructor(private readonly deps: ProviderDeps = defaultProviderDeps) {}
 
 	init(): this {
 		this.registration = vscode.lm.registerLanguageModelChatProvider(VENDOR, this);
 		this.sessionListener = SessionManager.onSessionChange(() => this.changeEmitter.fire());
+		// Keep the cached workspace overview fresh: invalidate it on top-level file
+		// and template-link changes, with the cache's TTL as the backstop.
+		if (this.deps.invalidateOverview) {
+			this.overviewInvalidation = wireWorkspaceOverviewInvalidation(() => this.deps.invalidateOverview?.());
+		}
 		log.debug('RoboRewstyChatModelProvider: registered', VENDOR);
 		return this;
+	}
+
+	private cachedEngineeringDirective(permittedNames: ReadonlySet<string>): string {
+		const key = [...permittedNames].sort().join('|');
+		let value = this.directiveCache.get(key);
+		if (value === undefined) {
+			value = buildEngineeringDirective(permittedNames);
+			this.directiveCache.set(key, value);
+		}
+		return value;
+	}
+
+	private cachedNativeToolReminder(permittedNames: ReadonlySet<string>): string {
+		const key = [...permittedNames].sort().join('|');
+		let value = this.nativeReminderCache.get(key);
+		if (value === undefined) {
+			value = buildNativeToolReminder(permittedNames);
+			this.nativeReminderCache.set(key, value);
+		}
+		return value;
+	}
+
+	private cachedToolInstructions(tools: readonly vscode.LanguageModelChatTool[]): string {
+		const key = tools
+			.map(tool => tool.name)
+			.sort()
+			.join('|');
+		let value = this.toolInstructionsCache.get(key);
+		if (value === undefined) {
+			value = buildInstructionsForChatTools(tools);
+			this.toolInstructionsCache.set(key, value);
+		}
+		return value;
 	}
 
 	dispose(): void {
@@ -151,6 +203,8 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 		this.registration = undefined;
 		this.sessionListener?.dispose();
 		this.sessionListener = undefined;
+		this.overviewInvalidation?.dispose();
+		this.overviewInvalidation = undefined;
 		this.changeEmitter.dispose();
 	}
 
@@ -562,8 +616,8 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 			const root = this.deps.workspaceRoot();
 			if (root) message += `\n\nThe user's VS Code working directory: ${root}`;
 		}
-		if (tools.length > 0) message += `\n\n${buildInstructionsForChatTools(tools)}`;
-		message += `\n\n${buildNativeToolReminder(permittedNames)}`;
+		if (tools.length > 0) message += `\n\n${this.cachedToolInstructions(tools)}`;
+		message += `\n\n${this.cachedNativeToolReminder(permittedNames)}`;
 		return message;
 	}
 
@@ -593,11 +647,11 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 			const root = this.deps.workspaceRoot();
 			if (root) message += `\n\nThe user's VS Code working directory: ${root}`;
 		}
-		if (tools.length > 0) message += `\n\n${buildInstructionsForChatTools(tools)}`;
-		message = [buildEngineeringDirective(permittedNames), message].filter(Boolean).join('\n\n');
+		if (tools.length > 0) message += `\n\n${this.cachedToolInstructions(tools)}`;
+		message = [this.cachedEngineeringDirective(permittedNames), message].filter(Boolean).join('\n\n');
 		// Highest-recency line: the directive sits far above the latest user turn
 		// (buried in the transcript), so repeat the native-tool curb last.
-		message += `\n\n${buildNativeToolReminder(permittedNames)}`;
+		message += `\n\n${this.cachedNativeToolReminder(permittedNames)}`;
 		return message;
 	}
 }

--- a/src/ui/chat/model/conversationMap.test.ts
+++ b/src/ui/chat/model/conversationMap.test.ts
@@ -2,7 +2,16 @@ import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { initTestEnvironment } from '@test';
 import vscode from 'vscode';
-import { ConversationMap, MAX_ENTRIES, nextTurnKey, prefixKey, serializeHistory, spineDepth } from './conversationMap';
+import {
+	ConversationMap,
+	MAX_ENTRIES,
+	nextTurnKey,
+	prefixKey,
+	serializeHistory,
+	spineDepth,
+	type ConversationMapStorage,
+	type PersistedConversationMap,
+} from './conversationMap';
 
 const { suite, test, setup } = Mocha;
 
@@ -179,6 +188,83 @@ suite('Unit: conversationMap', () => {
 			assert.strictEqual(map.lookup('key-1'), undefined);
 			assert.strictEqual(map.lookupByCallIds(['call-1']), undefined);
 			assert.strictEqual(map.breadcrumbFollowable('conv-1', 2), false);
+		});
+	});
+
+	suite('persistence', () => {
+		function fakeStorage(initial?: PersistedConversationMap): {
+			storage: ConversationMapStorage;
+			saved: () => PersistedConversationMap | undefined;
+		} {
+			let state = initial;
+			return {
+				storage: {
+					load: () => state,
+					save: snapshot => {
+						state = snapshot;
+					},
+				},
+				saved: () => state,
+			};
+		}
+
+		const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms));
+
+		test('hydrate restores entries, tips, and callId bindings', () => {
+			const map = new ConversationMap();
+			const { storage } = fakeStorage({
+				entries: [
+					['key-turn-1', { conversationId: 'conv-1', depth: 1 }],
+					['key-turn-2', { conversationId: 'conv-1', depth: 2 }],
+				],
+				tipDepth: [['conv-1', 2]],
+				byCallId: [['call-1', 'conv-1']],
+			});
+			map.hydrate(storage);
+
+			assert.deepStrictEqual(map.lookup('key-turn-2'), { conversationId: 'conv-1', followable: true });
+			assert.strictEqual(map.lookup('key-turn-1')?.followable, false, 'behind-tip prefix survives the reload');
+			assert.strictEqual(map.lookupByCallIds(['call-1']), 'conv-1');
+			assert.strictEqual(map.breadcrumbFollowable('conv-1', 2), true);
+		});
+
+		test('hydrate on a fresh store with no snapshot is a no-op', () => {
+			const map = new ConversationMap();
+			const { storage } = fakeStorage(undefined);
+			map.hydrate(storage);
+			assert.strictEqual(map.lookup('anything'), undefined);
+		});
+
+		test('mutations are persisted (debounced) once a store is attached', async () => {
+			const map = new ConversationMap();
+			const { storage, saved } = fakeStorage();
+			map.hydrate(storage);
+
+			map.store('key-1', 'conv-1', 1);
+			map.storeByCallIds(['call-1'], 'conv-1');
+			assert.strictEqual(saved(), undefined, 'write is debounced, not synchronous');
+
+			await wait(400);
+			const snapshot = saved();
+			assert.ok(snapshot, 'snapshot was written after the debounce window');
+			assert.deepStrictEqual(snapshot?.entries, [['key-1', { conversationId: 'conv-1', depth: 1 }]]);
+			assert.deepStrictEqual(snapshot?.byCallId, [['call-1', 'conv-1']]);
+
+			// A reload from the written snapshot reconstructs the same map.
+			const reloaded = new ConversationMap();
+			reloaded.hydrate({ load: () => snapshot, save: () => {} });
+			assert.strictEqual(reloaded.lookup('key-1')?.conversationId, 'conv-1');
+			assert.strictEqual(reloaded.lookupByCallIds(['call-1']), 'conv-1');
+		});
+
+		test('without a store, mutations never attempt to persist', () => {
+			const map = new ConversationMap();
+			// No hydrate(): schedulePersist must short-circuit and not throw.
+			assert.doesNotThrow(() => {
+				map.store('key-1', 'conv-1', 1);
+				map.storeByCallIds(['call-1'], 'conv-1');
+				map.forget('conv-1');
+			});
 		});
 	});
 });

--- a/src/ui/chat/model/conversationMap.ts
+++ b/src/ui/chat/model/conversationMap.ts
@@ -117,6 +117,28 @@ interface Entry {
 	depth: number;
 }
 
+/**
+ * Serializable snapshot of the map, so warm conversations survive a window
+ * reload / extension restart instead of every chat downgrading to a stateless
+ * full-transcript resend on its next turn.
+ */
+export interface PersistedConversationMap {
+	entries: [string, Entry][];
+	tipDepth: [string, number][];
+	byCallId: [string, string][];
+}
+
+/**
+ * Backing store for persistence (a VS Code Memento in production). Kept abstract
+ * so the map stays unit-testable without a vscode runtime dependency.
+ */
+export interface ConversationMapStorage {
+	load(): PersistedConversationMap | undefined;
+	save(state: PersistedConversationMap): void;
+}
+
+const PERSIST_DEBOUNCE_MS = 300;
+
 /** Result of a spine-hash lookup: the matched conversation and whether it is still followable. */
 export interface ConversationMatch {
 	conversationId: string;
@@ -129,6 +151,38 @@ export class ConversationMap {
 	/** Deepest stored spine per conversation — the conversation's tip. */
 	private tipDepth = new Map<string, number>();
 	private byCallId = new Map<string, string>();
+
+	private storage: ConversationMapStorage | undefined;
+	private persistTimer: ReturnType<typeof setTimeout> | undefined;
+
+	/**
+	 * Attach a backing store and load any persisted snapshot. Called once at
+	 * activation; absent in unit tests, where persistence is simply inert.
+	 */
+	hydrate(storage: ConversationMapStorage): void {
+		this.storage = storage;
+		const saved = storage.load();
+		if (!saved) return;
+		// Insertion order in the persisted arrays carries LRU recency; the size
+		// caps re-apply defensively in case the stored snapshot predates a lower cap.
+		for (const [key, entry] of saved.entries.slice(-MAX_ENTRIES)) this.entries.set(key, entry);
+		for (const [id, depth] of saved.tipDepth.slice(-MAX_ENTRIES)) this.tipDepth.set(id, depth);
+		for (const [callId, id] of saved.byCallId.slice(-MAX_ENTRIES)) this.byCallId.set(callId, id);
+	}
+
+	/** Debounced, fire-and-forget snapshot write; inert until hydrated. */
+	private schedulePersist(): void {
+		if (!this.storage) return;
+		if (this.persistTimer) clearTimeout(this.persistTimer);
+		this.persistTimer = setTimeout(() => {
+			this.persistTimer = undefined;
+			this.storage?.save({
+				entries: [...this.entries],
+				tipDepth: [...this.tipDepth],
+				byCallId: [...this.byCallId],
+			});
+		}, PERSIST_DEBOUNCE_MS);
+	}
 
 	/**
 	 * The backend conversation a request prefix belongs to, if known, plus
@@ -177,6 +231,7 @@ export class ConversationMap {
 			if (oldest === undefined) break;
 			this.tipDepth.delete(oldest);
 		}
+		this.schedulePersist();
 	}
 
 	/**
@@ -196,6 +251,7 @@ export class ConversationMap {
 			if (oldest === undefined) break;
 			this.byCallId.delete(oldest);
 		}
+		this.schedulePersist();
 	}
 
 	/** The backend conversation that emitted any of these tool calls, if known. */
@@ -220,6 +276,7 @@ export class ConversationMap {
 		for (const [callId, id] of this.byCallId) {
 			if (id === conversationId) this.byCallId.delete(callId);
 		}
+		this.schedulePersist();
 	}
 
 	/** Clears all state between tests. */
@@ -227,6 +284,9 @@ export class ConversationMap {
 		this.entries.clear();
 		this.tipDepth.clear();
 		this.byCallId.clear();
+		if (this.persistTimer) clearTimeout(this.persistTimer);
+		this.persistTimer = undefined;
+		this.storage = undefined;
 	}
 }
 

--- a/src/ui/chat/tools/workspaceTools.test.ts
+++ b/src/ui/chat/tools/workspaceTools.test.ts
@@ -187,6 +187,29 @@ suite('Unit: workspaceTools', () => {
 			assert.strictEqual(builds, 2);
 		});
 
+		test('a scan invalidated mid-flight is not re-cached', async () => {
+			let builds = 0;
+			const releases: ((value: string) => void)[] = [];
+			const cache = createCachedWorkspaceOverview(
+				() => {
+					builds++;
+					return new Promise<string>(resolve => releases.push(resolve));
+				},
+				30_000,
+				() => 1000, // clock frozen inside the TTL
+			);
+
+			const first = cache.get(); // scan #1 starts
+			cache.invalidate(); // a file changed while scan #1 was in flight
+			releases[0]('stale');
+			assert.strictEqual(await first, 'stale', 'the original caller still receives its result');
+
+			const second = cache.get(); // must rebuild, not serve the pre-invalidation scan
+			releases[1]('fresh');
+			assert.strictEqual(await second, 'fresh');
+			assert.strictEqual(builds, 2, 'the stale scan was discarded, not re-cached');
+		});
+
 		test('concurrent callers share a single in-flight scan', async () => {
 			let builds = 0;
 			let release!: (value: string) => void;

--- a/src/ui/chat/tools/workspaceTools.test.ts
+++ b/src/ui/chat/tools/workspaceTools.test.ts
@@ -4,7 +4,13 @@ import { initTestEnvironment } from '@test';
 import type { TemplateLink } from '@models';
 import vscode from 'vscode';
 import type { GraphqlToolDeps } from './graphqlTool';
-import { buildWorkspaceOverview, runToolRequests, type WorkspaceToolDeps } from './workspaceTools';
+import {
+	buildWorkspaceOverview,
+	createCachedWorkspaceOverview,
+	runToolRequests,
+	wireWorkspaceOverviewInvalidation,
+	type WorkspaceToolDeps,
+} from './workspaceTools';
 
 const { suite, test, setup } = Mocha;
 
@@ -132,6 +138,90 @@ suite('Unit: workspaceTools', () => {
 			assert.ok(overview.includes('Workspace folder "ws": package.json, src/'));
 			assert.ok(overview.includes('1 file(s) are linked to Rewst templates'));
 			assert.ok(!overview.includes('.git'));
+		});
+	});
+
+	suite('createCachedWorkspaceOverview()', () => {
+		test('serves a cached value within the TTL instead of rebuilding', async () => {
+			let builds = 0;
+			let clock = 1000;
+			const cache = createCachedWorkspaceOverview(
+				async () => `overview-${++builds}`,
+				30_000,
+				() => clock,
+			);
+
+			assert.strictEqual(await cache.get(), 'overview-1');
+			clock += 10_000; // still inside the TTL
+			assert.strictEqual(await cache.get(), 'overview-1', 'second call within TTL is cached');
+			assert.strictEqual(builds, 1, 'the underlying scan ran once');
+		});
+
+		test('rebuilds after the TTL elapses', async () => {
+			let builds = 0;
+			let clock = 1000;
+			const cache = createCachedWorkspaceOverview(
+				async () => `overview-${++builds}`,
+				30_000,
+				() => clock,
+			);
+
+			assert.strictEqual(await cache.get(), 'overview-1');
+			clock += 30_001; // past the TTL
+			assert.strictEqual(await cache.get(), 'overview-2');
+			assert.strictEqual(builds, 2);
+		});
+
+		test('invalidate() forces a rebuild on the next get, even within the TTL', async () => {
+			let builds = 0;
+			const cache = createCachedWorkspaceOverview(
+				async () => `overview-${++builds}`,
+				30_000,
+				() => 1000, // clock frozen inside the TTL
+			);
+
+			assert.strictEqual(await cache.get(), 'overview-1');
+			assert.strictEqual(await cache.get(), 'overview-1', 'cached while fresh');
+			cache.invalidate();
+			assert.strictEqual(await cache.get(), 'overview-2', 'rebuilt after invalidation');
+			assert.strictEqual(builds, 2);
+		});
+
+		test('concurrent callers share a single in-flight scan', async () => {
+			let builds = 0;
+			let release!: (value: string) => void;
+			const cache = createCachedWorkspaceOverview(
+				() => {
+					builds++;
+					return new Promise<string>(resolve => {
+						release = resolve;
+					});
+				},
+				30_000,
+				() => 1000,
+			);
+
+			const first = cache.get();
+			const second = cache.get();
+			release('overview');
+			assert.strictEqual(await first, 'overview');
+			assert.strictEqual(await second, 'overview');
+			assert.strictEqual(builds, 1, 'only one scan started for the overlapping calls');
+		});
+	});
+
+	suite('wireWorkspaceOverviewInvalidation()', () => {
+		test('registers file/link/folder watchers and disposes cleanly', () => {
+			// Exercises the real VS Code watcher API (createFileSystemWatcher +
+			// RelativePattern) so a misuse surfaces here rather than at runtime.
+			const wiring = wireWorkspaceOverviewInvalidation(() => {}, [folder]);
+			assert.strictEqual(typeof wiring.dispose, 'function');
+			assert.doesNotThrow(() => wiring.dispose());
+		});
+
+		test('no workspace folders still wires link/folder invalidation without throwing', () => {
+			const wiring = wireWorkspaceOverviewInvalidation(() => {}, []);
+			assert.doesNotThrow(() => wiring.dispose());
 		});
 	});
 });

--- a/src/ui/chat/tools/workspaceTools.ts
+++ b/src/ui/chat/tools/workspaceTools.ts
@@ -176,22 +176,32 @@ export function createCachedWorkspaceOverview(
 	let cachedAt = Number.NEGATIVE_INFINITY;
 	let value: string | undefined;
 	let inFlight: Promise<string | undefined> | undefined;
+	// Bumped on every invalidation; a scan whose generation no longer matches
+	// started before the invalidation, so its result must not be (re-)cached.
+	let generation = 0;
 	return {
 		async get() {
 			if (now() - cachedAt < ttlMs) return value;
 			if (inFlight) return inFlight;
-			inFlight = build();
+			const gen = generation;
+			const pending = build();
+			inFlight = pending;
 			try {
-				value = await inFlight;
-				cachedAt = now();
-				return value;
+				const result = await pending;
+				if (gen === generation) {
+					value = result;
+					cachedAt = now();
+				}
+				return result;
 			} finally {
-				inFlight = undefined;
+				if (inFlight === pending) inFlight = undefined;
 			}
 		},
 		invalidate() {
+			generation++;
 			cachedAt = Number.NEGATIVE_INFINITY;
 			value = undefined;
+			inFlight = undefined;
 		},
 	};
 }
@@ -208,13 +218,32 @@ export function wireWorkspaceOverviewInvalidation(
 	invalidate: () => void,
 	folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders ?? [],
 ): vscode.Disposable {
-	const disposables: vscode.Disposable[] = [];
+	let folderWatchers: vscode.Disposable[] = [];
 	// Non-recursive `*` pattern: only the folder's direct children matter, since
 	// that is all the overview lists. Renames surface as delete + create.
-	for (const folder of folders.slice(0, 3)) {
-		const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(folder, '*'));
-		disposables.push(watcher, watcher.onDidCreate(invalidate), watcher.onDidDelete(invalidate));
-	}
-	disposables.push(LinkManager.onLinksSaved(invalidate), vscode.workspace.onDidChangeWorkspaceFolders(invalidate));
-	return { dispose: () => disposables.forEach(d => d.dispose()) };
+	const registerFolderWatchers = (current: readonly vscode.WorkspaceFolder[]): void => {
+		folderWatchers.forEach(d => d.dispose());
+		folderWatchers = [];
+		for (const folder of current.slice(0, 3)) {
+			const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(folder, '*'));
+			folderWatchers.push(watcher, watcher.onDidCreate(invalidate), watcher.onDidDelete(invalidate));
+		}
+	};
+	registerFolderWatchers(folders);
+
+	const subscriptions = [
+		LinkManager.onLinksSaved(invalidate),
+		// A changed folder set both alters the overview's folder list AND means the
+		// old watchers point at stale folders — rebind them, then invalidate.
+		vscode.workspace.onDidChangeWorkspaceFolders(() => {
+			registerFolderWatchers(vscode.workspace.workspaceFolders ?? []);
+			invalidate();
+		}),
+	];
+	return {
+		dispose: () => {
+			folderWatchers.forEach(d => d.dispose());
+			subscriptions.forEach(d => d.dispose());
+		},
+	};
 }

--- a/src/ui/chat/tools/workspaceTools.ts
+++ b/src/ui/chat/tools/workspaceTools.ts
@@ -152,3 +152,69 @@ export async function buildWorkspaceOverview(deps: WorkspaceToolDeps = defaultDe
 	}
 	return sections.join('\n');
 }
+
+export interface CachedWorkspaceOverview {
+	/** The overview, served from cache when fresh; rebuilt on a miss/invalidation. */
+	get(): Promise<string | undefined>;
+	/** Marks the cached value stale so the next get() rebuilds it. */
+	invalidate(): void;
+}
+
+/**
+ * Wraps {@link buildWorkspaceOverview} with a cache so a multi-turn chat does
+ * not re-scan the workspace (a `readDirectory` round-trip) before every backend
+ * call. Freshness is event-driven — {@link wireWorkspaceOverviewInvalidation}
+ * calls `invalidate()` when workspace files or template links change — and the
+ * TTL is a backstop for changes no event reports (external edits, unwatched
+ * paths). Concurrent callers share a single in-flight scan.
+ */
+export function createCachedWorkspaceOverview(
+	build: () => Promise<string | undefined> = () => buildWorkspaceOverview(),
+	ttlMs = 60_000,
+	now: () => number = Date.now,
+): CachedWorkspaceOverview {
+	let cachedAt = Number.NEGATIVE_INFINITY;
+	let value: string | undefined;
+	let inFlight: Promise<string | undefined> | undefined;
+	return {
+		async get() {
+			if (now() - cachedAt < ttlMs) return value;
+			if (inFlight) return inFlight;
+			inFlight = build();
+			try {
+				value = await inFlight;
+				cachedAt = now();
+				return value;
+			} finally {
+				inFlight = undefined;
+			}
+		},
+		invalidate() {
+			cachedAt = Number.NEGATIVE_INFINITY;
+			value = undefined;
+		},
+	};
+}
+
+/**
+ * Event-driven invalidation for {@link createCachedWorkspaceOverview}: the
+ * overview lists each workspace folder's top-level entries plus a linked-template
+ * count, so it goes stale when a top-level file is created/removed/renamed, when
+ * the linked-template set changes, or when workspace folders change. The handler
+ * only flags the cache stale (a lazy rebuild on the next turn), so it stays cheap
+ * even on busy workspaces. Returned Disposable owns every watcher/subscription.
+ */
+export function wireWorkspaceOverviewInvalidation(
+	invalidate: () => void,
+	folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders ?? [],
+): vscode.Disposable {
+	const disposables: vscode.Disposable[] = [];
+	// Non-recursive `*` pattern: only the folder's direct children matter, since
+	// that is all the overview lists. Renames surface as delete + create.
+	for (const folder of folders.slice(0, 3)) {
+		const watcher = vscode.workspace.createFileSystemWatcher(new vscode.RelativePattern(folder, '*'));
+		disposables.push(watcher, watcher.onDidCreate(invalidate), watcher.onDidDelete(invalidate));
+	}
+	disposables.push(LinkManager.onLinksSaved(invalidate), vscode.workspace.onDidChangeWorkspaceFolders(invalidate));
+	return { dispose: () => disposables.forEach(d => d.dispose()) };
+}

--- a/src/ui/index.ts
+++ b/src/ui/index.ts
@@ -10,6 +10,11 @@ export {
 export { ContextUsageStatusBar } from './ContextUsageStatusBar';
 export { LmToolRegistry } from './chat/model/lmTools';
 export { RoboRewstyChatModelProvider } from './chat/model/RoboRewstyChatModelProvider';
+export {
+	conversationMap,
+	type ConversationMapStorage,
+	type PersistedConversationMap,
+} from './chat/model/conversationMap';
 export { ProposedContentProvider, PROPOSED_SCHEME } from './chat/ProposedContentProvider';
 export * from './pickers';
 export { StatusBar } from './StatusBarIcon';


### PR DESCRIPTION
Persist the chat conversation map across window reloads and add caching for workspace overviews and prompt assembly.

- conversationMap: add PersistedConversationMap and ConversationMapStorage, hydrate/save with a debounced (300ms) fire-and-forget persist, and restore entries/tips/byCallId on activation. Tests added for persistence behavior and edge cases.
- extension: wire conversationMap.hydrate to workspaceState under key `RewstConversationMap`.
- workspaceTools: introduce createCachedWorkspaceOverview (TTL-backed cache, single in-flight scan, invalidate) and wireWorkspaceOverviewInvalidation to mark the cache stale on file/link/folder changes; add unit tests for caching and wiring.
- RoboRewstyChatModelProvider: use cached workspace overview and wire invalidation; memoize engineering directive, native-tool reminder, and tool-instruction assembly per tool set to avoid expensive string rebuilds each turn; manage disposables.
- ui index: export conversationMap and storage types.
- CHANGELOG: document chat continuity, workspace overview caching, and prompt assembly memoization.

These changes reduce costly per-turn filesystem scans and transcript re-shipping after reloads, improving chat continuity and performance.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Chat conversations now persist across window reloads, allowing seamless resumption without losing context
  * Workspace information is cached and automatically refreshed when relevant changes occur (workspace files, structure updates)

* **Performance Improvements**
  * Optimized prompt assembly by caching reusable instruction components across conversation turns

* **Documentation**
  * Updated feature notes describing conversation persistence behavior
<!-- end of auto-generated comment: release notes by coderabbit.ai -->