### PR TITLE
Add a Rotate MCP Token command (#57)

### DIFF
--- a/changelog.d/mcp-token-rotation.md
+++ b/changelog.d/mcp-token-rotation.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): Rotate MCP Token command** — a new **Rotate MCP Token** command lets you revoke MCP access by minting a fresh endpoint token; any external client still using the old token immediately loses access. It confirms first (rotating breaks connected clients until you update their config), then points you at **Copy MCP Config to Clipboard** to share the new token.

--- a/changelog.d/mcp-token-rotation.md
+++ b/changelog.d/mcp-token-rotation.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 65
 ---
 
 - **MCP server (experimental): Rotate MCP Token command** — a new **Rotate MCP Token** command lets you revoke MCP access by minting a fresh endpoint token; any external client still using the old token immediately loses access. It confirms first (rotating breaks connected clients until you update their config), then points you at **Copy MCP Config to Clipboard** to share the new token.

--- a/docs/features.md
+++ b/docs/features.md
@@ -112,6 +112,8 @@ The old combined chat tool `buddy_graphql` is not exposed; its MCP replacement i
 
 Large MCP outputs are bounded at the MCP response boundary; the retired chat-only `buddy_result_read` cache is no longer part of the chat tool protocol.
 
+The local MCP endpoint is guarded by a persistent localhost token. If it is ever exposed, run `Rewst Buddy: Rotate MCP Token` to replace it after a modal confirmation — existing MCP clients holding the old token lose access until you re-copy the config with `Copy MCP Config to Clipboard`.
+
 ### Context and answers
 
 - **Attached context** — files attached via the paperclip or `#file`, and editor selections, are included by the chat itself

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -89,6 +89,7 @@ All commands are available via Command Palette (Cmd/Ctrl + Shift + P) under the 
 - `Start Server` — Start the session receiver server
 - `Add MCP Server to VS Code` — Register the extension's local MCP server with VS Code's own MCP client in one step, so it appears in the editor's MCP server list ready to start — no config to copy. Turns on `rewst-buddy.mcp.enable` if needed and offers to open the MCP server list. VS Code receives the localhost token directly, so there is no environment variable to set.
 - `Copy MCP Config to Clipboard` — Copy (and open) a credential-free JSON config that points an **external** MCP client (Claude Desktop, Claude Code, Cursor) at the extension's local MCP server. The config carries the token via the standard `Authorization: Bearer` header, referencing it as the `REWST_BUDDY_MCP_TOKEN` environment variable rather than embedding it. Use the command's **Copy token** action to grab the localhost token (set it as that env var), or paste it in place of `${REWST_BUDDY_MCP_TOKEN}` for clients that don't expand env vars. Requires `rewst-buddy.mcp.enable`.
+- `Rotate MCP Token` — Replace the localhost MCP token after a modal confirmation. Existing MCP clients using the old token lose access until you update them; run `Copy MCP Config to Clipboard` afterward to copy the updated token/config for external clients.
 
 ## Settings
 

--- a/package.json
+++ b/package.json
@@ -333,6 +333,12 @@
 				"command": "rewst-buddy.prefix.AddMcpToVSCode",
 				"title": "Rewst Buddy: Add MCP Server to VS Code",
 				"icon": "$(plug)"
