### PR TITLE
WIP: Fix workflow-vs-GraphQL AI steering regression

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -4,8 +4,18 @@
 # CodeRabbit's approval a merge gate: it requests changes while it has unresolved
 # comments and approves once they're resolved.
 reviews:
+    # "assertive" surfaces more findings — nitpicks, edge cases, and
+    # lower-confidence concerns — than the default "chill" profile.
+    profile: assertive
     request_changes_workflow: true
     poem: false
+    # Richer review output.
+    high_level_summary: true
+    sequence_diagrams: true
+    assess_linked_issues: true
+    related_issues: true
+    related_prs: true
+    suggested_labels: true
     auto_review:
         enabled: true
         drafts: false
@@ -31,6 +41,9 @@ reviews:
               over array.find/filter for repeated lookups, async I/O over sync, and
               early returns. Context-menu commands read the URI from args[0][0], not
               args[0]. Fire-and-forget persistence should not block user actions.
+              Review assertively: surface edge cases, error-handling gaps, race
+              conditions, and lower-confidence concerns rather than withholding them,
+              and do not suppress nitpicks.
         - path: 'src/ui/chat/**/*.ts'
           instructions: >-
               This is AI prompt-steering / vscode-tool protocol code. Keep wording
@@ -41,7 +54,11 @@ reviews:
               prompt-injection reflex. Prefer neutral framing: "Rewst Buddy VS Code
               Context", "local tool protocol", "VS Code approval/sandbox flow", and
               state that fenced vscode-tool JSON blocks are intercepted and executed by
-              the extension. Does not apply to *.test.ts.
+              the extension. Flag steering that contradicts another steering layer:
+              the engineering directive (engineeringDirective.ts) and the tool-protocol
+              block (toolProtocol.ts) must agree, and reuse turns ship only the
+              tool-protocol block, so it must be self-consistent on its own. Does not
+              apply to *.test.ts.
         - path: 'tsconfig.json'
           instructions: >-
               Path-alias changes (compilerOptions.paths) must be mirrored in
@@ -74,6 +91,21 @@ reviews:
     tools:
         # Run ESLint in review (the repo uses a flat eslint.config.mjs).
         eslint:
+            enabled: true
+        # Secret scanning — this extension handles Rewst cookies/tokens.
+        gitleaks:
+            enabled: true
+        # Lint Markdown in README, docs/, and changelog notes.
+        markdownlint:
+            enabled: true
+        # Lint YAML (this config, .vscode-test config, workflow yaml).
+        yamllint:
+            enabled: true
+        # Lint GitHub Actions workflows under .github/workflows.
+        actionlint:
+            enabled: true
+        # Static analysis for security and bug patterns.
+        semgrep:
             enabled: true
 
 # Let CodeRabbit treat CLAUDE.md and docs as authoritative project guidelines.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,6 +37,10 @@ For edit/write tools specifically (`insert_edit_into_file`, `replace_string_in_f
 
 Live regression coverage for this behavior lives in `src/test/integration/directive.test.ts` under `an explicit insert edit tool request is a vscode-tool block, not a native call`.
 
