### PR TITLE
ci(release): auto-tag on release merge — merging is the publish approval

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,10 @@
 name: Publish
 
-# Fires when a vX.Y.Z tag is pushed (after the release PR has merged to main).
-# Packages the extension, creates the GitHub release, and publishes to the VS
-# Code Marketplace. The `release` environment requires a maintainer to approve
-# the run before it proceeds, and the Marketplace token (VSCE_PAT) is scoped to
-# that environment — so the token never unlocks without a human go-ahead.
+# Fires when a vX.Y.Z tag is pushed. CI tags automatically when a release PR
+# merges (tag-on-merge.yml), so merging the release PR is what ships a release —
+# there is no separate publish approval. Packages the extension, creates the
+# GitHub release, and publishes to the VS Code Marketplace. The Marketplace token
+# (VSCE_PAT) is scoped to the `release` environment, so only this job can read it.
 
 on:
     push:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
                     echo "Automated release prep for **v${VERSION}**."
                     echo
                     echo "- Collated \`changelog.d/\` notes into CHANGELOG.md and bumped \`package.json\`."
-                    echo "- Merging this PR does **not** publish. After it lands on \`main\`, push the tag \`v${VERSION}\` (e.g. \`npm run release:tag\`) to trigger Publish."
+                    echo "- ⚠️ **Merging this PR publishes v${VERSION} to the VS Code Marketplace.** On merge, CI tags \`v${VERSION}\` and the Publish workflow ships it. Merging is the approval to publish — there is no separate gate."
                     echo
                     echo "---"
                     echo

--- a/.github/workflows/tag-on-merge.yml
+++ b/.github/workflows/tag-on-merge.yml
@@ -1,0 +1,57 @@
+name: Tag merged release
+
+# When a release/* PR merges to main, create and push the matching vX.Y.Z tag so
+# the tag-driven Publish workflow runs. Merging the release PR is the go-ahead to
+# ship — there is no separate publish approval. The tag is pushed with the
+# release-bot App token (not GITHUB_TOKEN), because a tag pushed by GITHUB_TOKEN
+# would not trigger the Publish workflow.
+
+on:
+    pull_request:
+        types: [closed]
+        branches: [main]
+
+permissions:
+    contents: read
+
+concurrency:
+    group: tag-on-merge
+    cancel-in-progress: false
+
+jobs:
+    tag:
+        # Only merged release/* PRs (a closed-without-merge PR does nothing).
+        if: >-
+            github.event.pull_request.merged == true &&
+            startsWith(github.event.pull_request.head.ref, 'release/')
+        runs-on: ubuntu-latest
+        steps:
+            - name: Generate a token from the release-bot GitHub App
+              id: app-token
+              uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+              with:
+                  app-id: ${{ secrets.RELEASE_APP_ID }}
+                  private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+                  repositories: rewst-buddy
+                  permission-contents: write
+
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+              with:
+                  ref: ${{ github.event.pull_request.merge_commit_sha }}
+                  fetch-depth: 0
+                  persist-credentials: true
+                  token: ${{ steps.app-token.outputs.token }}
+
+            - name: Create and push the release tag
+              run: |
+                  VERSION="$(node -p "require('./package.json').version")"
+                  TAG="v${VERSION}"
+                  if git ls-remote --exit-code --tags origin "refs/tags/${TAG}" >/dev/null 2>&1; then
+                    echo "::notice::Tag ${TAG} already exists on origin; nothing to do."
+                    exit 0
+                  fi
+                  git config user.name 'github-actions[bot]'
+                  git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+                  git tag "${TAG}"
+                  git push origin "${TAG}"
+                  echo "::notice::Pushed ${TAG}; the Publish workflow will run."

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -125,8 +125,7 @@ The changelog is generated from **per-PR note files** — never hand-edit `CHANG
 Releases run entirely through GitHub Actions; runbook and one-time setup are in `docs/dev/releasing.md`. In short:
 
 1. Run the **Prepare release** workflow (Actions → Run workflow) — pick a bump (`patch`/`minor`/`major`) or an explicit version. It collates `changelog.d/` into a new `## [x.y.z]` section in `CHANGELOG.md`, bumps `package.json`, and opens a `release/vx.y.z` PR.
-2. Review and squash-merge that PR (CodeRabbit + maintainer approval gate it).
-3. `npm run release:tag` — the **Publish** workflow then creates the GitHub release (notes from the CHANGELOG section) and publishes to the Marketplace, gated by the `release` environment's required reviewer.
+2. Review and squash-merge that PR — **merging publishes.** On merge, `tag-on-merge.yml` pushes the `vx.y.z` tag (via the release-bot App token, so the tag triggers Publish), and the **Publish** workflow creates the GitHub release (notes from the CHANGELOG section) and publishes to the Marketplace. Merging the release PR is the approval to publish — there is no separate gate. (`npm run release:tag` stays as a manual fallback.)
 
 Per-change code review happens on each feature PR (CodeRabbit + CI), not at release time.
 

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -1,8 +1,9 @@
 # Releasing & changelog (maintainers)
 
 The changelog is built from **per-PR notes**, and releases run through GitHub
