### PR TITLE
Expose workflow write helpers over MCP behind per-edit approval (#56 Phase 2)

### DIFF
--- a/changelog.d/mcp-workflow-write.md
+++ b/changelog.d/mcp-workflow-write.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 63
 ---
 
 - **MCP server (experimental): workflow write tools behind in-VS-Code approval** — external MCP clients can now edit, auto-layout, and run Rewst workflows (`buddy_workflow_edit`, `buddy_workflow_autolayout`, `buddy_workflow_run`) when write tools are enabled (`rewst-buddy.mcp.enableWriteTools`). Every change is double-gated: writes are rejected at the MCP boundary unless write tools are turned on, and each edit then requires a per-workflow approval prompt **inside VS Code** before anything is sent — an external client can never approve its own write. Until you approve, the tool returns a clear `approval_required` result and makes no change.

--- a/changelog.d/mcp-workflow-write.md
+++ b/changelog.d/mcp-workflow-write.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): workflow write tools behind in-VS-Code approval** — external MCP clients can now edit, auto-layout, and run Rewst workflows (`buddy_workflow_edit`, `buddy_workflow_autolayout`, `buddy_workflow_run`) when write tools are enabled (`rewst-buddy.mcp.enableWriteTools`). Every change is double-gated: writes are rejected at the MCP boundary unless write tools are turned on, and each edit then requires a per-workflow approval prompt **inside VS Code** before anything is sent — an external client can never approve its own write. Until you approve, the tool returns a clear `approval_required` result and makes no change.

--- a/src/capabilities/chatToolCapabilities.ts
+++ b/src/capabilities/chatToolCapabilities.ts
@@ -18,6 +18,7 @@ import type {
 	CapabilityGroup,
 	CapabilitySettings,
 } from './Capability';
