### PR TITLE
Run nightly in a dedicated main-scoped environment

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,8 +12,9 @@ name: Nightly (pre-release)
 # channels, which the Marketplace requires for a single extension.
 #
 # Nightlies are not tagged and get no GitHub release — only the stable Publish
-# workflow does that. The VSCE_PAT lives in the `release` environment, so only
-# these privileged jobs can read it.
+# workflow does that. This job runs in the `nightly` environment (scoped to the
+# main branch with its own VSCE_PAT), so the `release` environment stays gated to
+# v* tags and its publish token is never reachable from branch code.
 
 on:
     push:
@@ -29,7 +30,7 @@ concurrency:
 jobs:
     nightly:
         runs-on: ubuntu-latest
-        environment: release
+        environment: nightly
         steps:
             - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
               with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,9 +12,12 @@ name: Nightly (pre-release)
 # channels, which the Marketplace requires for a single extension.
 #
 # Nightlies are not tagged and get no GitHub release — only the stable Publish
-# workflow does that. This job runs in the `nightly` environment (scoped to the
-# main branch with its own VSCE_PAT), so the `release` environment stays gated to
-# v* tags and its publish token is never reachable from branch code.
+# workflow does that. This job runs in the `nightly` environment, scoped to the
+# `main` branch; the stable `release` environment stays scoped to `v*` tags. Each
+# environment answers only the ref that should drive it, so the publish token is
+# reachable only from protected refs (tags for stable, main for nightly) — never
+# from an unmerged PR/feature branch — even though both environments reuse the
+# same VSCE_PAT (a Marketplace PAT can't be scoped to a single release anyway).
 
 on:
     push:
@@ -106,7 +109,7 @@ jobs:
                   VSCE_PAT: ${{ secrets.VSCE_PAT }}
               run: npx --yes @vscode/vsce publish --pre-release --no-dependencies --packagePath "rewst-buddy-nightly-${VERSION}.vsix"
 
-            # Open VSX (optional). Configure OVSX_PAT in the release environment to enable.
+            # Open VSX (optional). Configure OVSX_PAT in the nightly environment to enable.
             # - name: Publish the pre-release to Open VSX
             #   env:
             #     OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -58,10 +58,13 @@ committed `CHANGELOG.md` and the notes are untouched (the real stable release
 still collates them), and an empty or invalid note never fails the publish.
 
 Nightlies are **not tagged and get no GitHub release** — only stable does. The
-job runs in its own **`nightly`** environment (scoped to the `main` branch, with
-its own `VSCE_PAT`), so the `release` environment stays gated to `v*` tags and
-its publish token is never reachable from branch code. Users opt in with the
-extension's **"Switch to Pre-Release Version"** button in the Extensions panel.
+job runs in its own **`nightly`** environment, scoped to the `main` branch, while
+the stable `release` environment stays scoped to `v*` tags. Each environment
+answers only the ref that should drive it, so the publish token is reachable only
+from protected refs (tags for stable, `main` for nightly) and never from an
+unmerged PR or feature branch — even though both environments reuse the same
+`VSCE_PAT`. Users opt in with the extension's **"Switch to Pre-Release Version"**
+button in the Extensions panel.
 
 ## One-time GitHub setup (required for the gates)
 
@@ -79,14 +82,17 @@ note` status checks; block direct pushes and force-pushes. CodeRabbit's
   `OVSX_PAT` for Open VSX and uncomment that step in `publish.yml`.
 - **`nightly` environment** (Settings → Environments): used by `nightly.yml` for
   the pre-release channel. Restrict its **deployment branches** to **`main` only**
-  (custom branch policy), and store a **`VSCE_PAT`** secret here too — it can be
-  the same Marketplace PAT as `release`, or a separate one so revoking the nightly
-  token doesn't affect stable. Leave it with **no required reviewers** (nightlies
-  publish automatically on merge). Keeping this separate from `release` is
-  deliberate: `release` stays gated to `v*` tags, so its token is never reachable
-  from branch code. The environment and its branch policy can be created with the
-  GitHub API (`gh api .../environments/nightly` + `.../deployment-branch-policies`);
-  only the secret must be added by hand.
+  (custom branch policy), and store the **`VSCE_PAT`** secret here too — reuse the
+  same Marketplace PAT as `release` (a Marketplace PAT can't be scoped to a single
+  release, so a second token buys no real isolation and just doubles what you
+  rotate). Leave it with **no required reviewers** (nightlies publish
+  automatically on merge). The split from `release` is about **deployment refs,
+  not the credential**: `release` answers only `v*` tags and `nightly` only the
+  `main` branch, so neither can be triggered from an unmerged PR/feature branch,
+  and the tag path can't mint a nightly nor the branch path a stable release. The
+  environment and its branch policy can be created with the GitHub API (`gh api
+  .../environments/nightly` + `.../deployment-branch-policies`); only the secret
+  must be added by hand.
 - **Release-bot GitHub App** (for the Prepare release PR): the default
   `GITHUB_TOKEN` cannot open a PR, and a PR it opened would not trigger the
   required CI checks. So `release.yml` mints a short-lived token from a GitHub

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -57,10 +57,11 @@ see "what's new since stable". This is **runner-only and non-destructive** — t
 committed `CHANGELOG.md` and the notes are untouched (the real stable release
 still collates them), and an empty or invalid note never fails the publish.
 
-Nightlies are **not tagged and get no GitHub release** — only stable does. They
-reuse the same `release` environment and `VSCE_PAT` as Publish. Users opt in with
-the extension's **"Switch to Pre-Release Version"** button in the Extensions
-panel.
+Nightlies are **not tagged and get no GitHub release** — only stable does. The
+job runs in its own **`nightly`** environment (scoped to the `main` branch, with
+its own `VSCE_PAT`), so the `release` environment stays gated to `v*` tags and
+its publish token is never reachable from branch code. Users opt in with the
+extension's **"Switch to Pre-Release Version"** button in the Extensions panel.
 
 ## One-time GitHub setup (required for the gates)
 
@@ -76,6 +77,16 @@ note` status checks; block direct pushes and force-pushes. CodeRabbit's
   read it. Leave it with **no required reviewers**: merging the release PR is the
   publish approval, so a second environment gate would just re-ask. Optionally add
   `OVSX_PAT` for Open VSX and uncomment that step in `publish.yml`.
