### PR TITLE
ci(release): open release PR with a GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,11 +43,22 @@ jobs:
             VERSION_INPUT: ${{ github.event.inputs.version }}
             DATE: ${{ github.event.inputs.date }}
         steps:
+            # The default GITHUB_TOKEN cannot open a PR (and PRs it opens never
+            # trigger CI), so mint a short-lived token from the release-bot
+            # GitHub App. The PR it opens triggers the required pull_request checks.
+            - name: Generate a token from the release-bot GitHub App
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  app-id: ${{ secrets.RELEASE_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
               with:
                   ref: main
                   fetch-depth: 0
                   persist-credentials: true
+                  token: ${{ steps.app-token.outputs.token }}
 
             - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
               with:
@@ -89,6 +100,8 @@ jobs:
                   npm version "$VERSION" --no-git-tag-version
 
             - name: Open release PR
+              env:
+                  GH_TOKEN: ${{ steps.app-token.outputs.token }}
               run: |
                   git config user.name 'github-actions[bot]'
                   git config user.email '41898282+github-actions[bot]@users.noreply.github.com'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -52,6 +52,12 @@ jobs:
               with:
                   app-id: ${{ secrets.RELEASE_APP_ID }}
                   private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+                  # Scope the minted token to only this repo and only the
+                  # permissions this workflow uses, so broadening the App's
+                  # install later cannot silently widen this token.
+                  repositories: rewst-buddy
+                  permission-contents: write
+                  permission-pull-requests: write
 
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
               with:

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -42,6 +42,22 @@ note` status checks; block direct pushes and force-pushes. CodeRabbit's
   Marketplace PAT for the `JBramley` publisher) there — not as a repo-wide secret.
   Optionally add `OVSX_PAT` for Open VSX and uncomment that step in
   `publish.yml`.
+- **Release-bot GitHub App** (for the Prepare release PR): the default
+  `GITHUB_TOKEN` cannot open a PR, and a PR it opened would not trigger the
+  required CI checks. So `release.yml` mints a short-lived token from a GitHub
+  App instead. One-time setup:
+    1. Settings → Developer settings → **GitHub Apps → New GitHub App**. Name it
+       (e.g. `rewst-buddy-release-bot`), set any Homepage URL, and **uncheck
+       Webhook → Active**.
+    2. **Repository permissions**: `Contents: Read and write` and
+       `Pull requests: Read and write` (Metadata read-only is implied). Install
+       target: **Only on this account**. Create the app.
+    3. On the app's page, note the **App ID** and **Generate a private key**
+       (downloads a `.pem`).
+    4. **Install App** → this account → **Only select repositories** →
+       `rewst-buddy`.
+    5. Store the credentials as repo secrets: **`RELEASE_APP_ID`** (the App ID)
+       and **`RELEASE_APP_PRIVATE_KEY`** (the `.pem` contents).
 
 ## Hardening notes
 


### PR DESCRIPTION
## Problem

The **Prepare release** workflow failed with:

```
pull request create failed: GraphQL: GitHub Actions is not permitted to create or approve pull requests (createPullRequest)
```

The default `GITHUB_TOKEN` is blocked from creating PRs. And even if the repo toggle were enabled, a PR opened by `GITHUB_TOKEN` does **not** trigger `pull_request` workflows (GitHub's recursion guard), so the release PR would never run the `Lint, type-check, build, test` + `Changelog note` checks the `main` ruleset requires — leaving it un-mergeable without admin bypass.

## Fix

Mint a short-lived token from a **release-bot GitHub App** with [`actions/create-github-app-token`](https://github.com/actions/create-github-app-token) (pinned to v3.2.0) and use it for `checkout` and `gh pr create`. A PR opened by the App triggers CI normally. This is GitHub's recommended approach over a personal PAT (short-lived, repo-scoped, not tied to a human account).

## Required before merging

Add two repo secrets (one-time App setup documented in `docs/dev/releasing.md`):
- `RELEASE_APP_ID`
- `RELEASE_APP_PRIVATE_KEY`

Without them the next Prepare release run fails at the token step, so **add the secrets first, then merge.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved release automation to use a short-lived GitHub App token with explicit write permissions when creating release pull requests, ensuring the correct CI checks run.

* **Documentation**
  * Added a one-time setup guide explaining the Release-bot GitHub App token requirements and step-by-step instructions to configure and store the needed credentials as repository secrets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->