+import { runWorkflowMutationWithApproval } from './workflowMutateCapability';
 
 const workflowAccess: Record<string, CapabilityAccess> = {
 	buddy_workflow_get: 'read',
@@ -65,6 +66,8 @@ function chatCapability(
 	group: CapabilityGroup,
 	enabled: (settings: CapabilitySettings) => boolean,
 	mcp = false,
+	run: (input: Record<string, unknown>, ctx: CapabilityContext) => Promise<string> = (input, ctx) =>
+		runViaChatToolPath(spec, input, ctx),
 ): Capability {
 	return {
 		spec,
@@ -74,7 +77,7 @@ function chatCapability(
 		mcp,
 		...(doesNotRequireOrg.has(spec.name) ? { requiresOrg: false as const } : {}),
 		enabled,
-		run: (input, ctx) => runViaChatToolPath(spec, input, ctx),
+		run,
 	};
 }
 
@@ -88,7 +91,14 @@ export const WEB_CHAT_CAPABILITIES: Capability[] = WEB_TOOL_SPECS.map(spec =>
 
 export const WORKFLOW_CHAT_CAPABILITIES: Capability[] = WORKFLOW_TOOL_SPECS.map(spec => {
 	const access = workflowAccessFor(spec);
-	return chatCapability(spec, access, 'workflow', settings => settings.enableWorkflowTools, access === 'read');
+	return chatCapability(
+		spec,
+		access,
+		'workflow',
+		settings => settings.enableWorkflowTools,
+		true,
+		access === 'write' ? (input, ctx) => runWorkflowMutationWithApproval(spec, input, ctx) : undefined,
+	);
 });
 
 export const RESULT_READ_CHAT_CAPABILITIES: Capability[] = RESULT_READ_TOOL_SPECS.map(spec =>

--- a/src/capabilities/graphqlMutateCapability.ts
+++ b/src/capabilities/graphqlMutateCapability.ts
@@ -20,6 +20,10 @@ export function _resetMcpMutationApproverForTesting(): void {
 	approver = async () => false;
 }
 
+export function requestMcpMutationApproval(scope: MutationScope, operation: string): Promise<boolean> {
+	return approver(scope, operation);
+}
+
 const graphqlMutateSpec: ToolSpec = {
 	name: 'rewst_graphql_mutate',
 	args: '{"orgId": string, "query": string, "variables"?: object, "scopeId": string, "scopeName": string, "orgName"?: string}',

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -30,14 +30,6 @@ const GRAPHQL_CHAT_CAPABILITIES = ['buddy_graphql_schema', 'buddy_graphql'];
 const WORKSPACE_CHAT_CAPABILITIES = WORKSPACE_TOOL_SPECS.map(spec => spec.name);
 const WEB_CHAT_CAPABILITIES = WEB_TOOL_SPECS.map(spec => spec.name);
 const WORKFLOW_CHAT_CAPABILITIES = WORKFLOW_TOOL_SPECS.map(spec => spec.name);
-const WORKFLOW_READ_MCP_CAPABILITIES = [
-	'buddy_workflow_get',
-	WORKFLOW_SEARCH_TOOL_NAME,
-	'buddy_action_search',
-	'buddy_workflow_executions',
-	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
-	'buddy_render_jinja',
-];
 const WORKFLOW_WRITE_CHAT_CAPABILITIES = [
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
@@ -207,17 +199,19 @@ suite('Unit: capability registry', () => {
 			assert.ok(names.includes('buddy_graphql_schema'));
 		});
 
-		test('read-only workflow helpers are exposed to MCP', () => {
+		test('all workflow helpers are exposed to MCP', () => {
 			const names = new Set(mcpCapabilities().map(capability => capability.spec.name));
-			for (const name of WORKFLOW_READ_MCP_CAPABILITIES) {
+			for (const name of WORKFLOW_CHAT_CAPABILITIES) {
 				assert.ok(names.has(name), `${name} exposed to MCP`);
 			}
 		});
 
-		test('workflow write helpers are not exposed to MCP', () => {
-			const names = new Set(mcpCapabilities().map(capability => capability.spec.name));
+		test('workflow write helpers keep write access on MCP', () => {
 			for (const name of WORKFLOW_WRITE_CHAT_CAPABILITIES) {
-				assert.ok(!names.has(name), `${name} stays off MCP`);
+				const capability = getCapability(name);
+				assert.ok(capability, `${name} registered`);
+				assert.strictEqual(capability.mcp, true, `${name} exposed to MCP`);
+				assert.strictEqual(capability.access, 'write', `${name} remains write-gated`);
 			}
 		});
 

--- a/src/capabilities/workflowMutateCapability.ts
+++ b/src/capabilities/workflowMutateCapability.ts
@@ -1,0 +1,59 @@
+import {
+	approveMutationScope,
+	createGraphqlDeps,
+	isMutationScopeApproved,
+	type MutationScope,
+} from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import {
+	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_RUN_TOOL_NAME,
+	runWorkflowTool,
+	workflowEditScope,
+} from '../ui/chat/tools/workflowTools';
+import type { CapabilityContext } from './Capability';
+import { requestMcpMutationApproval } from './graphqlMutateCapability';
+
+function approvalRequiredResult(): string {
+	return JSON.stringify({
+		status: 'approval_required',
+		message:
+			'The mutation was not run. The user must approve it in VS Code (a modal appears in their editor); retry after they approve.',
+	});
+}
+
+function missingScopeResult(toolName: string): string {
+	return JSON.stringify({
+		status: 'invalid_request',
+		message: `${toolName} requires non-empty workflowId, workflowName, orgId, and orgName before it can request approval.`,
+	});
+}
+
+function approvalVerb(toolName: string): string {
+	if (toolName === WORKFLOW_AUTOLAYOUT_TOOL_NAME) return 'Auto-layout';
+	if (toolName === WORKFLOW_RUN_TOOL_NAME) return 'Run';
+	return 'Edit';
+}
+
+function operationSummary(toolName: string, scope: MutationScope): string {
+	const verb = approvalVerb(toolName);
+	return `${verb} workflow "${scope.scopeName}" (${scope.scopeId}) in org "${scope.orgName}" (${scope.orgId})`;
+}
+
+export async function runWorkflowMutationWithApproval(
+	spec: ToolSpec,
+	input: Record<string, unknown>,
+	ctx: CapabilityContext,
+): Promise<string> {
+	const scope = workflowEditScope(spec.name, input);
+	if (!scope) return missingScopeResult(spec.name);
+
+	if (!isMutationScopeApproved(scope)) {
+		if (!(await requestMcpMutationApproval(scope, operationSummary(spec.name, scope)))) {
+			return approvalRequiredResult();
+		}
+		approveMutationScope(scope);
+	}
+
+	return runWorkflowTool({ tool: spec.name, args: input }, createGraphqlDeps(ctx.session));
+}

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -5,6 +5,11 @@ import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import vscode from 'vscode';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover } from '../capabilities/graphqlMutateCapability';
 import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import {
+	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_EDIT_TOOL_NAME,
+	WORKFLOW_RUN_TOOL_NAME,
+} from '../ui/chat/tools/workflowTools';
 import { McpError, _resetMcpThrottleForTesting, callTool, listResources, listTools, readResource } from './McpActions';
 import type { McpSettings } from './settings';
 
@@ -77,6 +82,17 @@ function workflowGetResponse() {
 			},
 		},
 	};
+}
+
+function workflowMutationRawGraphqlResponse(request: { query?: string }): { data: unknown } {
+	const query = request.query ?? '';
+	if (query.includes('RewstBuddyWorkflowGet')) {
+		return { data: workflowGetResponse() };
+	}
+	if (query.includes('RewstBuddyWorkflowUpdate')) {
+		return { data: { data: { updateWorkflow: { id: 'wf-1', name: 'MCP Sample Workflow', updatedAt: '2000' } } } };
+	}
+	throw new Error(`Unexpected rawGraphql operation in workflow mutation test: ${query}`);
 }
 
 function detectGraphqlOperation(query: string): string {
@@ -214,16 +230,29 @@ suite('Unit: McpActions', () => {
 			assert.deepStrictEqual(calls[0].variables.variables, { where: { id: 'wf-1', orgId: 'org-1' } });
 		});
 
-		test('buddy_workflow_edit is not available over MCP', async () => {
+		test('workflow write helpers are listed only when MCP write tools are enabled', async () => {
 			useSession('org-1');
 			await setAiTools(['workspace', 'workflows']);
 
+			const withoutWrite = listTools(settings()).map(tool => tool.name);
+			assert.ok(!withoutWrite.includes(WORKFLOW_EDIT_TOOL_NAME));
+			assert.ok(!withoutWrite.includes(WORKFLOW_AUTOLAYOUT_TOOL_NAME));
+			assert.ok(!withoutWrite.includes(WORKFLOW_RUN_TOOL_NAME));
+
 			const names = listTools(settings({ enableWriteTools: true })).map(tool => tool.name);
-			assert.ok(!names.includes('buddy_workflow_edit'));
+			assert.ok(names.includes(WORKFLOW_EDIT_TOOL_NAME));
+			assert.ok(names.includes(WORKFLOW_AUTOLAYOUT_TOOL_NAME));
+			assert.ok(names.includes(WORKFLOW_RUN_TOOL_NAME));
+		});
+
+		test('buddy_workflow_edit is rejected at the boundary while write tools are disabled', async () => {
+			useSession('org-1');
+			await setAiTools(['workspace', 'workflows']);
+
 			await assert.rejects(
 				callTool(
 					{
-						name: 'buddy_workflow_edit',
+						name: WORKFLOW_EDIT_TOOL_NAME,
 						arguments: {
 							orgId: 'org-1',
 							workflowId: 'wf-1',
@@ -232,10 +261,69 @@ suite('Unit: McpActions', () => {
 							operations: [],
 						},
 					},
-					settings({ enableWriteTools: true }),
+					settings({ enableWriteTools: false }),
 				),
-				(error: unknown) => error instanceof McpError && error.code === 'unknown_tool',
+				(error: unknown) => error instanceof McpError && error.code === 'write_disabled',
 			);
+		});
+
+		test('buddy_workflow_edit returns approval_required without executing when the user declines', async () => {
+			const { session, wrapper } = useSession('org-1', 'Acme');
+			useRawGraphqlWrapper(session, wrapper);
+			await setAiTools(['workspace', 'workflows']);
+			setMcpMutationApprover(async () => false);
+
+			const result = await callTool(
+				{
+					name: WORKFLOW_EDIT_TOOL_NAME,
+					arguments: {
+						orgId: 'org-1',
+						workflowId: 'wf-1',
+						workflowName: 'MCP Sample Workflow',
+						orgName: 'Acme',
+						operations: [{ op: 'reposition', task: 'start', x: 100, y: 200 }],
+					},
+				},
+				settings({ enableWriteTools: true }),
+			);
+
+			assert.ok(!result.isError);
+			assert.strictEqual(JSON.parse(result.text).status, 'approval_required');
+			assert.strictEqual(wrapper.getCallsFor('rawGraphql').length, 0);
+		});
+
+		test('buddy_workflow_edit executes after MCP approval and returns workflow output', async () => {
+			const { session, wrapper } = useSession('org-1', 'Acme');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when<unknown>('rawGraphql', workflowMutationRawGraphqlResponse);
+			await setAiTools(['workspace', 'workflows']);
+			let approvals = 0;
+			setMcpMutationApprover(async () => {
+				approvals++;
+				return true;
+			});
+
+			const result = await callTool(
+				{
+					name: WORKFLOW_EDIT_TOOL_NAME,
+					arguments: {
+						orgId: 'org-1',
+						workflowId: 'wf-1',
+						workflowName: 'MCP Sample Workflow',
+						orgName: 'Acme',
+						operations: [{ op: 'reposition', task: 'start', x: 100, y: 200 }],
+					},
+				},
+				settings({ enableWriteTools: true }),
+			);
+
+			assert.ok(!result.isError);
+			assert.match(result.text, /Applied 1 operation/);
+			assert.match(result.text, /New version token: 2000/);
+			assert.strictEqual(approvals, 1);
+			const calls = wrapper.getCallsFor('rawGraphql');
+			assert.ok(calls.some(call => String(call.variables.query).includes('RewstBuddyWorkflowGet')));
+			assert.ok(calls.some(call => String(call.variables.query).includes('RewstBuddyWorkflowUpdate')));
 		});
 
 		test('an org-scoped tool without orgId throws org_required', async () => {


### PR DESCRIPTION
Part of the MCP server epic (#52), issue #56 (Phase 2). **Stacked on #62** (`feat/mcp-workflow-helpers`, the read-only Phase 1) which is itself stacked on #61. Review/merge order: #61 → #62 → this. Will be retargeted to `main` as the lower PRs land.

## What

Promotes the three **write** workflow helpers to the MCP surface, gated so an external MCP client can never mutate Rewst without explicit in-VS-Code approval:

- `buddy_workflow_edit`, `buddy_workflow_autolayout`, `buddy_workflow_run`

**Double-gated:**
1. The MCP boundary rejects `access:'write'` tools unless `rewst-buddy.mcp.enableWriteTools` is set.
2. Each edit then needs a **per-workflow approval prompt inside VS Code** before the mutation runs.

## Design — mirrors the GraphQL mutate capability

The gated `run()` (`runWorkflowMutationWithApproval` in the new `workflowMutateCapability.ts`) resolves the workflow scope, and if it isn't already approved it requests approval through the **same wired seam** as GraphQL mutations — it calls `requestMcpMutationApproval`, which delegates to the existing `setMcpMutationApprover` approver already wired to a VS Code modal in `extension.ts`. So **no new extension wiring** is needed. On denial it returns a structured `approval_required` result and runs nothing; on approval it records the scope (`approveMutationScope`) and executes via `runWorkflowTool`.

The **chat path is unchanged** — `capability.run()` is dormant for chat (which keeps its own inline `workflowEditConfirmation`); the gated `run()` only fires on the MCP surface.

## Tests

- **Fail-closed:** a declined approver makes `buddy_workflow_edit` return `approval_required` with **zero** GraphQL calls (no execution).
- Approved approver → executes and returns workflow output.
- Boundary rejection (`write_disabled`) when `enableWriteTools` is off; write tools listed only when it's on.
- `npm run test:unit` — 569 passing. `package.json` unchanged (specs already contributed as chat tools).

## Completes #56

With Phase 1 (reads) + Phase 2 (writes), all nine `buddy_workflow_*` helpers are on the MCP surface — reads open, writes behind enable + per-edit VS Code approval.