+			},
+			{
+				"command": "rewst-buddy.prefix.RotateMcpToken",
+				"title": "Rotate MCP Token",
+				"category": "Rewst Buddy",
+				"icon": "$(key)"
 			}
 		],
 		"keybindings": [

--- a/src/commands/exportedCommands.ts
+++ b/src/commands/exportedCommands.ts
@@ -1,5 +1,6 @@
 export * from './folders/index';
 export * from './mcp/index';
+export { RotateMcpToken } from './mcp/RotateMcpToken';
 export * from './server/index';
 export * from './sessions/index';
 export * from './template/index';

--- a/src/commands/mcp/RotateMcpToken.test.ts
+++ b/src/commands/mcp/RotateMcpToken.test.ts
@@ -1,7 +1,9 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import vscode from 'vscode';
+import { context } from '@global';
 import { getMcpToken, _resetMcpTokenForTesting } from '@mcp';
+import { SessionManager } from '@sessions';
 import { initTestEnvironment } from '@test';
 import { RotateMcpToken } from './RotateMcpToken';
 
@@ -33,6 +35,7 @@ suite('Unit: RotateMcpToken', () => {
 
 	setup(async () => {
 		initTestEnvironment();
+		SessionManager._resetForTesting();
 		await _resetMcpTokenForTesting();
 		warningChoice = undefined;
 		warningMessage = undefined;
@@ -66,6 +69,7 @@ suite('Unit: RotateMcpToken', () => {
 	teardown(async () => {
 		while (restores.length) restores.pop()!.restore();
 		await _resetMcpTokenForTesting();
+		SessionManager._resetForTesting();
 	});
 
 	test('rotating changes the token after confirmation', async () => {
@@ -94,5 +98,24 @@ suite('Unit: RotateMcpToken', () => {
 		assert.strictEqual(getMcpToken(), before, 'token does not rotate without confirmation');
 		assert.deepStrictEqual(infoMessages, [], 'does not report success');
 		assert.deepStrictEqual(errorMessages, [], 'does not report an error');
+	});
+
+	test('a rotation failure is surfaced as an error notification', async () => {
+		warningChoice = 'Rotate Token';
+		// rotateMcpToken persists through context.globalState.update, evaluated
+		// synchronously; making it throw drives execute() down its catch path.
+		restores.push(
+			stub(context.globalState, 'update', (() => {
+				throw new Error('persist boom');
+			}) as unknown as typeof context.globalState.update),
+		);
+
+		await new RotateMcpToken().execute();
+
+		assert.deepStrictEqual(infoMessages, [], 'does not report success when rotation fails');
+		assert.ok(
+			errorMessages.some(message => message.includes('failed to rotate MCP token')),
+			'reports the failure as an error notification',
+		);
 	});
 });

--- a/src/commands/mcp/RotateMcpToken.test.ts
+++ b/src/commands/mcp/RotateMcpToken.test.ts
@@ -1,0 +1,98 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { getMcpToken, _resetMcpTokenForTesting } from '@mcp';
+import { initTestEnvironment } from '@test';
+import { RotateMcpToken } from './RotateMcpToken';
+
+const { suite, test, setup, teardown } = Mocha;
+
+interface Restore {
+	restore(): void;
+}
+
+/** Replaces one method on a (real) vscode object and returns a restore handle. */
+function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): Restore {
+	const original = obj[key];
+	Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+	return {
+		restore() {
+			Object.defineProperty(obj, key, { value: original, configurable: true, writable: true });
+		},
+	};
+}
+
+suite('Unit: RotateMcpToken', () => {
+	const restores: Restore[] = [];
+	let warningChoice: string | undefined;
+	let warningMessage: string | undefined;
+	let warningOptions: vscode.MessageOptions | undefined;
+	let warningItems: string[] = [];
+	let infoMessages: string[] = [];
+	let errorMessages: string[] = [];
+
+	setup(async () => {
+		initTestEnvironment();
+		await _resetMcpTokenForTesting();
+		warningChoice = undefined;
+		warningMessage = undefined;
+		warningOptions = undefined;
+		warningItems = [];
+		infoMessages = [];
+		errorMessages = [];
+
+		restores.push(
+			stub(vscode.window, 'showWarningMessage', (async (
+				message: string,
+				options: vscode.MessageOptions,
+				...items: string[]
+			) => {
+				warningMessage = message;
+				warningOptions = options;
+				warningItems = items;
+				return warningChoice;
+			}) as unknown as typeof vscode.window.showWarningMessage),
+			stub(vscode.window, 'showInformationMessage', (async (message: string) => {
+				infoMessages.push(message);
+				return undefined;
+			}) as unknown as typeof vscode.window.showInformationMessage),
+			stub(vscode.window, 'showErrorMessage', (async (message: string) => {
+				errorMessages.push(message);
+				return undefined;
+			}) as unknown as typeof vscode.window.showErrorMessage),
+		);
+	});
+
+	teardown(async () => {
+		while (restores.length) restores.pop()!.restore();
+		await _resetMcpTokenForTesting();
+	});
+
+	test('rotating changes the token after confirmation', async () => {
+		const before = getMcpToken();
+		warningChoice = 'Rotate Token';
+
+		await new RotateMcpToken().execute();
+
+		assert.notStrictEqual(getMcpToken(), before, 'token rotates after confirmation');
+		assert.strictEqual(warningOptions?.modal, true, 'confirmation is modal');
+		assert.ok(warningMessage?.includes('old token'), 'warns about old-token access loss');
+		assert.ok(warningItems.includes('Rotate Token'), 'offers the destructive action');
+		assert.ok(
+			infoMessages.some(message => message.includes('MCP token rotated')),
+			'reports success',
+		);
+		assert.deepStrictEqual(errorMessages, [], 'does not report an error');
+	});
+
+	test('dismissal leaves the token unchanged', async () => {
+		const before = getMcpToken();
+		warningChoice = undefined;
+
+		await new RotateMcpToken().execute();
+
+		assert.strictEqual(getMcpToken(), before, 'token does not rotate without confirmation');
+		assert.deepStrictEqual(infoMessages, [], 'does not report success');
+		assert.deepStrictEqual(errorMessages, [], 'does not report an error');
+	});
+});

--- a/src/commands/mcp/RotateMcpToken.ts
+++ b/src/commands/mcp/RotateMcpToken.ts
@@ -1,0 +1,28 @@
+import { rotateMcpToken } from '@mcp';
+import { log } from '@utils';
+import vscode from 'vscode';
+import GenericCommand from '../GenericCommand';
+
+const ROTATE_ACTION = 'Rotate Token';
+
+export class RotateMcpToken extends GenericCommand {
+	commandName = 'RotateMcpToken';
+
+	async execute(): Promise<void> {
+		const confirm = await vscode.window.showWarningMessage(
+			'Rotate the MCP token? Existing MCP clients holding the old token will lose access until you update their config.',
+			{ modal: true },
+			ROTATE_ACTION,
+		);
+		if (confirm !== ROTATE_ACTION) return;
+
+		try {
+			rotateMcpToken();
+			log.notifyInfo(
+				'MCP token rotated. Run "Rewst Buddy: Copy MCP Config to Clipboard" to update external clients with the new token.',
+			);
+		} catch (error) {
+			log.notifyError('RotateMcpToken: failed to rotate MCP token', error);
+		}
+	}
+}


### PR DESCRIPTION
Part of the MCP server epic (#52), issue #57 (hardening) — the **token rotation / revocation** item. **Independent of the other PRs**; branches off `main`, touches only command + manifest + docs (no `McpActions.ts`).

## What

Adds a **Rotate MCP Token** command so the user can revoke MCP access. It mints a fresh endpoint token via the existing `rotateMcpToken()` (the backend already existed; this is the missing user-facing entry point), so any external client still holding the old token immediately loses access.

- Confirms with a modal first — rotating breaks connected clients until their config is updated.
- On success, points the user to **Copy MCP Config to Clipboard** to re-share the new token.

## Implementation

- `RotateMcpToken` command (`GenericCommand` + standard auto-registration), declared in `package.json` `contributes.commands` next to the other MCP commands (key icon, `Rewst Buddy` category).
- Documented in `docs/reference.md` alongside the existing MCP commands.

## Tests

- Confirmation rotates the token (`getMcpToken()` before != after), the prompt is modal and warns about old-token access loss.
- Dismissal leaves the token unchanged and reports no success.
- `npm run test:unit` — 556 passing.

## Scope

One item from the #57 tracking issue (after the audit-logging item in #64). Remaining: multi-window/which-org-exposed story, reuse chat result truncation for large MCP results, prompt-injection review, SDK bundle/license, unofficial-extension ToS posture.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Rotate MCP Token** command to generate a new local endpoint token and revoke access for external clients still using the old token (they must update configuration).
  * Includes modal confirmation and then prompts you to copy the updated MCP config to clipboard.
* **Documentation**
  * Updated the command reference and features documentation with rotation instructions and client impact.
* **Tests**
  * Added unit tests for successful rotation (with confirmation), dismissal (no change), and failure handling with an error notification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->