### PR TITLE
Add nightly pre-release channel (publish on every main merge)

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -1,0 +1,112 @@
+name: Nightly (pre-release)
+
+# Fires on every push to main and publishes a pre-release build to the VS Code
+# Marketplace. Users who opt into "pre-release" in the Extensions panel get these
+# nightlies; everyone else stays on the stable channel shipped by publish.yml.
+#
+# Versioning follows VS Code's even/odd convention: stable lives on EVEN minor
+# versions (package.json on main), and nightlies publish on the next ODD minor
+# with the commit count as a monotonic patch number — e.g. stable 0.44.x ->
+# nightly 0.45.<build>. When a release bumps package.json to 0.46.0, nightlies
+# automatically move to 0.47.<build>. Versions only ever increase across both
+# channels, which the Marketplace requires for a single extension.
+#
+# Nightlies are not tagged and get no GitHub release — only the stable Publish
+# workflow does that. The VSCE_PAT lives in the `release` environment, so only
+# these privileged jobs can read it.
+
+on:
+    push:
+        branches: [main]
+
+permissions:
+    contents: read
+
+concurrency:
+    group: nightly
+    cancel-in-progress: true
+
+jobs:
+    nightly:
+        runs-on: ubuntu-latest
+        environment: release
+        steps:
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+              with:
+                  fetch-depth: 0
+                  persist-credentials: false
+
+            # No dependency cache here: this job holds the publish token, and
+            # restoring a cache populated by a less-privileged PR run is a
+            # cache-poisoning vector. Mirrors publish.yml.
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4.4.0
+              with:
+                  node-version: 22
+
+            - run: npm ci
+
+            - name: Resolve the nightly version
+              run: |
+                  STABLE="$(node -p "require('./package.json').version")"
+                  MAJOR="$(echo "$STABLE" | cut -d. -f1)"
+                  MINOR="$(echo "$STABLE" | cut -d. -f2)"
+                  if [ $((MINOR % 2)) -ne 0 ]; then
+                    echo "::error::package.json minor version $MINOR is odd; stable must use even minors so nightlies can own the next odd minor. Bump stable to an even minor."
+                    exit 1
+                  fi
+                  ODD_MINOR=$((MINOR + 1))
+                  BUILD="$(git rev-list --count HEAD)"
+                  VERSION="${MAJOR}.${ODD_MINOR}.${BUILD}"
+                  echo "VERSION=$VERSION" >> "$GITHUB_ENV"
+                  echo "Stable on main is $STABLE; publishing nightly $VERSION"
+
+            - name: Set the package version
+              run: npm version "$VERSION" --no-git-tag-version --allow-same-version
+
+            # Bundle the pending changelog.d/ notes into this nightly's CHANGELOG.md
+            # so pre-release users see "what's new since stable". This is a PREVIEW
+            # (`--preview` writes nothing and deletes no notes) injected only into the
+            # runner's working copy before packaging — the committed CHANGELOG.md and
+            # the notes are untouched, so the real stable release still collates them.
+            # Non-fatal: if there are no pending notes (or one is invalid), the nightly
+            # ships the committed CHANGELOG.md as-is rather than failing the publish.
+            - name: Inject pending changelog notes as a nightly preview
+              run: |
+                  if SECTION="$(node scripts/changelog/build.mjs --version "$VERSION" --preview 2>/dev/null)" \
+                     && printf '%s' "$SECTION" | grep -q '^## \['; then
+                    printf '%s' "$SECTION" > /tmp/nightly-section.md
+                    node -e '
+                      const fs = require("node:fs");
+                      const section = fs.readFileSync("/tmp/nightly-section.md", "utf8").trimEnd();
+                      const cl = fs.readFileSync("CHANGELOG.md", "utf8");
+                      const marker = cl.indexOf("\n## [");
+                      const out = marker === -1
+                        ? cl.replace(/^(# Changelog\s*\n)/, (_, h) => `${h}\n${section}\n`)
+                        : cl.slice(0, marker + 1) + section + "\n\n" + cl.slice(marker + 1);
+                      fs.writeFileSync("CHANGELOG.md", out);
+                    '
+                    echo "Injected pending notes as the $VERSION nightly section."
+                  else
+                    echo "No valid pending notes; shipping the committed CHANGELOG.md as-is."
+                  fi
+
+            - name: Package the pre-release extension
+              run: npx --yes @vscode/vsce package --pre-release --no-dependencies -o "rewst-buddy-nightly-${VERSION}.vsix"
+
+            - name: Upload the vsix as a build artifact
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+              with:
+                  name: rewst-buddy-nightly-${{ env.VERSION }}
+                  path: rewst-buddy-nightly-${{ env.VERSION }}.vsix
+                  if-no-files-found: error
+
+            - name: Publish the pre-release to the VS Code Marketplace
+              env:
+                  VSCE_PAT: ${{ secrets.VSCE_PAT }}
+              run: npx --yes @vscode/vsce publish --pre-release --no-dependencies --packagePath "rewst-buddy-nightly-${VERSION}.vsix"
+
+            # Open VSX (optional). Configure OVSX_PAT in the release environment to enable.
+            # - name: Publish the pre-release to Open VSX
+            #   env:
+            #     OVSX_PAT: ${{ secrets.OVSX_PAT }}
+            #   run: npx --yes ovsx publish "rewst-buddy-nightly-${VERSION}.vsix" --pre-release -p "$OVSX_PAT"

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,6 +133,10 @@ Releases run entirely through GitHub Actions; runbook and one-time setup are in 
 
 Per-change code review happens on each feature PR (CodeRabbit + CI), not at release time.
 
+### Nightly (pre-release) channel
+
+Every push to `main` runs `nightly.yml`, which publishes a `--pre-release` build to the Marketplace. Stable rides **even** minors (`package.json`); nightlies ride the next **odd** minor as `MAJOR.<oddMinor>.<git rev-list --count HEAD>` (e.g. stable `0.44.x` ⇒ nightly `0.45.<build>`), so versions only ever increase across both channels. Stable must stay on an even minor — `nightly.yml` fails fast otherwise. Nightlies are not tagged and get no GitHub release. Details in `docs/dev/releasing.md`.
+
 ## Path Aliases (CRITICAL)
 
 **Must be configured in BOTH files:**

--- a/changelog.d/nightly-release.md
+++ b/changelog.d/nightly-release.md
@@ -1,0 +1,8 @@
+---
+category: Added
+---
+
+- **Nightly pre-release channel** — every merge to `main` now publishes a
+  pre-release build to the VS Code Marketplace. Opt in via the extension's
+  "Switch to Pre-Release Version" button in the Extensions panel to ride the
+  latest changes ahead of stable releases.

--- a/changelog.d/nightly-release.md
+++ b/changelog.d/nightly-release.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 66
 ---
 
 - **Nightly pre-release channel** — every merge to `main` now publishes a

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -32,6 +32,36 @@ release skill — these workflows are the whole process.
 > If the auto-tag ever needs re-running by hand, `npm run release:tag` from the
 > merged `main` does the same thing.
 
+## Nightly (pre-release) channel
+
+There are **two Marketplace channels for the one extension**, split by VS Code's
+even/odd minor convention:
+
+- **Stable** rides **even** minors (`package.json` on `main`, e.g. `0.44.x`) and
+  ships only through the Release flow above.
+- **Nightly** rides the next **odd** minor and ships automatically: every push to
+  `main` runs `nightly.yml`, which publishes a `--pre-release` build as
+  `MAJOR.<oddMinor>.<build>`, where `<build>` is `git rev-list --count HEAD` — a
+  monotonic commit count. So stable `0.44.x` ⇒ nightly `0.45.<build>`.
+
+The odd minor is derived from `package.json`, so when a release bumps stable to
+`0.46.0`, nightlies automatically move to `0.47.<build>`. Because even-stable is
+always below the surrounding odd-nightly and the next even-stable is above it,
+versions only ever increase across both channels — the Marketplace's
+single-extension requirement. `nightly.yml` **fails fast** if `package.json` ever
+lands on an odd minor (that would collide with the nightly minor).
+
+Before packaging, the nightly injects the pending `changelog.d/` notes into its
+`CHANGELOG.md` as a preview section (`build.mjs --preview`), so pre-release users
+see "what's new since stable". This is **runner-only and non-destructive** — the
+committed `CHANGELOG.md` and the notes are untouched (the real stable release
+still collates them), and an empty or invalid note never fails the publish.
+
+Nightlies are **not tagged and get no GitHub release** — only stable does. They
+reuse the same `release` environment and `VSCE_PAT` as Publish. Users opt in with
+the extension's **"Switch to Pre-Release Version"** button in the Extensions
+panel.
+
 ## One-time GitHub setup (required for the gates)
 
 These live in repo settings, not in code — set them once:


### PR DESCRIPTION
## What

Adds a **nightly pre-release channel** so every merge to `main` ships to the VS Code Marketplace's pre-release track, separate from the deliberate stable releases.

## Approach

Single-branch (no `dev`): PRs keep going to `main`, each merge publishes a nightly; stable stays the existing manual **Prepare release → merge = publish** flow. Two Marketplace channels for one extension, split by VS Code's even/odd minor convention.

## Versioning

- Stable rides **even** minors (`package.json`, currently `0.44.1`).
- Nightly rides the next **odd** minor: `MAJOR.<minor+1>.<git rev-list --count HEAD>` — e.g. `0.45.171`. The commit-count patch is monotonic and deterministic (no timestamps).
- Auto-tracks stable: a release to `0.46.0` moves nightlies to `0.47.<build>`. Even-stable always sits below the surrounding odd-nightly and the next even-stable sits above it, so versions only ever increase across both channels (the Marketplace's single-extension rule).
- `nightly.yml` **fails fast** if `package.json` ever lands on an odd minor.

## Changelog integration

The changelog collation stays a **stable-release-only, destructive** step (it `unlink`s the notes). Nightly never runs it. Instead, before packaging, nightly injects the pending `changelog.d/` notes into its `CHANGELOG.md` as a `--preview` section — runner-only, non-destructive (committed `CHANGELOG.md` and notes untouched), and non-fatal if a note is empty/invalid. Pre-release users get an accurate "what's new since stable".

## Notes

- Reuses the existing `release` environment + `VSCE_PAT`; no new secrets/setup.
- Nightlies are **not tagged** and get **no GitHub release** — only stable does.
- Same hardening as `publish.yml`: no dependency cache, `persist-credentials: false`, SHA-pinned actions.
- Nightly also fires on the release-PR merge commit (harmless — different minor, just an extra pre-release alongside stable). Can add a skip for `release/*` merge commits if preferred.

## Docs
- `docs/dev/releasing.md`: new "Nightly (pre-release) channel" section.
- `CLAUDE.md`: short nightly note under Releasing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Nightly pre-release builds are now automatically published to the VS Code Marketplace on every merge to main. Users can opt-in to pre-release updates using the extension's "Switch to Pre-Release Version" option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->