### PR TITLE
Audit-log every MCP tool call (#57)

### DIFF
--- a/changelog.d/mcp-audit-logging.md
+++ b/changelog.d/mcp-audit-logging.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): audit logging** — every tool call an external MCP client makes is now logged to the Rewst Buddy output channel as a single `[MCP audit]` line showing the tool name, the organization it targeted, the outcome (`ok`, `approval_required`, or the specific error), and how long it took. Argument values, GraphQL query bodies, and secrets are never logged, so you can see what an external agent did without leaking sensitive data.

--- a/changelog.d/mcp-audit-logging.md
+++ b/changelog.d/mcp-audit-logging.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 64
 ---
 
 - **MCP server (experimental): audit logging** — every tool call an external MCP client makes is now logged to the Rewst Buddy output channel as a single `[MCP audit]` line showing the tool name, the organization it targeted, the outcome (`ok`, `approval_required`, or the specific error), and how long it took. Argument values, GraphQL query bodies, and secrets are never logged, so you can see what an external agent did without leaking sensitive data.

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -642,6 +642,26 @@ suite('Unit: MCP audit logging', () => {
 		assert.ok(lines[0].includes('outcome=error:unknown_tool'));
 	});
 
+	test('a tool name with unicode line/paragraph separators cannot forge audit lines', async () => {
+		useSession('org-1');
+		const capture = captureInfoLogs();
+		try {
+			await assert.rejects(
+				callTool(
+					{ name: 'evil\u2028[MCP audit] tool=forged\u2029x', arguments: { orgId: 'org-1' } },
+					settings(),
+				),
+				(error: unknown) => error instanceof McpError && error.code === 'unknown_tool',
+			);
+		} finally {
+			capture.restore();
+		}
+
+		const lines = auditLines(capture.messages);
+		assert.strictEqual(lines.length, 1, 'unicode separators do not split the record');
+		assert.ok(!/[\u2028\u2029]/.test(lines[0]), 'the audit line carries no unicode line separators');
+	});
+
 	test('audit logs do not include arguments or secrets', async () => {
 		const { wrapper } = useSession('org-1');
 		wrapper.when('listTemplates', {

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -627,6 +627,24 @@ suite('Unit: MCP audit logging', () => {
 		assert.match(lines[0], /durationMs=\d+/);
 	});
 
+	test('a tool name with line breaks cannot forge extra audit lines', async () => {
+		useSession('org-1');
+		const capture = captureInfoLogs();
+		try {
+			await assert.rejects(
+				callTool({ name: 'evil\n[MCP audit] tool=forged', arguments: { orgId: 'org-1' } }, settings()),
+				(error: unknown) => error instanceof McpError && error.code === 'unknown_tool',
+			);
+		} finally {
+			capture.restore();
+		}
+
+		const lines = auditLines(capture.messages);
+		assert.strictEqual(lines.length, 1, 'the injected newline does not split the record into two audit lines');
+		assert.ok(!lines[0].includes('\n'), 'the audit line carries no embedded newline');
+		assert.ok(lines[0].includes('outcome=error:unknown_tool'));
+	});
+
 	test('audit logs do not include arguments or secrets', async () => {
 		const { wrapper } = useSession('org-1');
 		wrapper.when('listTemplates', {

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -2,6 +2,8 @@ import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { SessionManager, type Session } from '@sessions';
 import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import { log } from '@utils';
+import vscode from 'vscode';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover } from '../capabilities/graphqlMutateCapability';
 import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import {
@@ -93,6 +95,24 @@ function workflowMutationRawGraphqlResponse(request: { query?: string }): { data
 function detectGraphqlOperation(query: string): string {
 	const match = /\b(query|mutation|subscription)\s+([A-Za-z_][A-Za-z0-9_]*)/.exec(query);
 	return match ? `${match[1]} ${match[2]}` : 'rawGraphql';
+}
+
+function captureInfoLogs(): { messages: string[]; restore: () => void } {
+	const messages: string[] = [];
+	const originalInfo = log.info;
+	log.info = (message: string, ...args: unknown[]) => {
+		messages.push([message, ...args.map(String)].join(' '));
+	};
+	return {
+		messages,
+		restore: () => {
+			log.info = originalInfo;
+		},
+	};
+}
+
+function auditLines(messages: string[]): string[] {
+	return messages.filter(message => message.includes('[MCP audit]'));
 }
 
 suite('Unit: McpActions', () => {
@@ -547,5 +567,124 @@ suite('Unit: McpActions', () => {
 			}
 			assert.ok(limited, 'the throttle eventually rejects a burst of resource reads');
 		});
+	});
+});
+
+suite('Unit: MCP audit logging', () => {
+	setup(async () => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		_resetMcpThrottleForTesting();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		await setAiTools(['workspace', 'graphql']);
+	});
+
+	teardown(async () => {
+		SessionManager._resetForTesting();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		await setAiTools(['workspace']);
+	});
+
+	test('successful tool call logs tool, resolved orgId, ok outcome, and duration', async () => {
+		const { wrapper } = useSession('org-1');
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-1', name: 'Welcome' })]),
+		});
+		const capture = captureInfoLogs();
+		try {
+			await callTool({ name: 'list_templates', arguments: { orgId: 'org-1' } }, settings());
+		} finally {
+			capture.restore();
+		}
+
+		const lines = auditLines(capture.messages);
+		assert.strictEqual(lines.length, 1);
+		assert.ok(lines[0].includes('tool=list_templates'));
+		assert.ok(lines[0].includes('orgId=org-1'));
+		assert.ok(lines[0].includes('outcome=ok'));
+		assert.match(lines[0], /durationMs=\d+/);
+	});
+
+	test('rejected tool call logs the McpError outcome', async () => {
+		useSession('org-1');
+		const capture = captureInfoLogs();
+		try {
+			await assert.rejects(
+				callTool({ name: 'list_templates' }, settings()),
+				(error: unknown) => error instanceof McpError && error.code === 'org_required',
+			);
+		} finally {
+			capture.restore();
+		}
+
+		const lines = auditLines(capture.messages);
+		assert.strictEqual(lines.length, 1);
+		assert.ok(lines[0].includes('tool=list_templates'));
+		assert.ok(lines[0].includes('orgId=—'));
+		assert.ok(lines[0].includes('outcome=error:org_required'));
+		assert.match(lines[0], /durationMs=\d+/);
+	});
+
+	test('audit logs do not include arguments or secrets', async () => {
+		const { wrapper } = useSession('org-1');
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-1', name: 'Welcome' })]),
+		});
+		const capture = captureInfoLogs();
+		try {
+			await callTool(
+				{
+					name: 'list_templates',
+					arguments: {
+						orgId: 'org-1',
+						apiToken: 'audit-secret-token',
+						query: 'query AuditSecret { secretField }',
+						variables: { password: 'audit-secret-password' },
+					},
+				},
+				settings(),
+			);
+		} finally {
+			capture.restore();
+		}
+
+		const lines = auditLines(capture.messages);
+		assert.strictEqual(lines.length, 1);
+		const combined = lines.join('\n');
+		assert.ok(!combined.includes('audit-secret-token'));
+		assert.ok(!combined.includes('AuditSecret'));
+		assert.ok(!combined.includes('secretField'));
+		assert.ok(!combined.includes('audit-secret-password'));
+	});
+
+	test('approval_required structured results log approval_required outcome', async () => {
+		const { session, wrapper } = useSession('org-1');
+		useRawGraphqlWrapper(session, wrapper);
+		setMcpMutationApprover(async () => false);
+		const capture = captureInfoLogs();
+		try {
+			await callTool(
+				{
+					name: 'rewst_graphql_mutate',
+					arguments: {
+						orgId: 'org-1',
+						query: 'mutation UpdateThing { updateThing { id } }',
+						scopeId: 'wf-1',
+						scopeName: 'Workflow',
+					},
+				},
+				settings({ enableWriteTools: true }),
+			);
+		} finally {
+			capture.restore();
+		}
+
+		const lines = auditLines(capture.messages);
+		assert.strictEqual(lines.length, 1);
+		assert.ok(lines[0].includes('tool=rewst_graphql_mutate'));
+		assert.ok(lines[0].includes('orgId=org-1'));
+		assert.ok(lines[0].includes('outcome=approval_required'));
 	});
 });

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -3,7 +3,6 @@ import * as Mocha from 'mocha';
 import { SessionManager, type Session } from '@sessions';
 import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import { log } from '@utils';
-import vscode from 'vscode';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover } from '../capabilities/graphqlMutateCapability';
 import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import {
@@ -571,20 +570,18 @@ suite('Unit: McpActions', () => {
 });
 
 suite('Unit: MCP audit logging', () => {
-	setup(async () => {
+	setup(() => {
 		initTestEnvironment();
 		SessionManager._resetForTesting();
 		_resetMcpThrottleForTesting();
 		_resetApprovedMutationScopes();
 		_resetMcpMutationApproverForTesting();
-		await setAiTools(['workspace', 'graphql']);
 	});
 
-	teardown(async () => {
+	teardown(() => {
 		SessionManager._resetForTesting();
 		_resetApprovedMutationScopes();
 		_resetMcpMutationApproverForTesting();
-		await setAiTools(['workspace']);
 	});
 
 	test('successful tool call logs tool, resolved orgId, ok outcome, and duration', async () => {
@@ -693,7 +690,7 @@ suite('Unit: MCP audit logging', () => {
 						scopeName: 'Workflow',
 					},
 				},
-				settings({ enableWriteTools: true }),
+				settings({ enableDangerousGraphqlMutation: true }),
 			);
 		} finally {
 			capture.restore();

--- a/src/mcp/McpActions.ts
+++ b/src/mcp/McpActions.ts
@@ -90,9 +90,10 @@ function auditOutcomeForText(text: string): 'ok' | 'approval_required' {
 
 // The tool name (and orgId, on some paths) originate in the client request, so
 // strip line breaks before logging to keep each audit record on its own line —
-// otherwise a crafted tool name could inject forged audit entries.
+// otherwise a crafted tool name could inject forged audit entries. Unicode line
+// (U+2028) and paragraph (U+2029) separators are stripped too for defense in depth.
 function sanitizeAuditField(value: string): string {
-	return value.replace(/[\r\n\t]/g, ' ').trim() || '—';
+	return value.replace(/[\r\n\t\u2028\u2029]/g, ' ').trim() || '—';
 }
 
 function logCallToolAudit(tool: string, orgId: string, outcome: AuditOutcome, startedAt: number): void {

--- a/src/mcp/McpActions.ts
+++ b/src/mcp/McpActions.ts
@@ -88,8 +88,17 @@ function auditOutcomeForText(text: string): 'ok' | 'approval_required' {
 	}
 }
 
+// The tool name (and orgId, on some paths) originate in the client request, so
+// strip line breaks before logging to keep each audit record on its own line —
+// otherwise a crafted tool name could inject forged audit entries.
+function sanitizeAuditField(value: string): string {
+	return value.replace(/[\r\n\t]/g, ' ').trim() || '—';
+}
+
 function logCallToolAudit(tool: string, orgId: string, outcome: AuditOutcome, startedAt: number): void {
-	log.info(`[MCP audit] tool=${tool} orgId=${orgId} outcome=${outcome} durationMs=${Date.now() - startedAt}`);
+	const safeTool = sanitizeAuditField(tool);
+	const safeOrgId = sanitizeAuditField(orgId);
+	log.info(`[MCP audit] tool=${safeTool} orgId=${safeOrgId} outcome=${outcome} durationMs=${Date.now() - startedAt}`);
 }
 
 /** Validates the session, attempting one refresh, before a capability runs. */

--- a/src/mcp/McpActions.ts
+++ b/src/mcp/McpActions.ts
@@ -18,6 +18,7 @@ const MCP_MAX_OUTPUT_CHARS = 24_000;
 // An external agent can loop fast and each call hits a real org through the
 // user's cookie session, so cap MCP-originated calls independently of the chat.
 const THROTTLE = new SlidingWindowThrottle(30, 10_000);
+type AuditOutcome = 'ok' | 'approval_required' | `error:${McpErrorCode}`;
 
 /** Parameters for one tool call; orgId may also travel inside `arguments`. */
 export interface CallToolParams {
@@ -72,6 +73,23 @@ function truncate(text: string): string {
 function asString(record: Record<string, unknown> | undefined, key: string): string | undefined {
 	const value = record?.[key];
 	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function auditOutcomeForText(text: string): 'ok' | 'approval_required' {
+	const trimmed = text.trimStart();
+	if (!trimmed.startsWith('{')) return 'ok';
+	try {
+		const parsed = JSON.parse(trimmed) as { status?: unknown };
+		return parsed && typeof parsed === 'object' && parsed.status === 'approval_required'
+			? 'approval_required'
+			: 'ok';
+	} catch {
+		return 'ok';
+	}
+}
+
+function logCallToolAudit(tool: string, orgId: string, outcome: AuditOutcome, startedAt: number): void {
+	log.info(`[MCP audit] tool=${tool} orgId=${orgId} outcome=${outcome} durationMs=${Date.now() - startedAt}`);
 }
 
 /** Validates the session, attempting one refresh, before a capability runs. */
@@ -139,44 +157,55 @@ export async function callTool(
 	params: CallToolParams,
 	settings: McpSettings = readMcpSettings(),
 ): Promise<McpToolResult> {
-	const capability = getCapability(params.name);
-	if (!capability || !capability.mcp) {
-		throw new McpError('unknown_tool', `Unknown tool "${params.name}".`);
-	}
-	if (capability.dangerous && !settings.enableDangerousGraphqlMutation) {
-		throw new McpError(
-			'write_disabled',
-			`"${params.name}" can run arbitrary GraphQL mutations against the live Rewst organization and is disabled. Enable rewst-buddy.mcp.enableDangerousGraphqlMutation in VS Code.`,
-		);
-	}
-	if (!capability.dangerous && capability.access === 'write' && !settings.enableWriteTools) {
-		throw new McpError(
-			'write_disabled',
-			`"${params.name}" changes Rewst data and write tools are disabled. Enable rewst-buddy.mcp.enableWriteTools in VS Code.`,
-		);
-	}
-	if (!isExposed(capability, settings)) {
-		throw new McpError('unknown_tool', `Tool "${params.name}" is not enabled.`);
-	}
-	if (!THROTTLE.tryAcquire()) {
-		throw new McpError(
-			'rate_limited',
-			`Too many MCP calls; slow down and retry in ~${Math.ceil(THROTTLE.retryAfterMs() / 1000)}s.`,
-		);
-	}
-
-	const args = params.arguments ?? {};
-	const ctx = await resolveContext(capability, args, params.orgId);
+	const startedAt = Date.now();
+	let auditOrgId = '—';
+	let auditOutcome: AuditOutcome = 'ok';
 	try {
-		const text = await capability.run(args, ctx);
-		log.info(`MCP callTool ok: ${params.name} org=${ctx.orgId}`);
-		return { text: truncate(text) };
+		const capability = getCapability(params.name);
+		if (!capability || !capability.mcp) {
+			throw new McpError('unknown_tool', `Unknown tool "${params.name}".`);
+		}
+		if (capability.dangerous && !settings.enableDangerousGraphqlMutation) {
+			throw new McpError(
+				'write_disabled',
+				`"${params.name}" can run arbitrary GraphQL mutations against the live Rewst organization and is disabled. Enable rewst-buddy.mcp.enableDangerousGraphqlMutation in VS Code.`,
+			);
+		}
+		if (!capability.dangerous && capability.access === 'write' && !settings.enableWriteTools) {
+			throw new McpError(
+				'write_disabled',
+				`"${params.name}" changes Rewst data and write tools are disabled. Enable rewst-buddy.mcp.enableWriteTools in VS Code.`,
+			);
+		}
+		if (!isExposed(capability, settings)) {
+			throw new McpError('unknown_tool', `Tool "${params.name}" is not enabled.`);
+		}
+		if (!THROTTLE.tryAcquire()) {
+			throw new McpError(
+				'rate_limited',
+				`Too many MCP calls; slow down and retry in ~${Math.ceil(THROTTLE.retryAfterMs() / 1000)}s.`,
+			);
+		}
+
+		const args = params.arguments ?? {};
+		const ctx = await resolveContext(capability, args, params.orgId);
+		auditOrgId = capability.requiresOrg === false ? '—' : ctx.orgId || '—';
+		try {
+			const text = await capability.run(args, ctx);
+			auditOutcome = auditOutcomeForText(text);
+			return { text: truncate(text) };
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			auditOutcome = `error:${error instanceof McpError ? error.code : 'graphql_error'}`;
+			// A capability that throws is a tool-execution failure the agent should
+			// see, not a transport error; surface it as an isError result.
+			return { text: message, isError: true };
+		}
 	} catch (error) {
-		const message = error instanceof Error ? error.message : String(error);
-		log.info(`MCP callTool error: ${params.name} org=${ctx.orgId}: ${message}`);
-		// A capability that throws is a tool-execution failure the agent should
-		// see, not a transport error; surface it as an isError result.
-		return { text: message, isError: true };
+		auditOutcome = `error:${error instanceof McpError ? error.code : 'internal'}`;
+		throw error;
+	} finally {
+		logCallToolAudit(params.name, auditOrgId, auditOutcome, startedAt);
 	}
 }
 


### PR DESCRIPTION
Part of the MCP server epic (#52), issue #57 (hardening) — the **audit logging** item, called out there as essential for trust. **Independent of the #55/#56 PRs** (#61/#62/#63); branches off `main` (the merged MCP foundation), touches only `src/mcp/McpActions.ts`.

## What

Logs one line per MCP-originated tool call to the Rewst Buddy output channel so the user can see what an external MCP client did:

```
[MCP audit] tool=<name> orgId=<org or —> outcome=<ok|approval_required|error:<code>> durationMs=<n>
```

`callTool` now wraps its gates, context resolution, and capability run in a single `try/finally` that emits the audit line **exactly once**, on every path.

## Privacy

Only the tool name, resolved orgId, outcome, and duration are logged — **never** argument values, GraphQL query bodies, variables, or secrets. A regression test passes an `apiToken`, a query body, and a `password` variable and asserts none appear in the audit output.

## No behavior change

Gate and session errors still throw (transport-level); capability failures still return `isError` results; the only addition is the observational log line. The `approval_required` outcome is detected from the structured result a gated mutation returns.

## Tests

- New `Unit: MCP audit logging` suite: success line (tool + orgId + `ok` + duration), an error outcome (`error:org_required`), the `approval_required` outcome, and the no-args/no-secrets guarantee.
- `npm run test:unit` — 558 passing.

## Scope

This is one item from the #57 tracking issue. Remaining #57 items (token rotation command, multi-window story, result-truncation reuse, ToS/bundle review) are separate follow-ups.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added experimental MCP server audit logging for each external tool call, emitting a single `[MCP audit]` line with a sanitized tool name, targeted organization (or unknown), computed outcome (`ok`, `approval_required`, or `error:<code>`), and call duration. Tool arguments, GraphQL bodies, and secrets are omitted/redacted.
* **Refactor**
  * Centralized and standardized audit-log generation and outcome classification for tool invocations.
* **Tests**
  * Added unit coverage for success/error outcomes, approval-required flows, forgery/newline injection resistance, and absence of sensitive content.
* **Documentation**
  * Updated the changelog with the new audit-logging entry.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->