-Actions with two human approval gates so nothing reaches `main` or the
-Marketplace unreviewed. There is no manual release skill — these workflows are the whole process.
+Actions. Approving and merging the release PR is the single human gate — it both
+lands the version on `main` and publishes to the Marketplace. There is no manual
+release skill — these workflows are the whole process.
 
 ## Changelog notes
 
@@ -19,15 +20,17 @@ Marketplace unreviewed. There is no manual release skill — these workflows are
 1. **Prepare** — run the **Prepare release** workflow (Actions → Run workflow)
    picking a version bump (`patch`/`minor`/`major`) or an explicit version. It collates `changelog.d/` into a `## [x.y.z]`
    section, bumps `package.json`, and opens a `release/vx.y.z` PR.
-2. **Review & merge** — review the PR and merge it (squash). Branch protection
-   requires the approval here — this is gate #1.
-3. **Tag** — from the merged `main`: `npm run release:tag` (tags `vx.y.z` and
-   pushes it).
-4. **Publish** — the tag triggers the **Publish** workflow. It runs in the
-   `release` environment, which requires a maintainer to approve the run — gate
-   #2 — then packages the `.vsix`, creates the GitHub release, and publishes to
-   the Marketplace. The `VSCE_PAT` is scoped to that environment, so it never
-   unlocks without that approval.
+2. **Review & merge — this ships it.** Review the PR and merge it (squash).
+   Branch protection requires the approval here, and **merging is the approval to
+   publish**: on merge, `tag-on-merge.yml` creates and pushes the `vx.y.z` tag
+   (using the release-bot App token, so the tag triggers Publish).
+3. **Publish** — the tag triggers the **Publish** workflow, which packages the
+   `.vsix`, creates the GitHub release, and publishes to the Marketplace
+   automatically. The `VSCE_PAT` is scoped to the `release` environment, so only
+   that job can read it.
+
+> If the auto-tag ever needs re-running by hand, `npm run release:tag` from the
+> merged `main` does the same thing.
 
 ## One-time GitHub setup (required for the gates)
 
@@ -37,11 +40,12 @@ These live in repo settings, not in code — set them once:
   resolution, and the `CI / Lint, type-check, build, test` + `CI / Changelog
 note` status checks; block direct pushes and force-pushes. CodeRabbit's
   `request_changes_workflow` (`.coderabbit.yaml`) then counts toward the gate.
-- **`release` environment** (Settings → Environments): add yourself / maintainers
-  as **required reviewers**, and store the **`VSCE_PAT`** secret (a VS Code
-  Marketplace PAT for the `JBramley` publisher) there — not as a repo-wide secret.
-  Optionally add `OVSX_PAT` for Open VSX and uncomment that step in
-  `publish.yml`.
+- **`release` environment** (Settings → Environments): store the **`VSCE_PAT`**
+  secret (a VS Code Marketplace PAT for the `JBramley` publisher) here as an
+  **environment secret** — not a repo-wide secret — so only the publish job can
+  read it. Leave it with **no required reviewers**: merging the release PR is the
+  publish approval, so a second environment gate would just re-ask. Optionally add
+  `OVSX_PAT` for Open VSX and uncomment that step in `publish.yml`.
 - **Release-bot GitHub App** (for the Prepare release PR): the default
   `GITHUB_TOKEN` cannot open a PR, and a PR it opened would not trigger the
   required CI checks. So `release.yml` mints a short-lived token from a GitHub


### PR DESCRIPTION
## Why

The release flow had a manual local step (`npm run release:tag`) after merging the release PR, plus a second `release`-environment reviewer gate — a redundant double-approval that undercut the point of CI automation.

## What changed

- **New `tag-on-merge.yml`**: when a `release/*` PR merges to `main`, CI creates and pushes the `vX.Y.Z` tag, which fires the existing tag-driven **Publish** workflow. The tag is pushed with the **release-bot App token** — a tag pushed by `GITHUB_TOKEN` would not trigger Publish (same recursion guard as PR creation). Token scoped to `contents: write` on this repo only. Guards against an already-existing tag; only fires on `merged == true` `release/*` PRs.
- **Merging is the publish approval.** Removed the `release` environment's required-reviewer rule (repo settings) so Publish runs automatically on the tag. The `v*` tag deploy policy is preserved.
- **Release PR body** now warns: merging publishes `vX.Y.Z` to the Marketplace.
- Updated `publish.yml` header, `docs/dev/releasing.md`, and `CLAUDE.md` to the new flow. `npm run release:tag` kept as a manual fallback.

## Resulting flow

1. Run **Prepare release** → opens the release PR
2. **Merge it** → auto-tags → Publish ships to the Marketplace (no second gate)

## Follow-up (not in this PR)

`VSCE_PAT` is currently a **repo** secret. With the reviewer gate gone, it should move to the `release` **environment** as an environment secret so only the publish job can read it. (Can't be done in code — secrets are write-only.)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified release and publishing process documentation, including how PR approval triggers automated version tagging and Marketplace publication.

* **Chores**
  * Automated version tagging for release PRs, streamlining the path from approval to publication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->