+- **`nightly` environment** (Settings → Environments): used by `nightly.yml` for
+  the pre-release channel. Restrict its **deployment branches** to **`main` only**
+  (custom branch policy), and store a **`VSCE_PAT`** secret here too — it can be
+  the same Marketplace PAT as `release`, or a separate one so revoking the nightly
+  token doesn't affect stable. Leave it with **no required reviewers** (nightlies
+  publish automatically on merge). Keeping this separate from `release` is
+  deliberate: `release` stays gated to `v*` tags, so its token is never reachable
+  from branch code. The environment and its branch policy can be created with the
+  GitHub API (`gh api .../environments/nightly` + `.../deployment-branch-policies`);
+  only the secret must be added by hand.
 - **Release-bot GitHub App** (for the Prepare release PR): the default
   `GITHUB_TOKEN` cannot open a PR, and a PR it opened would not trigger the
   required CI checks. So `release.yml` mints a short-lived token from a GitHub

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -116,5 +116,10 @@ note` status checks; block direct pushes and force-pushes. CodeRabbit's
   `persist-credentials: false` except where a push is required.
 - Actions are referenced by major version tag. For supply-chain hardening, pin
   them to full commit SHAs (e.g. with `pin-github-action` or `zizmor`).
-- The publish token lives only in the `release` environment and is referenced
-  only by the publish step, behind the required-reviewer gate.
+- The publish token (`VSCE_PAT`) lives in the `release` and `nightly`
+  environments and is referenced only by their publish steps. The security
+  boundary is each environment's **deployment-ref scoping**, not the token (the
+  same PAT is reused): `release` answers only `v*` tags — it ships only when the
+  tag-driven Publish runs, which a merged release PR is the gate for — and
+  `nightly` answers only the `main` branch, publishing pre-releases automatically
+  on merge. So an unmerged PR or feature branch can read neither secret.


### PR DESCRIPTION
Follow-up to #66. The nightly job used `environment: release`, but the `release`
environment is gated to `v*` tags (so its `VSCE_PAT` is unreachable from branch
code). Nightly runs on `main`, so GitHub rejected the deployment:

> Branch "main" is not allowed to deploy to release due to environment protection rules.

This points nightly at its own **`nightly`** environment — scoped to the `main`
branch, with its own `VSCE_PAT` — so the `release` environment stays tag-gated
and the stable publish token is never reachable from branch code.

The `nightly` environment and its `main`-only branch policy are already created
on the repo. **Remaining manual step:** add the `VSCE_PAT` secret to the
`nightly` environment (same Marketplace PAT as `release`, or a separate one).

`skip-changelog`: the nightly channel was already announced in #66's note; this
is internal CI plumbing with no additional user-facing change.

Docs (`docs/dev/releasing.md`) updated to describe the `nightly` environment in
both the nightly section and the one-time setup list.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated nightly pre-release instructions: nightlies are untagged, publish no GitHub releases, and run in a dedicated `nightly` environment scoped to `main` (stable remains `release` scoped to `v*` tags).
  * Expanded setup and hardening guidance, including how environment-based deployment-ref scoping controls access to publishing tokens and how to configure the `nightly` environment via policy/API.

* **Configuration**
  * Updated the nightly publish workflow to target the `nightly` GitHub environment (instead of `release`) so the correct environment-scoped settings apply.
  * Refreshed related comments for optional Open VSX token configuration in the `nightly` environment.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->