### PR TITLE
MCP GraphQL primitives: schema introspect / query (read) / mutate (write)

### DIFF
--- a/changelog.d/mcp-graphql-primitives.md
+++ b/changelog.d/mcp-graphql-primitives.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP GraphQL primitives (experimental)** — the MCP server now exposes the three GraphQL-wrapping tools the rest of the feature is built on. Schema introspection (`buddy_graphql_schema`) and read-only queries (`rewst_graphql_query`) are available to external MCP clients when GraphQL tools are enabled, and a dedicated write tool (`rewst_graphql_mutate`) runs mutations behind a clean read/write split: it requires `rewst-buddy.mcp.enableWriteTools` and a per-resource approval prompt **inside VS Code** before any change is sent — an external client can never approve its own write. Until you approve, the mutation is not run and the tool returns a clear `approval_required` result.

--- a/changelog.d/mcp-graphql-primitives.md
+++ b/changelog.d/mcp-graphql-primitives.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 60
 ---
 
 - **MCP GraphQL primitives (experimental)** — the MCP server now exposes the three GraphQL-wrapping tools the rest of the feature is built on. Schema introspection (`buddy_graphql_schema`) and read-only queries (`rewst_graphql_query`) are available to external MCP clients when GraphQL tools are enabled, and a dedicated write tool (`rewst_graphql_mutate`) runs mutations behind a clean read/write split: it requires `rewst-buddy.mcp.enableWriteTools` and a per-resource approval prompt **inside VS Code** before any change is sent — an external client can never approve its own write. Until you approve, the mutation is not run and the tool returns a clear `approval_required` result.

--- a/src/capabilities/graphqlCapabilities.ts
+++ b/src/capabilities/graphqlCapabilities.ts
@@ -9,10 +9,9 @@ import type { Capability } from './Capability';
  * surface keeps offering the identical two tools.
  *
  * Execution wraps runGraphqlTool with deps bound to the resolved session, the
