### PR TITLE
Expose read-only workflow helper tools over MCP (#56 Phase 1)

### DIFF
--- a/changelog.d/56.md
+++ b/changelog.d/56.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 62
 ---
 
 - **MCP server (experimental): workflow read tools** — external MCP clients (Claude Desktop, Claude Code, Cursor) can now read and debug Rewst workflows through the same helpers the Cage-Free Rewsty chat uses, when workflow tools are enabled. Six read-only tools are exposed: `buddy_workflow_get` (read a workflow as a node/edge graph), `buddy_workflow_search` (find workflows by name across your orgs), `buddy_action_search` (find or describe actions), `buddy_workflow_executions` (list recent runs), `buddy_execution_logs` (per-task logs for one run), and `buddy_render_jinja` (evaluate a Jinja expression against an execution). These are read-only at the MCP boundary; the workflow editing, autolayout, and run tools stay off MCP until a per-edit approval prompt inside VS Code is added.

--- a/changelog.d/56.md
+++ b/changelog.d/56.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): workflow read tools** — external MCP clients (Claude Desktop, Claude Code, Cursor) can now read and debug Rewst workflows through the same helpers the Cage-Free Rewsty chat uses, when workflow tools are enabled. Six read-only tools are exposed: `buddy_workflow_get` (read a workflow as a node/edge graph), `buddy_workflow_search` (find workflows by name across your orgs), `buddy_action_search` (find or describe actions), `buddy_workflow_executions` (list recent runs), `buddy_execution_logs` (per-task logs for one run), and `buddy_render_jinja` (evaluate a Jinja expression against an execution). These are read-only at the MCP boundary; the workflow editing, autolayout, and run tools stay off MCP until a per-edit approval prompt inside VS Code is added.