+When editing AI tool steering, keep all tool metadata surfaces in sync. Runtime specs such as `WORKFLOW_TOOL_SPECS` are mirrored into `package.json` `contributes.languageModelTools`; after changing a tool description or `inputSchema`, run `npm run test:grep -- "Unit: package manifest"` and fix any drift instead of leaving VS Code's contributed metadata stale.
+
+For `buddy_workflow_get` detail steering specifically, do **not** say or imply that `detail:"full"` is needed for ordinary workflow edit prep. The summary view is enough for understanding and most name-based `buddy_workflow_edit` operations because edits resolve tasks by name. Reserve `detail:"full"` only for cases that actually need task ids, transition ids, or canvas positions, such as repositioning or targeting one specific transition by id. Regression coverage for this wording lives in `src/ui/chat/tools/workflowTools.test.ts` under `buddy_workflow_get spec reserves full detail for ids and positions, not ordinary edits`.
+
 ## Directory Structure
 
 ```

--- a/changelog.d/workflow-steering.md
+++ b/changelog.d/workflow-steering.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Workflow AI steering** — keep workflow listing, reading, editing, running, and debugging on the dedicated workflow tools when GraphQL is also enabled.

--- a/changelog.d/workflow-steering.md
+++ b/changelog.d/workflow-steering.md
@@ -3,4 +3,4 @@ category: Fixed
 pr: 47
 ---
 
-- **Workflow AI steering** — keep workflow listing, reading, editing, running, and debugging on the dedicated workflow tools when GraphQL is also enabled.
+- **Workflow AI steering** — keep workflow listing, reading, editing, running, and debugging on the dedicated workflow tools when GraphQL is also enabled, and steer workflow reads to the concise summary view by default, reserving the full (ids/positions) view for when an edit is being prepared.

--- a/changelog.d/workflow-steering.md
+++ b/changelog.d/workflow-steering.md
@@ -3,4 +3,4 @@ category: Fixed
 pr: 47
 ---
 
-- **Workflow AI steering** — keep workflow listing, reading, editing, running, and debugging on the dedicated workflow tools when GraphQL is also enabled, and steer workflow reads to the concise summary view by default, reserving the full (ids/positions) view for when an edit is being prepared.
+- **Workflow AI steering** — keep workflow listing, reading, editing, running, and debugging on the dedicated workflow tools when GraphQL is also enabled, and steer workflow reads to the concise summary view by default, reserving the full (ids/positions) view for edits that specifically need task ids, transition ids, or canvas positions.

--- a/changelog.d/workflow-steering.md
+++ b/changelog.d/workflow-steering.md
@@ -1,5 +1,6 @@
 ---
 category: Fixed
+pr: 47
 ---
 
 - **Workflow AI steering** — keep workflow listing, reading, editing, running, and debugging on the dedicated workflow tools when GraphQL is also enabled.

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
 				"tags": [
 					"rewst"
 				],
-				"modelDescription": "Read a Rewst workflow as a normalized graph: nodes (tasks with their action ref and input) and edges (transitions with their condition, label, target task names, and published context variables). Returns far less noise than raw GraphQL and the node/edge names this tool uses are exactly what buddy_workflow_edit operations expect. By default (detail \"summary\") it returns a concise ANALYSIS view: task ids, transition ids, canvas x/y positions, and the version token are OMITTED and tasks/edges are referenced by name — ideal for understanding what a workflow does with far fewer tokens, and enough to edit (operations resolve tasks by name). Pass detail \"full\" only when you need those ids/positions, e.g. to reposition a task or target one specific transition by its id. Use this before editing a workflow.",
+				"modelDescription": "Read a Rewst workflow as a normalized graph: nodes (tasks with their action ref and input) and edges (transitions with their condition, label, target task names, and published context variables). Returns far less noise than raw GraphQL and the node/edge names this tool uses are exactly what buddy_workflow_edit operations expect. detail defaults to \"summary\": a concise ANALYSIS view that OMITS task ids, transition ids, canvas x/y positions, and the version token and refers to tasks/edges by name. Summary is sufficient for understanding, explaining, and most name-based edits (buddy_workflow_edit operations resolve tasks by name). Pass detail \"full\" only when you need task ids, transition ids, or canvas positions, such as repositioning a task or targeting one specific transition by id.",
 				"inputSchema": {
 					"type": "object",
 					"properties": {
@@ -99,7 +99,7 @@
 								"summary",
 								"full"
 							],
-							"description": "\"summary\" (default): concise analysis view, no ids/positions/version token. \"full\": adds task ids, transition ids, and canvas positions for repositioning or targeting a specific transition."
+							"description": "\"summary\" (default): concise analysis view for reading, understanding, and most name-based edits; no ids/positions/version token. \"full\": adds task ids, transition ids, and canvas positions — use only when you need task ids, transition ids, or canvas positions (repositioning a task or targeting a specific transition by id)."
 						}
 					},
 					"required": [

--- a/src/ui/chat/tools/toolProtocol.test.ts
+++ b/src/ui/chat/tools/toolProtocol.test.ts
@@ -172,6 +172,28 @@ suite('Unit: toolProtocol', () => {
 			assert.ok(/resend the whole graph so nothing is dropped/i.test(text));
 		});
 
+		test('keeps workflow requests on workflow tools when GraphQL is also available', () => {
+			const text = buildToolInstructions([
+				{ name: 'buddy_workflow_search', args: '{}', description: 'Search workflows.' },
+				{ name: 'buddy_workflow_get', args: '{}', description: 'Read a workflow.' },
+				{ name: 'buddy_workflow_edit', args: '{}', description: 'Edit a workflow.' },
+				{ name: 'buddy_action_search', args: '{}', description: 'Search actions.' },
+				{ name: 'buddy_graphql_schema', args: '{}', description: 'Inspect schema.' },
+				{ name: 'buddy_graphql', args: '{"query": string}', description: 'Run GraphQL.' },
+			]);
+
+			assert.ok(text.includes('buddy_workflow_search'), 'workflow search remains advertised');
+			assert.ok(
+				!/GraphQL tools take priority[^.]*workflows/i.test(text),
+				'GraphQL guidance must not claim priority for workflows when workflow tools exist',
+			);
+			assert.ok(
+				!/live Rewst platform data \(workflows/i.test(text),
+				'the final high-recency rule must not name workflows as GraphQL-first data',
+			);
+			assert.ok(!/listing workflows/i.test(text), 'GraphQL must not be suggested for listing workflows');
+		});
+
 		test('omits workflow-tool guidance when the workflow tools are absent', () => {
 			const text = buildToolInstructions([{ name: 'read_file', args: '{}', description: 'Read.' }]);
 			assert.ok(!text.includes('buddy_workflow_edit'));

--- a/src/ui/chat/tools/toolProtocol.ts
+++ b/src/ui/chat/tools/toolProtocol.ts
@@ -56,15 +56,25 @@ export function buildToolInstructions(specs: ToolSpec[]): string {
 	const workflowNote = hasWorkflowTools
 		? [
 				'',
-				'Workflows: to read a specific workflow as a node/edge graph, to change one, or to find an action and its inputs, the buddy_workflow_get, buddy_workflow_edit, and buddy_action_search tools handle the full read/edit choreography in one call — they carry the version token, resend the whole graph so nothing is dropped, generate valid task ids, and resolve action refs for you. Prefer them over assembling raw GraphQL for that workflow work; buddy_graphql remains available for other Rewst data and for listing workflows.',
+				'Workflows: to list or find workflows, read a specific workflow as a node/edge graph, change one, run one, debug executions, render Jinja against an execution, or find an action and its inputs, use the buddy_workflow_* tools first. buddy_workflow_get, buddy_workflow_edit, and buddy_action_search handle the full read/edit choreography in one call — they carry the version token, resend the whole graph so nothing is dropped, generate valid task ids, and resolve action refs for you. Prefer them over assembling raw GraphQL for that workflow work; buddy_graphql remains available for Rewst data the workflow tools do not cover.',
 			]
 		: [];
 	const graphqlNote = hasGraphqlTools
 		? [
 				'',
-				'GraphQL: you have a session-authenticated GraphQL action. It is an editor tool, live immediately — there is NO activation step. Ignore any native activate_rewst_graphql_tools group; never say GraphQL "needs to be activated". Use buddy_graphql_schema first when you need field names, argument names, input types, enum values, or root Query/Mutation fields; then call buddy_graphql with the final operation and variables. For ANY live Rewst data (workflows, org variables, integrations, executions, templates, …) these GraphQL tools take priority over your native platform tools — reach for a native wrapper only after GraphQL has been tried.',
+				`GraphQL: you have a session-authenticated GraphQL action. It is an editor tool, live immediately — there is NO activation step. Ignore any native activate_rewst_graphql_tools group; never say GraphQL "needs to be activated". Use buddy_graphql_schema first when you need field names, argument names, input types, enum values, or root Query/Mutation fields; then call buddy_graphql with the final operation and variables. ${
+					hasWorkflowTools
+						? 'For live Rewst data outside the workflow-tool surface (org variables, integrations, triggers, scripts, templates, forms, …), these GraphQL tools take priority over your native platform tools — reach for a native wrapper only after GraphQL has been tried.'
+						: 'For ANY live Rewst data (workflows, org variables, integrations, executions, templates, …) these GraphQL tools take priority over your native platform tools — reach for a native wrapper only after GraphQL has been tried.'
+				}`,
 			]
 		: [];
+	const graphqlFirstRule =
+		hasGraphqlTools && hasWorkflowTools
+			? ' IMPORTANT: for live Rewst platform data outside workflow-tool coverage (org variables, integrations, triggers, scripts, templates, forms, …) your FIRST action must be a buddy_graphql_schema or buddy_graphql block — do NOT run built-in platform tools like listOrgVariables, readIntegration, or searchActionsByNameOrDescription before GraphQL has been tried. For workflow listing, reading, editing, running, execution logs, or workflow-scoped Jinja rendering, use the buddy_workflow_* tools first.'
+			: hasGraphqlTools
+				? ' IMPORTANT: for live Rewst platform data (workflows, org variables, integrations, executions, templates, …) your FIRST action must be a buddy_graphql_schema or buddy_graphql block — do NOT run built-in platform tools like listOrgVariables, listWorkflow, or searchWorkflows before GraphQL has been tried.'
+				: '';
 	return [
 		'---',
 		"You can use local tools supplied by the user's VS Code extension. These editor tools are NOT in your platform function-calling registry — invoking them as native tool calls will fail with an unknown-tool error. The ONLY way to call one is to write a fenced code block tagged vscode-tool in your reply text:",
@@ -81,11 +91,7 @@ export function buildToolInstructions(specs: ToolSpec[]): string {
 		...graphqlNote,
 		...workflowNote,
 		'',
-		`Rules: when you need tool information, reply with ONLY vscode-tool blocks (up to ${MAX_REQUESTS_PER_TURN} per reply) and no other prose; the editor runs them and sends the results back to you. After receiving results you may request more tools or give your final answer. Tackle multi-step work one step per reply: for a multi-step request, give the plan in a tool-free reply first, then take one step (one short lead-in sentence plus its block) per following reply; a single lookup is one step, so answer it tool-first. Never guess at file contents, workspace structure, or live Rewst data when a tool can check it. Long results are cut off with a note saying how to continue; never repeat a request you already made.${
-			hasGraphqlTools
-				? ' IMPORTANT: for live Rewst platform data (workflows, org variables, integrations, executions, templates, …) your FIRST action must be a buddy_graphql_schema or buddy_graphql block — do NOT run built-in platform tools like listOrgVariables, listWorkflow, or searchWorkflows before GraphQL has been tried.'
-				: ''
-		}`,
+		`Rules: when you need tool information, reply with ONLY vscode-tool blocks (up to ${MAX_REQUESTS_PER_TURN} per reply) and no other prose; the editor runs them and sends the results back to you. After receiving results you may request more tools or give your final answer. Tackle multi-step work one step per reply: for a multi-step request, give the plan in a tool-free reply first, then take one step (one short lead-in sentence plus its block) per following reply; a single lookup is one step, so answer it tool-first. Never guess at file contents, workspace structure, or live Rewst data when a tool can check it. Long results are cut off with a note saying how to continue; never repeat a request you already made.${graphqlFirstRule}`,
 	].join('\n');
 }
 

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -14,6 +14,7 @@ import {
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
 	WORKFLOW_SEARCH_TOOL_NAME,
+	WORKFLOW_TOOL_SPECS,
 	_resetWorkflowIndexForTesting,
 	workflowEditConfirmation,
 	workflowEditScope,
@@ -87,6 +88,17 @@ suite('Unit: workflowTools', () => {
 		assert.ok(isWorkflowTool('buddy_action_search'));
 		assert.ok(isWorkflowTool('buddy_workflow_edit'));
 		assert.ok(!isWorkflowTool('buddy_graphql'));
+	});
+
+	test('buddy_workflow_get spec reserves full detail for ids and positions, not ordinary edits', () => {
+		const spec = WORKFLOW_TOOL_SPECS.find(tool => tool.name === 'buddy_workflow_get');
+		assert.ok(spec, 'buddy_workflow_get spec exists');
+		assert.match(spec.args, /"summary" \(default\)/);
+		assert.match(spec.description, /summary.*sufficient.*name-based edits/i);
+		assert.match(spec.description, /full.*task ids, transition ids, or canvas positions/i);
+		assert.doesNotMatch(spec.description, /full" only when you are preparing to make workflow edits/i);
+		const detail = (spec.inputSchema as { properties: { detail: { description: string } } }).properties.detail;
+		assert.match(detail.description, /full.*only when you need task ids, transition ids, or canvas positions/i);
 	});
 
 	suite('normalizePublish()', () => {

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -40,9 +40,9 @@ const MUTATION_SCOPE_KEYS = ['workflowId', 'workflowName', 'orgId', 'orgName'] a
 export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 	{
 		name: 'buddy_workflow_get',
-		args: '{"workflowId": string, "orgId": string, "detail"?: "summary" | "full"}',
+		args: '{"workflowId": string, "orgId": string, "detail"?: "summary" (default) | "full"}',
 		description:
-			'Read a Rewst workflow as a normalized graph: nodes (tasks with their action ref and input) and edges (transitions with their condition, label, target task names, and published context variables). Returns far less noise than raw GraphQL and the node/edge names this tool uses are exactly what buddy_workflow_edit operations expect. By default (detail "summary") it returns a concise ANALYSIS view: task ids, transition ids, canvas x/y positions, and the version token are OMITTED and tasks/edges are referenced by name — ideal for understanding what a workflow does with far fewer tokens, and enough to edit (operations resolve tasks by name). Pass detail "full" only when you need those ids/positions, e.g. to reposition a task or target one specific transition by its id. Use this before editing a workflow.',
+			'Read a Rewst workflow as a normalized graph: nodes (tasks with their action ref and input) and edges (transitions with their condition, label, target task names, and published context variables). Returns far less noise than raw GraphQL and the node/edge names this tool uses are exactly what buddy_workflow_edit operations expect. detail defaults to "summary": a concise ANALYSIS view that OMITS task ids, transition ids, canvas x/y positions, and the version token and refers to tasks/edges by name — ideal for understanding or explaining what a workflow does with far fewer tokens. Use the default "summary" whenever you are reading or analyzing a workflow. Pass detail "full" only when you are preparing to make workflow edits: it adds the task ids, transition ids, and canvas positions that editing needs to reposition a task or target a specific transition by its id.',
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -52,7 +52,7 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 					type: 'string',
 					enum: ['summary', 'full'],
 					description:
-						'"summary" (default): concise analysis view, no ids/positions/version token. "full": adds task ids, transition ids, and canvas positions for repositioning or targeting a specific transition.',
+						'"summary" (default): concise analysis view for reading or understanding a workflow, no ids/positions/version token. "full": adds task ids, transition ids, and canvas positions — use only when preparing to make workflow edits (repositioning a task or targeting a specific transition by id).',
 				},
 			},
 			required: ['workflowId', 'orgId'],

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -42,7 +42,7 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 		name: 'buddy_workflow_get',
 		args: '{"workflowId": string, "orgId": string, "detail"?: "summary" (default) | "full"}',
 		description:
-			'Read a Rewst workflow as a normalized graph: nodes (tasks with their action ref and input) and edges (transitions with their condition, label, target task names, and published context variables). Returns far less noise than raw GraphQL and the node/edge names this tool uses are exactly what buddy_workflow_edit operations expect. detail defaults to "summary": a concise ANALYSIS view that OMITS task ids, transition ids, canvas x/y positions, and the version token and refers to tasks/edges by name — ideal for understanding or explaining what a workflow does with far fewer tokens. Use the default "summary" whenever you are reading or analyzing a workflow. Pass detail "full" only when you are preparing to make workflow edits: it adds the task ids, transition ids, and canvas positions that editing needs to reposition a task or target a specific transition by its id.',
+			'Read a Rewst workflow as a normalized graph: nodes (tasks with their action ref and input) and edges (transitions with their condition, label, target task names, and published context variables). Returns far less noise than raw GraphQL and the node/edge names this tool uses are exactly what buddy_workflow_edit operations expect. detail defaults to "summary": a concise ANALYSIS view that OMITS task ids, transition ids, canvas x/y positions, and the version token and refers to tasks/edges by name. Summary is sufficient for understanding, explaining, and most name-based edits (buddy_workflow_edit operations resolve tasks by name). Pass detail "full" only when you need task ids, transition ids, or canvas positions, such as repositioning a task or targeting one specific transition by id.',
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -52,7 +52,7 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 					type: 'string',
 					enum: ['summary', 'full'],
 					description:
-						'"summary" (default): concise analysis view for reading or understanding a workflow, no ids/positions/version token. "full": adds task ids, transition ids, and canvas positions — use only when preparing to make workflow edits (repositioning a task or targeting a specific transition by id).',
+						'"summary" (default): concise analysis view for reading, understanding, and most name-based edits; no ids/positions/version token. "full": adds task ids, transition ids, and canvas positions — use only when you need task ids, transition ids, or canvas positions (repositioning a task or targeting a specific transition by id).',
 				},
 			},
 			required: ['workflowId', 'orgId'],


### PR DESCRIPTION
## Summary

The v0.44.0 workflow-tool migration updated the engineering directive to route workflow work to the `buddy_workflow_*` tools first, but left `buildToolInstructions` (the vscode-tool protocol block in `toolProtocol.ts`) still steering workflows to **GraphQL-first** — in both the GraphQL note and the high-recency final `IMPORTANT` rule. The two steering layers contradicted each other on workflows, so the agent chose inconsistently between workflow tools and raw GraphQL.

This is **amplified on conversation-reuse turns**: `RoboRewstyChatModelProvider.buildReuseMessage` ships the tool-protocol block but **omits** the engineering directive (only `buildStatelessMessage` prepends it). So on continuation turns the contradictory protocol block was the *only* steering present.

## Changes

- Scope the GraphQL-first guidance **and** the final `IMPORTANT` rule to non-workflow data when the workflow tools are present.
- Keep workflow listing / reading / editing / running / debugging on the `buddy_workflow_*` tools.
- Preserve the original wording when the workflow tools are **absent** (they are opt-in via `rewst-buddy.ai.tools`), where GraphQL legitimately handles workflows.
- Added a `toolProtocol.test.ts` regression case asserting the protocol block no longer names workflows as GraphQL-first when workflow tools are available.

## Verification

- `npm run test:grep -- "Unit: toolProtocol"` — 22 passing
- `npm run test:unit` — 447 passing
- `npm run lint` / `tsc --noEmit` — clean
- `npm run changelog:check -- --base main` — OK
- Live: `npm run test:grep:integration -- "workflow listing routes to the workflow search tool"` — agent requests `buddy_workflow_search` first (not GraphQL/native) ✅

## Note

Changelog note is `changelog.d/workflow-steering.md` (no `pr:` link yet) — will add the PR-number link in a follow-up push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved AI assistant workflow steering so workflow listing/reading/editing/running/debugging stays on dedicated workflow tools when available, with clearer GraphQL fallback behavior.
  * Refined workflow read detail: defaults to a concise summary view; “full” (IDs and canvas positions) is intended for edit preparation only.
* **Tests**
  * Added unit coverage to verify correct guidance when workflow and GraphQL tools coexist.
* **Documentation**
  * Updated user-facing tool descriptions and added a changelog entry for the corrected workflow steering behavior.
  * Updated editing guidance to prevent tool-spec drift.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->