- * same path the chat tools use. buddy_graphql_schema is read-only; buddy_graphql
- * is marked write because it can carry a mutation — the MCP server boundary
- * rejects writes unless write tools are enabled. A read-only GraphQL query
- * capability for MCP is added separately in a later phase.
+ * same path the chat tools use. buddy_graphql_schema is read-only and can also
+ * be exposed over MCP; buddy_graphql stays chat-only because it can carry both
+ * reads and writes. MCP gets separate read and mutation primitives.
  */
 
 function specByName(name: string): ToolSpec {
@@ -25,7 +24,8 @@ export const graphqlSchemaCapability: Capability = {
 	spec: specByName('buddy_graphql_schema'),
 	access: 'read',
 	chat: true,
-	mcp: false,
+	mcp: true,
+	requiresOrg: false,
 	enabled: settings => settings.enableGraphqlTool,
 	run: (input, ctx) => runGraphqlTool({ tool: 'buddy_graphql_schema', args: input }, createGraphqlDeps(ctx.session)),
 };

--- a/src/capabilities/graphqlMutateCapability.ts
+++ b/src/capabilities/graphqlMutateCapability.ts
@@ -1,0 +1,118 @@
+import {
+	approveMutationScope,
+	detectOperationType,
+	isMutationScopeApproved,
+	runMutationGraphql,
+	type MutationScope,
+} from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+
+export type McpMutationApprover = (scope: MutationScope, operation: string) => Promise<boolean>;
+
+let approver: McpMutationApprover = async () => false;
+
+export function setMcpMutationApprover(fn: McpMutationApprover): void {
+	approver = fn;
+}
+
+export function _resetMcpMutationApproverForTesting(): void {
+	approver = async () => false;
+}
+
+const graphqlMutateSpec: ToolSpec = {
+	name: 'rewst_graphql_mutate',
+	args: '{"orgId": string, "query": string, "variables"?: object, "scopeId": string, "scopeName": string, "orgName"?: string}',
+	description:
+		"Run a GraphQL mutation against one Rewst organization with the user's session. Write tools must be enabled. The request includes the mutation document, optional variables, and the Rewst resource scope that VS Code uses for approval.",
+	inputSchema: {
+		type: 'object',
+		properties: {
+			orgId: { type: 'string', description: 'Rewst organization id the mutation runs against.' },
+			query: { type: 'string', description: 'GraphQL mutation document.' },
+			variables: { type: 'object', description: 'Optional GraphQL variables.' },
+			scopeId: { type: 'string', description: 'Stable id of the Rewst resource being changed.' },
+			scopeName: { type: 'string', description: 'Human-readable name of the Rewst resource being changed.' },
+			orgName: { type: 'string', description: 'Human-readable name of the Rewst organization.' },
+		},
+		required: ['orgId', 'query', 'scopeId', 'scopeName'],
+	},
+};
+
+function requireTrimmedString(input: Record<string, unknown>, key: string): string {
+	const value = input[key];
+	if (typeof value !== 'string' || value.trim().length === 0) {
+		throw new Error(`Missing required string argument "${key}".`);
+	}
+	return value.trim();
+}
+
+function optionalTrimmedString(input: Record<string, unknown>, key: string): string | undefined {
+	const value = input[key];
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	if (typeof value !== 'object' || value === null || Array.isArray(value)) return false;
+	const prototype = Object.getPrototypeOf(value);
+	return prototype === Object.prototype || prototype === null;
+}
+
+function parseVariables(input: Record<string, unknown>, ctx: CapabilityContext): Record<string, unknown> | undefined {
+	const rawVariables = input.variables;
+	if (rawVariables === undefined) return undefined;
+	if (!isPlainObject(rawVariables)) {
+		throw new Error('"variables" must be a JSON object when provided.');
+	}
+	if (rawVariables.orgId !== undefined && rawVariables.orgId !== ctx.orgId) {
+		throw new Error('"variables.orgId" must match the requested "orgId".');
+	}
+	return rawVariables;
+}
+
+function formatOperationSummary(query: string, variables: Record<string, unknown> | undefined): string {
+	const operation = query.trim();
+	if (variables === undefined) return operation;
+	return `${operation}\n\nVariables:\n${JSON.stringify(variables, null, 2)}`;
+}
+
+async function runGraphqlMutate(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const query = requireTrimmedString(input, 'query');
+	const kind = detectOperationType(query);
+	if (kind === 'subscription') {
+		throw new Error('subscriptions are not supported; use a query or mutation');
+	}
+	if (kind === 'query') {
+		throw new Error('This tool runs mutations only; use rewst_graphql_query for read-only queries.');
+	}
+
+	const scopeId = requireTrimmedString(input, 'scopeId');
+	const scopeName = requireTrimmedString(input, 'scopeName');
+	const orgName = optionalTrimmedString(input, 'orgName') ?? ctx.session.profile.org.name;
+	const scope: MutationScope = { scopeId, scopeName, orgId: ctx.orgId, orgName };
+	const variables = parseVariables(input, ctx);
+	const operation = formatOperationSummary(query, variables);
+
+	if (!isMutationScopeApproved(scope)) {
+		if (!(await approver(scope, operation))) {
+			return JSON.stringify({
+				status: 'approval_required',
+				message:
+					'The mutation was not run. The user must approve it in VS Code (a modal appears in their editor); retry after they approve.',
+			});
+		}
+		approveMutationScope(scope);
+	}
+
+	return runMutationGraphql(query, variables, (q, v) => ctx.session.rawGraphql(q, v));
+}
+
+export const graphqlMutateCapability: Capability = {
+	spec: graphqlMutateSpec,
+	access: 'write',
+	chat: false,
+	mcp: true,
+	requiresOrg: true,
+	enabled: settings => settings.enableGraphqlTool,
+	run: runGraphqlMutate,
+};

--- a/src/capabilities/graphqlMutateCapability.ts
+++ b/src/capabilities/graphqlMutateCapability.ts
@@ -80,7 +80,7 @@ async function runGraphqlMutate(input: Record<string, unknown>, ctx: CapabilityC
 	const query = requireTrimmedString(input, 'query');
 	const kind = detectOperationType(query);
 	if (kind === 'subscription') {
-		throw new Error('subscriptions are not supported; use a query or mutation');
+		throw new Error('Subscriptions are not supported; this tool runs mutations only.');
 	}
 	if (kind === 'query') {
 		throw new Error('This tool runs mutations only; use rewst_graphql_query for read-only queries.');

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -6,3 +6,9 @@ export {
 	getCapability,
 	mcpCapabilities,
 } from './registry';
+export {
+	_resetMcpMutationApproverForTesting,
+	graphqlMutateCapability,
+	setMcpMutationApprover,
+	type McpMutationApprover,
+} from './graphqlMutateCapability';

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -73,7 +73,7 @@ suite('Unit: capability registry', () => {
 	});
 
 	suite('mcp surface', () => {
-		test('read tools are exposed to MCP and are all read access', () => {
+		test('read tools and the dedicated mutation tool are exposed to MCP', () => {
 			const names = mcpCapabilities().map(capability => capability.spec.name);
 			for (const expected of [
 				'list_orgs',
@@ -82,18 +82,19 @@ suite('Unit: capability registry', () => {
 				'list_workflows',
 				'get_workflow',
 				'rewst_graphql_query',
+				'buddy_graphql_schema',
+				'rewst_graphql_mutate',
 			]) {
 				assert.ok(names.includes(expected), `${expected} exposed to MCP`);
 			}
-			for (const capability of mcpCapabilities()) {
-				assert.strictEqual(capability.access, 'read', `${capability.spec.name} is read-only`);
-			}
+			assert.strictEqual(getCapability('rewst_graphql_mutate')?.access, 'write');
+			assert.ok(!names.includes('buddy_graphql'), 'combined chat write tool stays off MCP');
 		});
 
-		test('the GraphQL chat tools are not exposed to MCP (writes stay in the chat surface)', () => {
+		test('buddy_graphql_schema is also exposed to MCP, but buddy_graphql is not', () => {
 			const names = mcpCapabilities().map(capability => capability.spec.name);
 			assert.ok(!names.includes('buddy_graphql'));
-			assert.ok(!names.includes('buddy_graphql_schema'));
+			assert.ok(names.includes('buddy_graphql_schema'));
 		});
 
 		test('list_orgs does not require an org', () => {
@@ -102,14 +103,24 @@ suite('Unit: capability registry', () => {
 			assert.strictEqual(listOrgs.requiresOrg, false);
 		});
 
-		test('rewst_graphql_query is gated by enableGraphqlTool; structured reads are not', () => {
+		test('buddy_graphql_schema does not require an org', () => {
+			const schema = getCapability('buddy_graphql_schema');
+			assert.ok(schema);
+			assert.strictEqual(schema.requiresOrg, false);
+		});
+
+		test('raw GraphQL MCP tools are gated by enableGraphqlTool; structured reads are not', () => {
 			const off = enabledMcpCapabilities(settings()).map(capability => capability.spec.name);
 			assert.ok(!off.includes('rewst_graphql_query'), 'raw query off by default');
+			assert.ok(!off.includes('buddy_graphql_schema'), 'schema off by default');
+			assert.ok(!off.includes('rewst_graphql_mutate'), 'mutation off by default');
 			assert.ok(off.includes('list_templates'), 'structured reads always available');
 			const on = enabledMcpCapabilities(settings({ enableGraphqlTool: true })).map(
 				capability => capability.spec.name,
 			);
 			assert.ok(on.includes('rewst_graphql_query'), 'raw query available when graphql enabled');
+			assert.ok(on.includes('buddy_graphql_schema'), 'schema available when graphql enabled');
+			assert.ok(on.includes('rewst_graphql_mutate'), 'mutation available when graphql enabled');
 		});
 	});
 });

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -1,5 +1,6 @@
 import type { Capability, CapabilitySettings } from './Capability';
 import { GRAPHQL_CAPABILITIES } from './graphqlCapabilities';
+import { graphqlMutateCapability } from './graphqlMutateCapability';
 import { READ_CAPABILITIES } from './rewstReadCapabilities';
 
 /**
@@ -7,7 +8,11 @@ import { READ_CAPABILITIES } from './rewstReadCapabilities';
  * this list by their own gates; adding a capability here surfaces it everywhere
  * it opts into. Names must be unique across the registry.
  */
-export const CAPABILITY_REGISTRY: Capability[] = [...GRAPHQL_CAPABILITIES, ...READ_CAPABILITIES];
+export const CAPABILITY_REGISTRY: Capability[] = [
+	...GRAPHQL_CAPABILITIES,
+	...READ_CAPABILITIES,
+	graphqlMutateCapability,
+];
 
 const BY_NAME = new Map(CAPABILITY_REGISTRY.map(capability => [capability.spec.name, capability]));
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,5 @@
 import { CommandInitiater } from '@commands';
+import { setMcpMutationApprover } from '@capabilities';
 import { extPrefix, context as globalVSContext } from '@global';
 import { McpDefinitionProvider, McpServerController } from '@mcp';
 import { LinkManager, SyncManager, SyncOnSaveManager, TemplateBundleManager, TemplateMetadataStore } from '@models';
@@ -25,6 +26,14 @@ export async function activate(context: vscode.ExtensionContext) {
 	log.init();
 
 	log.info(`Starting activation of extension ${extPrefix}`);
+	setMcpMutationApprover(async (scope, operation) => {
+		const choice = await vscode.window.showWarningMessage(
+			`An external MCP client wants to run a mutation against ${scope.scopeName} (${scope.scopeId}) in org ${scope.orgName} (${scope.orgId}).`,
+			{ modal: true, detail: operation },
+			'Approve',
+		);
+		return choice === 'Approve';
+	});
 
 	// Register TreeDataProvider (self-registers for session change events)
 	const sessionTreeProvider = new SessionTreeDataProvider();

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -247,7 +247,7 @@ suite('Unit: McpActions', () => {
 				settings({ enableWriteTools: true }),
 			);
 			assert.strictEqual(result.isError, true);
-			assert.ok(result.text.includes('subscriptions are not supported'));
+			assert.ok(result.text.includes('Subscriptions are not supported'));
 		});
 
 		test('rewst_graphql_mutate returns approval_required without executing when the user declines', async () => {

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -1,7 +1,10 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { SessionManager } from '@sessions';
+import { SessionManager, type Session } from '@sessions';
 import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import vscode from 'vscode';
+import { _resetMcpMutationApproverForTesting, setMcpMutationApprover } from '../capabilities/graphqlMutateCapability';
+import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import { McpError, _resetMcpThrottleForTesting, callTool, listResources, listTools, readResource } from './McpActions';
 import type { McpSettings } from './settings';
 
@@ -11,6 +14,10 @@ function settings(over: Partial<McpSettings> = {}): McpSettings {
 	return { enable: true, enableWriteTools: false, enabledTools: [], ...over };
 }
 
+async function setAiTools(tools: string[]): Promise<void> {
+	await vscode.workspace.getConfiguration('rewst-buddy.ai').update('tools', tools, vscode.ConfigurationTarget.Global);
+}
+
 /** A mock session managing one org, registered with the SessionManager. */
 function useSession(orgId = 'org-1', orgName = 'Acme') {
 	const { session, wrapper } = createMockSession({ profile: { org: { id: orgId, name: orgName } } });
@@ -18,15 +25,36 @@ function useSession(orgId = 'org-1', orgName = 'Acme') {
 	return { session, wrapper };
 }
 
+function useRawGraphqlWrapper(session: Session, wrapper: ReturnType<typeof createMockSession>['wrapper']): void {
+	const wrap = wrapper.getWrapper();
+	(session as { rawGraphql: Session['rawGraphql'] }).rawGraphql = async (query, variables) => {
+		return wrap(async () => ({ data: undefined, errors: undefined }), 'rawGraphql', detectGraphqlOperation(query), {
+			query,
+			variables,
+		});
+	};
+}
+
+function detectGraphqlOperation(query: string): string {
+	const match = /\b(query|mutation|subscription)\s+([A-Za-z_][A-Za-z0-9_]*)/.exec(query);
+	return match ? `${match[1]} ${match[2]}` : 'rawGraphql';
+}
+
 suite('Unit: McpActions', () => {
-	setup(() => {
+	setup(async () => {
 		initTestEnvironment();
 		SessionManager._resetForTesting();
 		_resetMcpThrottleForTesting();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		await setAiTools(['workspace', 'graphql']);
 	});
 
-	teardown(() => {
+	teardown(async () => {
 		SessionManager._resetForTesting();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		await setAiTools(['workspace']);
 	});
 
 	suite('listTools()', () => {
@@ -38,7 +66,7 @@ suite('Unit: McpActions', () => {
 			assert.ok(names.includes('list_workflows'));
 			assert.ok(names.includes('get_workflow'));
 			assert.ok(!names.includes('buddy_graphql'), 'chat write tool is not on MCP');
-			assert.ok(!names.includes('buddy_graphql_schema'), 'chat schema tool is not on MCP');
+			assert.ok(names.includes('buddy_graphql_schema'), 'schema introspection is available on MCP');
 		});
 
 		test('an allowlist restricts the exposed tools', () => {
@@ -81,6 +109,36 @@ suite('Unit: McpActions', () => {
 			);
 		});
 
+		test('buddy_graphql_schema is callable over MCP and returns a schema view', async () => {
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', {
+				data: {
+					data: {
+						__schema: {
+							queryType: {
+								name: 'Query',
+								fields: [{ name: 'workflow', args: [], type: { name: 'Workflow' } }],
+							},
+							mutationType: {
+								name: 'Mutation',
+								fields: [{ name: 'updateWorkflow', args: [], type: { name: 'Workflow' } }],
+							},
+						},
+					},
+				},
+			});
+
+			const result = await callTool({ name: 'buddy_graphql_schema', arguments: {} }, settings());
+
+			assert.ok(!result.isError);
+			assert.ok(result.text.includes('## Query (Query)'));
+			assert.ok(result.text.includes('workflow: Workflow'));
+			const calls = wrapper.getCallsFor('rawGraphql');
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0].variables.variables, { includeDeprecated: false });
+		});
+
 		test('an org-scoped tool without orgId throws org_required', async () => {
 			useSession('org-1');
 			await assert.rejects(
@@ -114,17 +172,140 @@ suite('Unit: McpActions', () => {
 			assert.strictEqual(result.isError, true);
 		});
 
-		test('a write tool is rejected while write tools are disabled', async () => {
+		test('rewst_graphql_mutate is rejected while write tools are disabled', async () => {
 			useSession('org-1');
 			await assert.rejects(
 				callTool(
-					{ name: 'buddy_graphql', arguments: { orgId: 'org-1' } },
+					{
+						name: 'rewst_graphql_mutate',
+						arguments: {
+							orgId: 'org-1',
+							query: 'mutation UpdateThing { updateThing { id } }',
+							scopeId: 'wf-1',
+							scopeName: 'Workflow',
+						},
+					},
+					settings({ enableWriteTools: false }),
+				),
+				(error: unknown) => error instanceof McpError && error.code === 'write_disabled',
+			);
+		});
+
+		test('rewst_graphql_mutate is hidden and rejected when GraphQL tools are off', async () => {
+			useSession('org-1');
+			await setAiTools(['workspace']);
+
+			const names = listTools(settings({ enableWriteTools: true })).map(tool => tool.name);
+			assert.ok(!names.includes('rewst_graphql_mutate'));
+			await assert.rejects(
+				callTool(
+					{
+						name: 'rewst_graphql_mutate',
+						arguments: {
+							orgId: 'org-1',
+							query: 'mutation UpdateThing { updateThing { id } }',
+							scopeId: 'wf-1',
+							scopeName: 'Workflow',
+						},
+					},
 					settings({ enableWriteTools: true }),
 				),
-				// buddy_graphql is chat-only (mcp:false), so it stays unknown_tool even
-				// with writes enabled — there is no MCP write tool in the foundation yet.
 				(error: unknown) => error instanceof McpError && error.code === 'unknown_tool',
 			);
+		});
+
+		test('rewst_graphql_mutate returns an error result for query documents', async () => {
+			useSession('org-1');
+			const result = await callTool(
+				{
+					name: 'rewst_graphql_mutate',
+					arguments: {
+						orgId: 'org-1',
+						query: 'query ReadThing { thing { id } }',
+						scopeId: 'wf-1',
+						scopeName: 'Workflow',
+					},
+				},
+				settings({ enableWriteTools: true }),
+			);
+			assert.strictEqual(result.isError, true);
+			assert.ok(result.text.includes('use rewst_graphql_query'));
+		});
+
+		test('rewst_graphql_mutate returns an error result for subscriptions', async () => {
+			useSession('org-1');
+			const result = await callTool(
+				{
+					name: 'rewst_graphql_mutate',
+					arguments: {
+						orgId: 'org-1',
+						query: 'subscription WatchThing { thingChanged { id } }',
+						scopeId: 'wf-1',
+						scopeName: 'Workflow',
+					},
+				},
+				settings({ enableWriteTools: true }),
+			);
+			assert.strictEqual(result.isError, true);
+			assert.ok(result.text.includes('subscriptions are not supported'));
+		});
+
+		test('rewst_graphql_mutate returns approval_required without executing when the user declines', async () => {
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			setMcpMutationApprover(async () => false);
+
+			const result = await callTool(
+				{
+					name: 'rewst_graphql_mutate',
+					arguments: {
+						orgId: 'org-1',
+						query: 'mutation UpdateThing { updateThing { id } }',
+						scopeId: 'wf-1',
+						scopeName: 'Workflow',
+					},
+				},
+				settings({ enableWriteTools: true }),
+			);
+
+			assert.ok(!result.isError);
+			assert.strictEqual(JSON.parse(result.text).status, 'approval_required');
+			assert.strictEqual(wrapper.getCallsFor('rawGraphql').length, 0);
+		});
+
+		test('rewst_graphql_mutate executes after approval and remembers the same scope', async () => {
+			const { session, wrapper } = useSession('org-1', 'Acme Org');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', { data: { data: { updateThing: { id: 'wf-1' } } } });
+			let approvals = 0;
+			setMcpMutationApprover(async () => {
+				approvals++;
+				return true;
+			});
+			const args = {
+				orgId: 'org-1',
+				query: 'mutation UpdateThing($name: String!) { updateThing(name: $name) { id } }',
+				variables: { name: 'Renamed' },
+				scopeId: 'wf-1',
+				scopeName: 'Workflow',
+			};
+
+			const first = await callTool(
+				{ name: 'rewst_graphql_mutate', arguments: args },
+				settings({ enableWriteTools: true }),
+			);
+			const second = await callTool(
+				{ name: 'rewst_graphql_mutate', arguments: args },
+				settings({ enableWriteTools: true }),
+			);
+
+			assert.ok(!first.isError);
+			assert.ok(first.text.includes('"updateThing"'));
+			assert.ok(!second.isError);
+			const calls = wrapper.getCallsFor('rawGraphql');
+			assert.strictEqual(calls.length, 2);
+			assert.strictEqual(approvals, 1);
+			assert.deepStrictEqual(calls[0].variables.variables, { name: 'Renamed' });
 		});
 
 		test('exceeding the call rate throws rate_limited', async () => {

--- a/src/ui/chat/tools/graphqlTool.ts
+++ b/src/ui/chat/tools/graphqlTool.ts
@@ -577,6 +577,26 @@ export async function runReadonlyGraphql(
 	return formatResult(await execute(query, variables));
 }
 
+/**
+ * Runs a GraphQL mutation and formats the result the same way as the chat tool.
+ * Used by the MCP mutation capability after the MCP boundary and VS Code modal
+ * have allowed the write.
+ */
+export async function runMutationGraphql(
+	query: string,
+	variables: Record<string, unknown> | undefined,
+	execute: (q: string, v?: Record<string, unknown>) => Promise<{ data?: unknown; errors?: unknown }>,
+): Promise<string> {
+	if (typeof query !== 'string' || query.trim().length === 0) {
+		throw new Error('A non-empty GraphQL "query" is required.');
+	}
+	const kind = detectOperationType(query);
+	if (kind !== 'mutation') {
+		throw new Error(`This tool runs mutations only; received a ${kind}. Use a mutation operation.`);
+	}
+	return formatResult(await execute(query, variables));
+}
+
 export async function runGraphqlTool(request: ToolRequest, deps: GraphqlToolDeps | undefined): Promise<string> {
 	if (!deps || !deps.isEnabled()) {
 		throw new Error(


### PR DESCRIPTION
## Summary

Exposes the three GraphQL-wrapping primitives over the MCP server — the "start simple" surface the whole MCP feature is built around. Builds on the foundation (#53 / #58).

- **Schema introspect** — `buddy_graphql_schema` is flipped onto the MCP surface as a read capability. The GraphQL schema is org-independent, so it requires no `orgId` (`requiresOrg: false`).
- **Query (read)** — `rewst_graphql_query` already shipped with the foundation; left unchanged.
- **Mutate (write)** — new dedicated MCP tool `rewst_graphql_mutate`, kept separate from the combined chat `buddy_graphql` tool for a clean read/write boundary. Gated by `rewst-buddy.mcp.enableWriteTools` at the server boundary **and** per-resource approval **inside VS Code**: an injectable, fail-closed approver seam is wired to a `showWarningMessage` modal at activation. An unapproved mutation is never sent — it returns a structured `approval_required` result the agent can read. Reuses the existing `MutationScope` / `isMutationScopeApproved` / `approveMutationScope` machinery, so approving one change to a resource lets further changes to that same resource run for the session.
- Adds a shared `runMutationGraphql` helper mirroring `runReadonlyGraphql` so result formatting matches the read/chat path.

The combined `buddy_graphql` chat tool stays chat-only (`mcp: false`) per the issue's "separate tools" decision.

## Testing

- `npm run test:unit` — full suite green (554 passing).
- `Unit: McpActions` — 23 passing (schema-over-MCP, write gating, GraphQL-off gating, query/subscription rejection, approval-required-without-executing, approved + memoized scope).
- `Unit: capability registry` — 11 passing (mutate exposure, schema-on-MCP, `requiresOrg`).
- `Unit: package manifest` — 5 passing, no drift (the MCP-only mutate spec is `chat:false`, so it is correctly not mirrored into `package.json` `languageModelTools`).
- ESLint + `tsc --noEmit` clean.

Closes #54.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enabled experimental MCP GraphQL primitives, allowing external MCP clients to introspect the GraphQL schema and run read-only queries when GraphQL tools are enabled.
  * Added a dedicated GraphQL mutation tool that enforces a strict read/write split and requires explicit VS Code approval before any write operation.
* **Documentation**
  * Updated capability docs and added changelog entry describing the new experimental GraphQL primitives and approval workflow.
* **Tests**
  * Expanded MCP action and exposure tests to cover schema/query access and full mutation approval/error behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->