--- a/src/capabilities/chatToolCapabilities.ts
+++ b/src/capabilities/chatToolCapabilities.ts
@@ -64,13 +64,14 @@ function chatCapability(
 	access: CapabilityAccess,
 	group: CapabilityGroup,
 	enabled: (settings: CapabilitySettings) => boolean,
+	mcp = false,
 ): Capability {
 	return {
 		spec,
 		group,
 		access,
 		chat: true,
-		mcp: false,
+		mcp,
 		...(doesNotRequireOrg.has(spec.name) ? { requiresOrg: false as const } : {}),
 		enabled,
 		run: (input, ctx) => runViaChatToolPath(spec, input, ctx),
@@ -85,9 +86,10 @@ export const WEB_CHAT_CAPABILITIES: Capability[] = WEB_TOOL_SPECS.map(spec =>
 	chatCapability(spec, 'read', 'web', settings => settings.enableWebTools),
 );
 
-export const WORKFLOW_CHAT_CAPABILITIES: Capability[] = WORKFLOW_TOOL_SPECS.map(spec =>
-	chatCapability(spec, workflowAccessFor(spec), 'workflow', settings => settings.enableWorkflowTools),
-);
+export const WORKFLOW_CHAT_CAPABILITIES: Capability[] = WORKFLOW_TOOL_SPECS.map(spec => {
+	const access = workflowAccessFor(spec);
+	return chatCapability(spec, access, 'workflow', settings => settings.enableWorkflowTools, access === 'read');
+});
 
 export const RESULT_READ_CHAT_CAPABILITIES: Capability[] = RESULT_READ_TOOL_SPECS.map(spec =>
 	chatCapability(

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -14,7 +14,14 @@ import {
 } from './registry';
 import { RESULT_READ_TOOL_SPECS } from '../ui/chat/tools/toolOutputCache';
 import { WEB_TOOL_SPECS } from '../ui/chat/tools/webTools';
-import { WORKFLOW_TOOL_SPECS } from '../ui/chat/tools/workflowTools';
+import {
+	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_EDIT_TOOL_NAME,
+	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+	WORKFLOW_RUN_TOOL_NAME,
+	WORKFLOW_SEARCH_TOOL_NAME,
+	WORKFLOW_TOOL_SPECS,
+} from '../ui/chat/tools/workflowTools';
 import { WORKSPACE_TOOL_SPECS } from '../ui/chat/tools/workspaceTools';
 
 const { suite, test, setup } = Mocha;
@@ -23,6 +30,19 @@ const GRAPHQL_CHAT_CAPABILITIES = ['buddy_graphql_schema', 'buddy_graphql'];
 const WORKSPACE_CHAT_CAPABILITIES = WORKSPACE_TOOL_SPECS.map(spec => spec.name);
 const WEB_CHAT_CAPABILITIES = WEB_TOOL_SPECS.map(spec => spec.name);
 const WORKFLOW_CHAT_CAPABILITIES = WORKFLOW_TOOL_SPECS.map(spec => spec.name);
+const WORKFLOW_READ_MCP_CAPABILITIES = [
+	'buddy_workflow_get',
+	WORKFLOW_SEARCH_TOOL_NAME,
+	'buddy_action_search',
+	'buddy_workflow_executions',
+	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+	'buddy_render_jinja',
+];
+const WORKFLOW_WRITE_CHAT_CAPABILITIES = [
+	WORKFLOW_EDIT_TOOL_NAME,
+	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_RUN_TOOL_NAME,
+];
 const RESULT_READ_CHAT_CAPABILITIES = RESULT_READ_TOOL_SPECS.map(spec => spec.name);
 const CHAT_CAPABILITIES = [
 	...WORKSPACE_CHAT_CAPABILITIES,
@@ -187,12 +207,39 @@ suite('Unit: capability registry', () => {
 			assert.ok(names.includes('buddy_graphql_schema'));
 		});
 
-		test('chat-only tool categories are not exposed to MCP', () => {
+		test('read-only workflow helpers are exposed to MCP', () => {
+			const names = new Set(mcpCapabilities().map(capability => capability.spec.name));
+			for (const name of WORKFLOW_READ_MCP_CAPABILITIES) {
+				assert.ok(names.has(name), `${name} exposed to MCP`);
+			}
+		});
+
+		test('workflow write helpers are not exposed to MCP', () => {
+			const names = new Set(mcpCapabilities().map(capability => capability.spec.name));
+			for (const name of WORKFLOW_WRITE_CHAT_CAPABILITIES) {
+				assert.ok(!names.has(name), `${name} stays off MCP`);
+			}
+		});
+
+		test('promoted workflow helpers keep their existing org requirements', () => {
+			for (const name of [WORKFLOW_SEARCH_TOOL_NAME, WORKFLOW_EXECUTION_LOGS_TOOL_NAME]) {
+				assert.strictEqual(getCapability(name)?.requiresOrg, false, `${name} does not require org`);
+			}
+			for (const name of [
+				'buddy_workflow_get',
+				'buddy_action_search',
+				'buddy_workflow_executions',
+				'buddy_render_jinja',
+			]) {
+				assert.notStrictEqual(getCapability(name)?.requiresOrg, false, `${name} remains org-scoped`);
+			}
+		});
+
+		test('non-workflow chat-only tool categories are not exposed to MCP', () => {
 			const names = new Set(mcpCapabilities().map(capability => capability.spec.name));
 			for (const name of [
 				...WORKSPACE_CHAT_CAPABILITIES,
 				...WEB_CHAT_CAPABILITIES,
-				...WORKFLOW_CHAT_CAPABILITIES,
 				...RESULT_READ_CHAT_CAPABILITIES,
 			]) {
 				assert.ok(!names.has(name), `${name} stays off MCP`);

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -35,6 +35,50 @@ function useRawGraphqlWrapper(session: Session, wrapper: ReturnType<typeof creat
 	};
 }
 
+function workflowGetResponse() {
+	return {
+		data: {
+			workflow: {
+				id: 'wf-1',
+				name: 'MCP Sample Workflow',
+				description: null,
+				type: 'workflow',
+				orgId: 'org-1',
+				organization: { id: 'org-1', name: 'Acme' },
+				action: { parameters: {} },
+				updatedAt: '1000',
+				input: [],
+				tasks: [
+					{
+						id: 'task-start',
+						name: 'start',
+						actionId: 'action-noop',
+						action: { id: 'action-noop', ref: 'core.noop', name: 'Noop' },
+						input: {},
+						next: [
+							{
+								id: 'transition-1',
+								from: 'task-start',
+								to: 'task-end',
+								when: '{{ SUCCEEDED }}',
+								do: ['task-end'],
+							},
+						],
+					},
+					{
+						id: 'task-end',
+						name: 'end',
+						actionId: 'action-noop',
+						action: { id: 'action-noop', ref: 'core.noop', name: 'Noop' },
+						input: {},
+						next: [],
+					},
+				],
+			},
+		},
+	};
+}
+
 function detectGraphqlOperation(query: string): string {
 	const match = /\b(query|mutation|subscription)\s+([A-Za-z_][A-Za-z0-9_]*)/.exec(query);
 	return match ? `${match[1]} ${match[2]}` : 'rawGraphql';
@@ -137,6 +181,61 @@ suite('Unit: McpActions', () => {
 			const calls = wrapper.getCallsFor('rawGraphql');
 			assert.strictEqual(calls.length, 1);
 			assert.deepStrictEqual(calls[0].variables.variables, { includeDeprecated: false });
+		});
+
+		test('buddy_workflow_get is callable over MCP through the workflow capability', async () => {
+			const { session, wrapper } = useSession('org-1', 'Acme');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', { data: workflowGetResponse() });
+			await setAiTools(['workspace', 'workflows']);
+
+			const names = listTools(settings()).map(tool => tool.name);
+			assert.ok(names.includes('buddy_workflow_get'));
+
+			const result = await callTool(
+				{ name: 'buddy_workflow_get', arguments: { orgId: 'org-1', workflowId: 'wf-1' } },
+				settings(),
+			);
+
+			assert.ok(!result.isError);
+			const parsed = JSON.parse(result.text) as {
+				workflow: { id: string; name: string; orgId: string; orgName: string };
+				nodes: { name: string }[];
+			};
+			assert.strictEqual(parsed.workflow.name, 'MCP Sample Workflow');
+			assert.strictEqual(parsed.workflow.orgName, 'Acme');
+			assert.deepStrictEqual(
+				parsed.nodes.map(node => node.name),
+				['start', 'end'],
+			);
+			const calls = wrapper.getCallsFor('rawGraphql');
+			assert.strictEqual(calls.length, 1);
+			assert.match(calls[0].variables.query, /query RewstBuddyWorkflowGet/);
+			assert.deepStrictEqual(calls[0].variables.variables, { where: { id: 'wf-1', orgId: 'org-1' } });
+		});
+
+		test('buddy_workflow_edit is not available over MCP', async () => {
+			useSession('org-1');
+			await setAiTools(['workspace', 'workflows']);
+
+			const names = listTools(settings({ enableWriteTools: true })).map(tool => tool.name);
+			assert.ok(!names.includes('buddy_workflow_edit'));
+			await assert.rejects(
+				callTool(
+					{
+						name: 'buddy_workflow_edit',
+						arguments: {
+							orgId: 'org-1',
+							workflowId: 'wf-1',
+							workflowName: 'Workflow',
+							orgName: 'Acme',
+							operations: [],
+						},
+					},
+					settings({ enableWriteTools: true }),
+				),
+				(error: unknown) => error instanceof McpError && error.code === 'unknown_tool',
+			);
 		});
 
 		test('an org-scoped tool without orgId throws org_required', async () => {


### PR DESCRIPTION
Part of the MCP server epic (#52), issue #56 (Phase 1). **Stacked on #61** (`feat/mcp-steering-convergence`) — review/merge #61 first; this will be retargeted to `main` once #61 lands.

## What

Promotes the six **read-only** workflow helpers to the MCP surface so external MCP clients (Claude Desktop, Claude Code, Cursor) can read and debug workflows the same way the Cage-Free Rewsty chat does:

- `buddy_workflow_get`, `buddy_workflow_search`, `buddy_action_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_render_jinja`

These are the **existing chat capabilities with `mcp` flipped on** — one capability, both surfaces, no duplicate spec names (which the registry's uniqueness guard would reject). The `chatCapability` helper takes an `mcp` flag; workflow tools with `access:'read'` opt in, derived from the access classification so it can't drift. The three **write** tools (`buddy_workflow_edit`, `buddy_workflow_autolayout`, `buddy_workflow_run`) stay **off MCP** until the write-approval seam lands (Phase 2).

## Why it needs no plumbing changes

Chat and MCP execution already converge on `runWorkflowTool` + `createGraphqlDeps(session)`, and the MCP boundary (`McpActions.callTool` → `resolveContext` → `capability.run(args, ctx)`) already builds a valid context and invokes `run()`. All nine workflow tools are pure-GraphQL and headless-safe (no VS Code UI). So this is capability registration only — **no changes to `McpActions.ts`/`mcpServer.ts`**.

## Tests

- `registry.test.ts` — the 6 read workflow tools are now in `mcpCapabilities()`; the 3 write tools (and workspace/web/result) stay off MCP.
- `McpActions.test.ts` — a `callTool` round-trip for `buddy_workflow_get` (asserts the GraphQL query, org↔orgId binding, and parsed node/edge output) plus a guard that `buddy_workflow_edit` is rejected `unknown_tool` over MCP.
- `npm run test:unit` — 566 passing. `package.json` unchanged (these specs were already contributed as chat tools).

## Phase 2 (follow-up)

Write helpers (`edit`/`autolayout`/`run`) behind a `setWorkflowMutationApprover` seam mirroring `graphqlMutateCapability` — a VS Code modal approves each edit before it runs; an external client can never approve its own write.