### PR TITLE
Decouple steering from tool churn: converge chat onto the capability registry (#55)

### DIFF
--- a/changelog.d/61.md
+++ b/changelog.d/61.md
@@ -1,0 +1,6 @@
+---
+category: Changed
+pr: 61
+---
+
+- **MCP server (internal): chat tools converge onto the capability registry** — the Cage-Free Rewsty chat tools (workflow, web, workspace, GraphQL, result-reader) are now defined once in the shared capability registry instead of in separate spec arrays, and the chat steering detects tool families from that registry rather than from hardcoded tool-name lists. No change to the tools you see or how the assistant behaves; this is the steering-stability groundwork that lets the MCP surface grow without the chat prompt churning every time a tool is added or removed.

--- a/src/capabilities/Capability.ts
+++ b/src/capabilities/Capability.ts
@@ -13,6 +13,7 @@ import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
  */
 
 export type CapabilityAccess = 'read' | 'write';
+export type CapabilityGroup = 'workflow' | 'graphql' | 'web' | 'workspace' | 'result';
 
 /**
  * Settings that gate whether a capability is offered at all, independent of
@@ -40,6 +41,8 @@ export interface CapabilityContext {
 
 export interface Capability {
 	spec: ToolSpec;
+	/** Tool family used by steering and category-level capability lookups. */
+	group?: CapabilityGroup;
 	/**
 	 * Whether the capability can change Rewst state. The MCP server boundary
 	 * rejects access:'write' unless write tools are explicitly enabled, regardless

--- a/src/capabilities/Capability.ts
+++ b/src/capabilities/Capability.ts
@@ -15,13 +15,15 @@ import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 export type CapabilityAccess = 'read' | 'write';
 
 /**
- * Settings that gate whether a capability is offered at all, independent of any
- * surface. The MCP surface layers its own gates on top (master switch, write
- * toggle, allowlist); this is the capability's intrinsic feature gate, mirroring
- * the rewst-buddy.ai.* switches the chat tools already honor.
+ * Settings that gate whether a capability is offered at all, independent of
+ * any surface. Each field mirrors one rewst-buddy.ai.tools category. The MCP
+ * surface layers its own gates on top (master switch, write toggle, allowlist).
  */
 export interface CapabilitySettings {
 	enableGraphqlTool: boolean;
+	enableWorkflowTools: boolean;
+	enableWebTools: boolean;
+	enableWorkspaceTools: boolean;
 }
 
 /**

--- a/src/capabilities/chatToolCapabilities.ts
+++ b/src/capabilities/chatToolCapabilities.ts
@@ -11,7 +11,13 @@ import {
 	WORKFLOW_TOOL_SPECS,
 } from '../ui/chat/tools/workflowTools';
 import { runToolRequests, WORKSPACE_TOOL_SPECS } from '../ui/chat/tools/workspaceTools';
-import type { Capability, CapabilityAccess, CapabilityContext, CapabilitySettings } from './Capability';
+import type {
+	Capability,
+	CapabilityAccess,
+	CapabilityContext,
+	CapabilityGroup,
+	CapabilitySettings,
+} from './Capability';
 
 const workflowAccess: Record<string, CapabilityAccess> = {
 	buddy_workflow_get: 'read',
@@ -56,10 +62,12 @@ async function runViaChatToolPath(
 function chatCapability(
 	spec: ToolSpec,
 	access: CapabilityAccess,
+	group: CapabilityGroup,
 	enabled: (settings: CapabilitySettings) => boolean,
 ): Capability {
 	return {
 		spec,
+		group,
 		access,
 		chat: true,
 		mcp: false,
@@ -70,21 +78,22 @@ function chatCapability(
 }
 
 export const WORKSPACE_CHAT_CAPABILITIES: Capability[] = WORKSPACE_TOOL_SPECS.map(spec =>
-	chatCapability(spec, 'read', settings => settings.enableWorkspaceTools),
+	chatCapability(spec, 'read', 'workspace', settings => settings.enableWorkspaceTools),
 );
 
 export const WEB_CHAT_CAPABILITIES: Capability[] = WEB_TOOL_SPECS.map(spec =>
-	chatCapability(spec, 'read', settings => settings.enableWebTools),
+	chatCapability(spec, 'read', 'web', settings => settings.enableWebTools),
 );
 
 export const WORKFLOW_CHAT_CAPABILITIES: Capability[] = WORKFLOW_TOOL_SPECS.map(spec =>
-	chatCapability(spec, workflowAccessFor(spec), settings => settings.enableWorkflowTools),
+	chatCapability(spec, workflowAccessFor(spec), 'workflow', settings => settings.enableWorkflowTools),
 );
 
 export const RESULT_READ_CHAT_CAPABILITIES: Capability[] = RESULT_READ_TOOL_SPECS.map(spec =>
 	chatCapability(
 		spec,
 		'read',
+		'result',
 		settings =>
 			settings.enableWorkspaceTools ||
 			settings.enableWebTools ||

--- a/src/capabilities/chatToolCapabilities.ts
+++ b/src/capabilities/chatToolCapabilities.ts
@@ -1,0 +1,94 @@
+import { createGraphqlDeps } from '../ui/chat/tools/graphqlTool';
+import { RESULT_READ_TOOL_SPECS } from '../ui/chat/tools/toolOutputCache';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { WEB_TOOL_SPECS } from '../ui/chat/tools/webTools';
+import {
+	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_EDIT_TOOL_NAME,
+	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+	WORKFLOW_RUN_TOOL_NAME,
+	WORKFLOW_SEARCH_TOOL_NAME,
+	WORKFLOW_TOOL_SPECS,
+} from '../ui/chat/tools/workflowTools';
+import { runToolRequests, WORKSPACE_TOOL_SPECS } from '../ui/chat/tools/workspaceTools';
+import type { Capability, CapabilityAccess, CapabilityContext, CapabilitySettings } from './Capability';
+
+const workflowAccess: Record<string, CapabilityAccess> = {
+	buddy_workflow_get: 'read',
+	[WORKFLOW_SEARCH_TOOL_NAME]: 'read',
+	buddy_action_search: 'read',
+	[WORKFLOW_EDIT_TOOL_NAME]: 'write',
+	[WORKFLOW_AUTOLAYOUT_TOOL_NAME]: 'write',
+	[WORKFLOW_RUN_TOOL_NAME]: 'write',
+	buddy_workflow_executions: 'read',
+	[WORKFLOW_EXECUTION_LOGS_TOOL_NAME]: 'read',
+	buddy_render_jinja: 'read',
+};
+
+const doesNotRequireOrg = new Set<string>([
+	'list_template_links',
+	'web_search',
+	WORKFLOW_SEARCH_TOOL_NAME,
+	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+	'buddy_result_read',
+]);
+
+function workflowAccessFor(spec: ToolSpec): CapabilityAccess {
+	const access = workflowAccess[spec.name];
+	if (!access) throw new Error(`chatToolCapabilities: missing access classification for "${spec.name}"`);
+	return access;
+}
+
+async function runViaChatToolPath(
+	spec: ToolSpec,
+	input: Record<string, unknown>,
+	ctx: CapabilityContext,
+): Promise<string> {
+	const [result] = await runToolRequests(
+		[{ tool: spec.name, args: input }],
+		undefined,
+		undefined,
+		createGraphqlDeps(ctx.session),
+	);
+	return result.ok ? result.output : `Error: ${result.output}`;
+}
+
+function chatCapability(
+	spec: ToolSpec,
+	access: CapabilityAccess,
+	enabled: (settings: CapabilitySettings) => boolean,
+): Capability {
+	return {
+		spec,
+		access,
+		chat: true,
+		mcp: false,
+		...(doesNotRequireOrg.has(spec.name) ? { requiresOrg: false as const } : {}),
+		enabled,
+		run: (input, ctx) => runViaChatToolPath(spec, input, ctx),
+	};
+}
+
+export const WORKSPACE_CHAT_CAPABILITIES: Capability[] = WORKSPACE_TOOL_SPECS.map(spec =>
+	chatCapability(spec, 'read', settings => settings.enableWorkspaceTools),
+);
+
+export const WEB_CHAT_CAPABILITIES: Capability[] = WEB_TOOL_SPECS.map(spec =>
+	chatCapability(spec, 'read', settings => settings.enableWebTools),
+);
+
+export const WORKFLOW_CHAT_CAPABILITIES: Capability[] = WORKFLOW_TOOL_SPECS.map(spec =>
+	chatCapability(spec, workflowAccessFor(spec), settings => settings.enableWorkflowTools),
+);
+
+export const RESULT_READ_CHAT_CAPABILITIES: Capability[] = RESULT_READ_TOOL_SPECS.map(spec =>
+	chatCapability(
+		spec,
+		'read',
+		settings =>
+			settings.enableWorkspaceTools ||
+			settings.enableWebTools ||
+			settings.enableGraphqlTool ||
+			settings.enableWorkflowTools,
+	),
+);

--- a/src/capabilities/graphqlCapabilities.ts
+++ b/src/capabilities/graphqlCapabilities.ts
@@ -22,6 +22,7 @@ function specByName(name: string): ToolSpec {
 
 export const graphqlSchemaCapability: Capability = {
 	spec: specByName('buddy_graphql_schema'),
+	group: 'graphql',
 	access: 'read',
 	chat: true,
 	mcp: true,
@@ -32,6 +33,7 @@ export const graphqlSchemaCapability: Capability = {
 
 export const graphqlCapability: Capability = {
 	spec: specByName('buddy_graphql'),
+	group: 'graphql',
 	access: 'write',
 	chat: true,
 	mcp: false,

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -2,12 +2,14 @@ import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { SessionManager } from '@sessions';
 import { initTestEnvironment } from '@test';
-import type { CapabilitySettings } from './Capability';
+import type { CapabilityGroup, CapabilitySettings } from './Capability';
 import {
 	CAPABILITY_REGISTRY,
 	chatCapabilities,
+	chatCapabilityNames,
 	enabledMcpCapabilities,
 	getCapability,
+	hasChatCapability,
 	mcpCapabilities,
 } from './registry';
 import { RESULT_READ_TOOL_SPECS } from '../ui/chat/tools/toolOutputCache';
@@ -124,6 +126,39 @@ suite('Unit: capability registry', () => {
 					assert.strictEqual(capability.enabled(settings(on)), true, `${name} on when any tools are enabled`);
 				}
 			}
+		});
+	});
+
+	suite('tool-family groups', () => {
+		test('every chat capability declares a group', () => {
+			for (const capability of chatCapabilities()) {
+				assert.ok(capability.group, `${capability.spec.name} has a group`);
+			}
+		});
+
+		test('chatCapabilityNames returns the names in each family', () => {
+			const expected: Record<CapabilityGroup, string[]> = {
+				workspace: WORKSPACE_CHAT_CAPABILITIES,
+				web: WEB_CHAT_CAPABILITIES,
+				workflow: WORKFLOW_CHAT_CAPABILITIES,
+				graphql: GRAPHQL_CHAT_CAPABILITIES,
+				result: RESULT_READ_CHAT_CAPABILITIES,
+			};
+			for (const group of Object.keys(expected) as CapabilityGroup[]) {
+				assert.deepStrictEqual(
+					[...chatCapabilityNames(group)].sort(),
+					[...expected[group]].sort(),
+					`${group} family names`,
+				);
+			}
+		});
+
+		test('hasChatCapability matches only names in the family', () => {
+			assert.ok(hasChatCapability('workflow', new Set(['buddy_workflow_edit'])));
+			assert.ok(hasChatCapability('graphql', new Set(['buddy_graphql_schema'])));
+			assert.ok(!hasChatCapability('workflow', new Set(['buddy_graphql'])));
+			assert.ok(!hasChatCapability('graphql', new Set(['read_file', 'unknown_tool'])));
+			assert.ok(!hasChatCapability('web', new Set<string>()));
 		});
 	});
 

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -10,13 +10,34 @@ import {
 	getCapability,
 	mcpCapabilities,
 } from './registry';
+import { RESULT_READ_TOOL_SPECS } from '../ui/chat/tools/toolOutputCache';
+import { WEB_TOOL_SPECS } from '../ui/chat/tools/webTools';
+import { WORKFLOW_TOOL_SPECS } from '../ui/chat/tools/workflowTools';
+import { WORKSPACE_TOOL_SPECS } from '../ui/chat/tools/workspaceTools';
 
 const { suite, test, setup } = Mocha;
 
 const GRAPHQL_CHAT_CAPABILITIES = ['buddy_graphql_schema', 'buddy_graphql'];
+const WORKSPACE_CHAT_CAPABILITIES = WORKSPACE_TOOL_SPECS.map(spec => spec.name);
+const WEB_CHAT_CAPABILITIES = WEB_TOOL_SPECS.map(spec => spec.name);
+const WORKFLOW_CHAT_CAPABILITIES = WORKFLOW_TOOL_SPECS.map(spec => spec.name);
+const RESULT_READ_CHAT_CAPABILITIES = RESULT_READ_TOOL_SPECS.map(spec => spec.name);
+const CHAT_CAPABILITIES = [
+	...WORKSPACE_CHAT_CAPABILITIES,
+	...WEB_CHAT_CAPABILITIES,
+	...WORKFLOW_CHAT_CAPABILITIES,
+	...GRAPHQL_CHAT_CAPABILITIES,
+	...RESULT_READ_CHAT_CAPABILITIES,
+];
 
 function settings(overrides: Partial<CapabilitySettings> = {}): CapabilitySettings {
-	return { enableGraphqlTool: false, ...overrides };
+	return {
+		enableGraphqlTool: false,
+		enableWorkflowTools: false,
+		enableWebTools: false,
+		enableWorkspaceTools: false,
+		...overrides,
+	};
 }
 
 suite('Unit: capability registry', () => {
@@ -51,10 +72,9 @@ suite('Unit: capability registry', () => {
 	});
 
 	suite('chat surface', () => {
-		test('graphql tools are exposed on the chat surface', () => {
+		test('all VS Code chat tools are exposed on the chat surface', () => {
 			const names = chatCapabilities().map(capability => capability.spec.name);
-			assert.ok(names.includes('buddy_graphql_schema'));
-			assert.ok(names.includes('buddy_graphql'));
+			assert.deepStrictEqual([...names].sort(), [...CHAT_CAPABILITIES].sort());
 		});
 
 		test('chat graphql capabilities are gated by enableGraphqlTool', () => {
@@ -68,6 +88,41 @@ suite('Unit: capability registry', () => {
 					true,
 					`${capability.spec.name} on when graphql enabled`,
 				);
+			}
+		});
+
+		test('chat-only categories are gated by their feature switches', () => {
+			const byName = new Map(chatCapabilities().map(capability => [capability.spec.name, capability]));
+			const cases: [string, string[], Partial<CapabilitySettings>][] = [
+				['workspace', WORKSPACE_CHAT_CAPABILITIES, { enableWorkspaceTools: true }],
+				['web', WEB_CHAT_CAPABILITIES, { enableWebTools: true }],
+				['workflow', WORKFLOW_CHAT_CAPABILITIES, { enableWorkflowTools: true }],
+			];
+
+			for (const [label, names, on] of cases) {
+				for (const name of names) {
+					const capability = byName.get(name);
+					assert.ok(capability, `${name} is registered`);
+					assert.strictEqual(capability.enabled(settings()), false, `${name} off by default`);
+					assert.strictEqual(capability.enabled(settings(on)), true, `${name} on when ${label} enabled`);
+				}
+			}
+		});
+
+		test('result reader is enabled when any chat tool category is enabled', () => {
+			const byName = new Map(chatCapabilities().map(capability => [capability.spec.name, capability]));
+			for (const name of RESULT_READ_CHAT_CAPABILITIES) {
+				const capability = byName.get(name);
+				assert.ok(capability, `${name} is registered`);
+				assert.strictEqual(capability.enabled(settings()), false, `${name} off by default`);
+				for (const on of [
+					{ enableWorkspaceTools: true },
+					{ enableWebTools: true },
+					{ enableGraphqlTool: true },
+					{ enableWorkflowTools: true },
+				]) {
+					assert.strictEqual(capability.enabled(settings(on)), true, `${name} on when any tools are enabled`);
+				}
 			}
 		});
 	});
@@ -95,6 +150,18 @@ suite('Unit: capability registry', () => {
 			const names = mcpCapabilities().map(capability => capability.spec.name);
 			assert.ok(!names.includes('buddy_graphql'));
 			assert.ok(names.includes('buddy_graphql_schema'));
+		});
+
+		test('chat-only tool categories are not exposed to MCP', () => {
+			const names = new Set(mcpCapabilities().map(capability => capability.spec.name));
+			for (const name of [
+				...WORKSPACE_CHAT_CAPABILITIES,
+				...WEB_CHAT_CAPABILITIES,
+				...WORKFLOW_CHAT_CAPABILITIES,
+				...RESULT_READ_CHAT_CAPABILITIES,
+			]) {
+				assert.ok(!names.has(name), `${name} stays off MCP`);
+			}
 		});
 
 		test('list_orgs does not require an org', () => {

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -1,4 +1,10 @@
 import type { Capability, CapabilitySettings } from './Capability';
+import {
+	RESULT_READ_CHAT_CAPABILITIES,
+	WEB_CHAT_CAPABILITIES,
+	WORKFLOW_CHAT_CAPABILITIES,
+	WORKSPACE_CHAT_CAPABILITIES,
+} from './chatToolCapabilities';
 import { GRAPHQL_CAPABILITIES } from './graphqlCapabilities';
 import { graphqlMutateCapability } from './graphqlMutateCapability';
 import { READ_CAPABILITIES } from './rewstReadCapabilities';
@@ -9,9 +15,13 @@ import { READ_CAPABILITIES } from './rewstReadCapabilities';
  * it opts into. Names must be unique across the registry.
  */
 export const CAPABILITY_REGISTRY: Capability[] = [
+	...WORKSPACE_CHAT_CAPABILITIES,
+	...WEB_CHAT_CAPABILITIES,
+	...WORKFLOW_CHAT_CAPABILITIES,
 	...GRAPHQL_CAPABILITIES,
 	...READ_CAPABILITIES,
 	graphqlMutateCapability,
+	...RESULT_READ_CHAT_CAPABILITIES,
 ];
 
 const BY_NAME = new Map(CAPABILITY_REGISTRY.map(capability => [capability.spec.name, capability]));

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -1,4 +1,4 @@
-import type { Capability, CapabilitySettings } from './Capability';
+import type { Capability, CapabilityGroup, CapabilitySettings } from './Capability';
 import {
 	RESULT_READ_CHAT_CAPABILITIES,
 	WEB_CHAT_CAPABILITIES,
@@ -25,9 +25,18 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 ];
 
 const BY_NAME = new Map(CAPABILITY_REGISTRY.map(capability => [capability.spec.name, capability]));
+const EMPTY_CHAT_CAPABILITY_NAMES = new Set<string>();
+const CHAT_NAMES_BY_GROUP = new Map<CapabilityGroup, Set<string>>();
 
 if (BY_NAME.size !== CAPABILITY_REGISTRY.length) {
 	throw new Error('CAPABILITY_REGISTRY contains duplicate capability names');
+}
+
+for (const capability of CAPABILITY_REGISTRY) {
+	if (!capability.chat || capability.group === undefined) continue;
+	const names = CHAT_NAMES_BY_GROUP.get(capability.group) ?? new Set<string>();
+	names.add(capability.spec.name);
+	CHAT_NAMES_BY_GROUP.set(capability.group, names);
 }
 
 /** A capability by tool name, or undefined if no capability owns that name. */
@@ -38,6 +47,20 @@ export function getCapability(name: string): Capability | undefined {
 /** Capabilities exposed on the Cage-Free Rewsty chat surface. */
 export function chatCapabilities(): Capability[] {
 	return CAPABILITY_REGISTRY.filter(capability => capability.chat);
+}
+
+/** Chat-exposed capability names in a tool family. */
+export function chatCapabilityNames(group: CapabilityGroup): ReadonlySet<string> {
+	return CHAT_NAMES_BY_GROUP.get(group) ?? EMPTY_CHAT_CAPABILITY_NAMES;
+}
+
+/** Whether a provided tool-name set includes any chat capability in a tool family. */
+export function hasChatCapability(group: CapabilityGroup, names: ReadonlySet<string>): boolean {
+	const groupNames = chatCapabilityNames(group);
+	for (const name of names) {
+		if (groupNames.has(name)) return true;
+	}
+	return false;
 }
 
 /** Capabilities exposed on the MCP server surface. */

--- a/src/mcp/McpActions.ts
+++ b/src/mcp/McpActions.ts
@@ -51,8 +51,12 @@ export class McpError extends Error {
 }
 
 function capabilitySettings(): CapabilitySettings {
+	const tools = enabledAiTools();
 	return {
-		enableGraphqlTool: enabledAiTools().has('graphql'),
+		enableGraphqlTool: tools.has('graphql'),
+		enableWorkflowTools: tools.has('workflows'),
+		enableWebTools: tools.has('web'),
+		enableWorkspaceTools: tools.has('workspace'),
 	};
 }
 

--- a/src/ui/chat/model/engineeringDirective.ts
+++ b/src/ui/chat/model/engineeringDirective.ts
@@ -1,3 +1,5 @@
+import { hasChatCapability } from '../../../capabilities/registry';
+
 /**
  * Hidden preamble sent as the first part of the opening message of every NEW
  * backend conversation started from VS Code. RoboRewsty's system prompt is
@@ -134,8 +136,8 @@ Write like an engineer in a code review: direct, specific, complete. Deliver wor
  * editor tools at all, header, native-tool policy, and footer remain.
  */
 export function buildEngineeringDirective(availableTools: ReadonlySet<string>): string {
-	const hasWorkflowTools = availableTools.has('buddy_workflow_get') || availableTools.has('buddy_workflow_edit');
-	const hasGraphql = availableTools.has('buddy_graphql') || availableTools.has('buddy_graphql_schema');
+	const hasWorkflowTools = hasChatCapability('workflow', availableTools);
+	const hasGraphql = hasChatCapability('graphql', availableTools);
 	const bullets: string[] = [];
 	// Priority order is bullet order: our purpose-built workflow tools first, then
 	// raw GraphQL, then (per each bullet) native platform wrappers as the last resort.

--- a/src/ui/chat/model/lmTools.test.ts
+++ b/src/ui/chat/model/lmTools.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
+import { chatCapabilities } from '@capabilities';
 import { ALL_TOOL_SPECS, enabledToolNames, isToolPermitted, type AiToolSettings } from './lmTools';
 
 const { suite, test } = Mocha;
@@ -20,6 +21,12 @@ suite('Unit: lmTools', () => {
 		for (const spec of ALL_TOOL_SPECS) {
 			assert.ok(spec.inputSchema, `${spec.name} carries an inputSchema`);
 		}
+	});
+
+	test('derives protocol tools from chat capabilities', () => {
+		const capabilityNames = chatCapabilities().map(capability => capability.spec.name);
+		const specNames = ALL_TOOL_SPECS.map(spec => spec.name);
+		assert.deepStrictEqual([...specNames].sort(), [...capabilityNames].sort());
 	});
 
 	suite('enabledToolNames()', () => {

--- a/src/ui/chat/model/lmTools.ts
+++ b/src/ui/chat/model/lmTools.ts
@@ -1,4 +1,4 @@
-import { chatCapabilities } from '@capabilities';
+import { chatCapabilities, type CapabilitySettings } from '@capabilities';
 import { extPrefix } from '@global';
 import { SessionManager, type Session } from '@sessions';
 import { log } from '@utils';
@@ -10,57 +10,32 @@ import {
 	graphqlMutationScope,
 } from '../tools/graphqlTool';
 import { enabledAiTools } from '../tools/aiToolSettings';
-import { RESULT_READ_TOOL_SPECS } from '../tools/toolOutputCache';
 import { describeRequestBrief, type ToolSpec } from '../tools/toolProtocol';
-import { runToolRequests, WORKSPACE_TOOL_SPECS } from '../tools/workspaceTools';
-import { WEB_TOOL_SPECS } from '../tools/webTools';
-import { WORKFLOW_TOOL_SPECS, workflowEditConfirmation, workflowEditScope } from '../tools/workflowTools';
+import { runToolRequests } from '../tools/workspaceTools';
+import { workflowEditConfirmation, workflowEditScope } from '../tools/workflowTools';
 
 /**
- * Exposes every vscode-tool protocol tool as a registered VS Code language
+ * Exposes every chat capability as a registered VS Code language
  * model tool, so they are invocable when the RoboRewsty chat model emits tool
  * calls (and visible to agent mode like any extension tool). The spec arrays
- * remain the single source of truth: registration iterates them, so registered
- * names always equal the text-protocol names, and packageManifest.test.ts
- * keeps the static package.json declarations in sync with the same arrays.
+ * are owned by the capability registry and reused verbatim, so registered names
+ * always equal the text-protocol names, and packageManifest.test.ts keeps the
+ * static package.json declarations in sync with those same objects.
  */
 
 /** Snapshot of the rewst-buddy.ai.* switches that govern tool availability. */
-export interface AiToolSettings {
-	enableWorkspaceTools: boolean;
-	enableWebTools: boolean;
-	enableGraphqlTool: boolean;
-	enableWorkflowTools: boolean;
-}
+export type AiToolSettings = CapabilitySettings;
 
 interface GovernedSpec {
 	spec: ToolSpec;
 	enabled: (settings: AiToolSettings) => boolean;
 }
 
-// The GraphQL chat tools are sourced from the capability registry (the single
-// source of truth). Their spec objects are reused verbatim there, so the chat
-// tool set and the package.json manifest are unchanged; execution still flows
-// through runToolRequests until Phase 2 converges it onto the registry.
-const REGISTRY_CHAT_GOVERNED: GovernedSpec[] = chatCapabilities().map(capability => ({
-	spec: capability.spec,
-	enabled: (s: AiToolSettings) => capability.enabled({ enableGraphqlTool: s.enableGraphqlTool }),
-}));
-
 /** Every tool with the settings predicate that governs it. */
-export const GOVERNED_TOOL_SPECS: GovernedSpec[] = [
-	...WORKSPACE_TOOL_SPECS.map(spec => ({ spec, enabled: (s: AiToolSettings) => s.enableWorkspaceTools })),
-	...WEB_TOOL_SPECS.map(spec => ({ spec, enabled: (s: AiToolSettings) => s.enableWebTools })),
-	...WORKFLOW_TOOL_SPECS.map(spec => ({ spec, enabled: (s: AiToolSettings) => s.enableWorkflowTools })),
-	...REGISTRY_CHAT_GOVERNED,
-	// Available whenever any tool can run, since any of them can produce the
-	// oversized cached output this one reads back.
-	...RESULT_READ_TOOL_SPECS.map(spec => ({
-		spec,
-		enabled: (s: AiToolSettings) =>
-			s.enableWorkspaceTools || s.enableWebTools || s.enableGraphqlTool || s.enableWorkflowTools,
-	})),
-];
+export const GOVERNED_TOOL_SPECS: GovernedSpec[] = chatCapabilities().map(capability => ({
+	spec: capability.spec,
+	enabled: (settings: AiToolSettings) => capability.enabled(settings),
+}));
 
 export const ALL_TOOL_SPECS: ToolSpec[] = GOVERNED_TOOL_SPECS.map(entry => entry.spec);
 

--- a/src/ui/chat/tools/toolProtocol.ts
+++ b/src/ui/chat/tools/toolProtocol.ts
@@ -1,3 +1,6 @@
+import type { CapabilityGroup } from '../../../capabilities/Capability';
+import type * as capabilityRegistry from '../../../capabilities/registry';
+
 /**
  * Text tool protocol between the extension and RoboRewsty.
  *
@@ -45,14 +48,24 @@ export const TOOL_FENCE_MARKER = '```' + TOOL_FENCE_TAG;
 /** Hard cap on tool calls honored per assistant reply. */
 export const MAX_REQUESTS_PER_TURN = 5;
 
+let registry: typeof capabilityRegistry | undefined;
+
+function hasProvidedChatCapability(group: CapabilityGroup, names: ReadonlySet<string>): boolean {
+	// Lazy load to avoid the registry/workflowTools/toolProtocol initialization cycle.
+	// eslint-disable-next-line @typescript-eslint/no-require-imports
+	registry ??= require('../../../capabilities/registry') as typeof capabilityRegistry;
+	return registry.hasChatCapability(group, names);
+}
+
 /**
  * Instructions appended to the first message of a request so the assistant
  * knows the tools exist and how to call them.
  */
 export function buildToolInstructions(specs: ToolSpec[]): string {
 	const lines = specs.map(spec => `- ${spec.name} — args: ${spec.args}. ${spec.description}`);
-	const hasGraphqlTools = specs.some(spec => spec.name === 'buddy_graphql');
-	const hasWorkflowTools = specs.some(spec => spec.name === 'buddy_workflow_edit');
+	const specNames = new Set(specs.map(spec => spec.name));
+	const hasGraphqlTools = hasProvidedChatCapability('graphql', specNames);
+	const hasWorkflowTools = hasProvidedChatCapability('workflow', specNames);
 	const workflowNote = hasWorkflowTools
 		? [
 				'',


### PR DESCRIPTION
Closes #55. Part of the MCP server epic (#52). Builds on the foundation (#58) and GraphQL primitives (#60).

## What

Makes the capability registry the single source of truth for the Cage-Free Rewsty chat tool surface, and makes the steering's tool-family detection registry-driven — so adding or removing a tool no longer requires editing steering. **Behavior-preserving: the assembled steering output is byte-identical for every real tool set, and the tool surface (chat + MCP + `package.json`) is unchanged.**

## Commits

1. **Converge chat tool specs onto the registry** — workflow, web, workspace, and result-reader specs now register as chat-only capabilities (`chat:true, mcp:false`) that reuse the existing spec objects, so `package.json` stays byte-identical and the MCP surface is unchanged. `CapabilitySettings` carries every `rewst-buddy.ai.tools` category gate; `lmTools` derives `GOVERNED_TOOL_SPECS` from `chatCapabilities()`. Execution still flows through `runToolRequests` — only spec and gating ownership moved (execution convergence is deferred to #56).
2. **Registry-driven steering family detection** — adds a `group` (`workflow` | `graphql` | `web` | `workspace` | `result`) to chat capabilities; `engineeringDirective` and `toolProtocol` detect tool-family availability via `hasChatCapability(group, names)` instead of hardcoded tool-name checks. `toolProtocol` is a leaf module the tool specs depend on, so it reaches the registry through a memoized lazy `require` to avoid the initialization cycle. The hand-tuned `WORKFLOW_BULLET` prose stays literal (covered by live regression tests); only the enumerated *detection* — the actual churn point — became registry-driven.
3. **Tests for the group helpers.**

## Audit outcome

Per the issue's retire/reuse/keep audit: no LM tools warranted retirement — the `buddy_workflow_*` tools encode workflow choreography the GraphQL primitives don't subsume, so they stay chat-only. `buddy_graphql`/`buddy_graphql_schema` were already registry-backed. The convergence is structural, not a surface reduction.

## Tests

- `npm run test:unit` — 561 passing (558 + 3 new group-helper tests).
- `package.json` `contributes.languageModelTools` untouched; package-manifest unit test green.
- `engineeringDirective`, `toolProtocol`, and `registry` suites green — confirming byte-identical steering output.

## Changelog

No changelog note: the change is internal/architectural with no user-visible effect (identical tool surface and steering output). Applying `skip-changelog`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added granular feature controls to independently enable or disable workspace, web, and workflow tool categories, complementing the existing GraphQL tool control.
* **Improvements**
  * Reorganized chat tool capabilities into family groups for more consistent steering and guidance, including smarter inclusion of GraphQL/workflow instructions based on which tool families are available.
* **Tests**
  * Expanded coverage to validate chat surface exposure, tool-family group behavior, and MCP gating rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->