### PR TITLE
Cache oversized MCP results and add a result_read paging tool (#57)

### DIFF
--- a/changelog.d/mcp-result-paging.md
+++ b/changelog.d/mcp-result-paging.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 70
 ---
 
 - Oversized MCP results now return a preview plus cached id, so agents can page or search the full result with the `result_read` MCP tool.

--- a/changelog.d/mcp-result-paging.md
+++ b/changelog.d/mcp-result-paging.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- Oversized MCP results now return a preview plus cached id, so agents can page or search the full result with the `result_read` MCP tool.

--- a/docs/features.md
+++ b/docs/features.md
@@ -104,7 +104,7 @@ Cage-Free Rewsty is still told your VS Code working directory when one is open, 
 
 Rewst-specific actions are exposed through the Rewst Buddy MCP server instead of the chat LM tool surface. MCP exposure uses three switches:
 
-- `rewst-buddy.mcp.enable` exposes all read capabilities: `list_orgs`, `list_templates`, `get_template`, `list_workflows`, `get_workflow`, `rewst_graphql_query`, `buddy_graphql_schema`, `list_template_links`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_render_jinja`, and `buddy_action_search`.
+- `rewst-buddy.mcp.enable` exposes all read capabilities: `list_orgs`, `list_templates`, `get_template`, `list_workflows`, `get_workflow`, `rewst_graphql_query`, `buddy_graphql_schema`, `list_template_links`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_render_jinja`, `buddy_action_search`, and `result_read`.
 - `rewst-buddy.mcp.enableWriteTools` exposes the workflow write helpers `buddy_workflow_edit`, `buddy_workflow_autolayout`, and `buddy_workflow_run`.
 - `rewst-buddy.mcp.enableDangerousGraphqlMutation` exposes only `rewst_graphql_mutate`, the raw GraphQL mutation tool.
 
@@ -112,7 +112,7 @@ The old combined chat tool `buddy_graphql` is not exposed; its MCP replacement i
 
 When the server is registered with VS Code's own MCP client (the `Add MCP Server to VS Code` command), flipping any of these exposure switches re-advertises the server with a new version, so VS Code reconnects and refreshes the tool set in chat — no window reload needed.
 
-Large MCP outputs are bounded at the MCP response boundary; the retired chat-only `buddy_result_read` cache is no longer part of the chat tool protocol.
+Oversized MCP results are cached in memory and returned with a preview plus a short id; page or search the cached result with the MCP-only `result_read` tool. The retired chat-only `buddy_result_read` cache is no longer part of the chat tool protocol.
 
 The local MCP endpoint is guarded by a persistent localhost token. If it is ever exposed, run `Rewst Buddy: Rotate MCP Token` to replace it after a modal confirmation — existing MCP clients holding the old token lose access until you re-copy the config with `Copy MCP Config to Clipboard`.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -105,8 +105,8 @@ Cage-Free Rewsty is still told your VS Code working directory when one is open, 
 Rewst-specific actions are exposed through the Rewst Buddy MCP server instead of the chat LM tool surface. MCP exposure uses three switches:
 
 - `rewst-buddy.mcp.enable` exposes all read capabilities: `list_orgs`, `list_templates`, `get_template`, `list_workflows`, `get_workflow`, `rewst_graphql_query`, `buddy_graphql_schema`, `list_template_links`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_render_jinja`, `buddy_action_search`, and `result_read`.
-- `rewst-buddy.mcp.enableWriteTools` exposes the workflow write helpers `buddy_workflow_edit`, `buddy_workflow_autolayout`, and `buddy_workflow_run`.
-- `rewst-buddy.mcp.enableDangerousGraphqlMutation` exposes only `rewst_graphql_mutate`, the raw GraphQL mutation tool.
+- `rewst-buddy.mcp.enableWriteTools` adds the workflow write helpers `buddy_workflow_edit`, `buddy_workflow_autolayout`, and `buddy_workflow_run`.
+- `rewst-buddy.mcp.enableDangerousGraphqlMutation` unlocks only `rewst_graphql_mutate`, the raw GraphQL mutation tool.
 
 The old combined chat tool `buddy_graphql` is not exposed; its MCP replacement is the query/mutate pair. Workflow edits, auto-layout, runs, and raw GraphQL mutations still require approval inside VS Code before anything is sent to Rewst. `rewst_graphql_mutate` is intentionally separate from `enableWriteTools` because it can run arbitrary mutations against the live org.
 

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -12,3 +12,10 @@ export {
 	setMcpMutationApprover,
 	type McpMutationApprover,
 } from './graphqlMutateCapability';
+export {
+	MCP_MAX_OUTPUT_CHARS,
+	RESULT_READ_TOOL_NAME,
+	_resetMcpResultCacheForTesting,
+	formatMcpOutput,
+	mcpResultCache,
+} from './resultReadCapability';

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -11,6 +11,7 @@ import {
 	hasChatCapability,
 	mcpCapabilities,
 } from './registry';
+import { RESULT_READ_TOOL_NAME } from './resultReadCapability';
 import {
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
@@ -101,6 +102,7 @@ suite('Unit: capability registry', () => {
 				'list_template_links',
 				'buddy_graphql_schema',
 				'rewst_graphql_mutate',
+				RESULT_READ_TOOL_NAME,
 			]) {
 				assert.ok(names.includes(expected), `${expected} exposed to MCP`);
 			}

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -2,6 +2,7 @@ import type { Capability, CapabilityGroup } from './Capability';
 import { WORKFLOW_CHAT_CAPABILITIES, WORKSPACE_CHAT_CAPABILITIES } from './chatToolCapabilities';
 import { GRAPHQL_CAPABILITIES } from './graphqlCapabilities';
 import { graphqlMutateCapability } from './graphqlMutateCapability';
+import { resultReadCapability } from './resultReadCapability';
 import { READ_CAPABILITIES } from './rewstReadCapabilities';
 
 /**
@@ -15,6 +16,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...GRAPHQL_CAPABILITIES,
 	...READ_CAPABILITIES,
 	graphqlMutateCapability,
+	resultReadCapability,
 ];
 
 const BY_NAME = new Map(CAPABILITY_REGISTRY.map(capability => [capability.spec.name, capability]));

--- a/src/capabilities/resultReadCapability.test.ts
+++ b/src/capabilities/resultReadCapability.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
 import type { CapabilityContext } from './Capability';
 import {
 	MCP_MAX_OUTPUT_CHARS,
@@ -24,6 +25,7 @@ function ignoredContext(): CapabilityContext {
 
 suite('Unit: resultReadCapability', () => {
 	setup(() => {
+		initTestEnvironment();
 		_resetMcpResultCacheForTesting();
 	});
 

--- a/src/capabilities/resultReadCapability.test.ts
+++ b/src/capabilities/resultReadCapability.test.ts
@@ -1,0 +1,146 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import type { CapabilityContext } from './Capability';
+import {
+	MCP_MAX_OUTPUT_CHARS,
+	McpResultCache,
+	RESULT_READ_TOOL_NAME,
+	_resetMcpResultCacheForTesting,
+	formatMcpOutput,
+	mcpResultCache,
+	resultReadCapability,
+} from './resultReadCapability';
+
+const { suite, test, setup } = Mocha;
+
+function cacheId(result: ReturnType<McpResultCache['store']>): string {
+	assert.ok('id' in result, 'result was stored');
+	return result.id;
+}
+
+function ignoredContext(): CapabilityContext {
+	return undefined as unknown as CapabilityContext;
+}
+
+suite('Unit: resultReadCapability', () => {
+	setup(() => {
+		_resetMcpResultCacheForTesting();
+	});
+
+	suite('formatMcpOutput', () => {
+		test('returns output inline when it is at or below the threshold', () => {
+			const cache = new McpResultCache();
+			const text = 'x'.repeat(MCP_MAX_OUTPUT_CHARS);
+
+			assert.strictEqual(formatMcpOutput('list_templates', text, cache), text);
+			assert.strictEqual(cache.size, 0);
+		});
+
+		test('caches oversized output and returns preview with paging instructions', () => {
+			const cache = new McpResultCache();
+			const text = `${'x'.repeat(MCP_MAX_OUTPUT_CHARS)}tail`;
+			const formatted = formatMcpOutput('list_templates', text, cache);
+
+			assert.ok(formatted.startsWith(text.slice(0, MCP_MAX_OUTPUT_CHARS)));
+			assert.match(formatted, /cached in memory as id "[0-9a-f]{8}"/);
+			assert.ok(formatted.includes(`"offset":${MCP_MAX_OUTPUT_CHARS}`));
+			assert.ok(formatted.includes(RESULT_READ_TOOL_NAME));
+			assert.ok(formatted.includes(`{"id":"`));
+			assert.ok(formatted.includes(`"search":"<text>"`));
+			assert.strictEqual(cache.size, 1);
+		});
+
+		test('passes result_read output through without re-caching it', () => {
+			const cache = new McpResultCache();
+			const text = 'x'.repeat(MCP_MAX_OUTPUT_CHARS + 1);
+
+			assert.strictEqual(formatMcpOutput(RESULT_READ_TOOL_NAME, text, cache), text);
+			assert.strictEqual(cache.size, 0);
+		});
+
+		test('returns a preview with a cache-budget note when the result is too large to store', () => {
+			const cache = new McpResultCache(8);
+			const text = 'x'.repeat(MCP_MAX_OUTPUT_CHARS + 1);
+			const formatted = formatMcpOutput('list_templates', text, cache);
+
+			assert.ok(formatted.startsWith(text.slice(0, MCP_MAX_OUTPUT_CHARS)));
+			assert.ok(formatted.includes('exceeds the in-memory cache budget'));
+			assert.strictEqual(cache.size, 0);
+		});
+	});
+
+	suite('result_read run', () => {
+		test('returns a requested slice with a continuation footer', async () => {
+			const id = cacheId(mcpResultCache.store('list_templates', '0123456789abcdef'));
+
+			const output = await resultReadCapability.run({ id, offset: '4', limit: '6' }, ignoredContext());
+
+			assert.ok(output.startsWith(`Cached result "${id}" (list_templates), characters 4-10 of 16.`));
+			assert.ok(output.includes('\n\n456789\n'));
+			assert.ok(output.includes(`{"id":"${id}","offset":10}`));
+		});
+
+		test('marks the final slice as the end of the result', async () => {
+			const id = cacheId(mcpResultCache.store('list_templates', '0123456789abcdef'));
+
+			const output = await resultReadCapability.run({ id, offset: 10, limit: 100 }, ignoredContext());
+
+			assert.ok(output.includes('abcdef'));
+			assert.ok(output.endsWith('(end of result)'));
+		});
+
+		test('searches matching lines with line numbers and caps hits', async () => {
+			const lines = Array.from({ length: 60 }, (_, i) => `row ${i + 1} target value`);
+			const id = cacheId(mcpResultCache.store('rewst_graphql_query', lines.join('\n')));
+
+			const output = await resultReadCapability.run({ id, search: 'target' }, ignoredContext());
+			const hitLines = output.split('\n').filter(line => /^\d+:/.test(line));
+
+			assert.strictEqual(hitLines.length, 50);
+			assert.ok(hitLines[0].startsWith('1: row 1 target'));
+			assert.ok(hitLines[49].startsWith('50: row 50 target'));
+			assert.ok(output.includes('10 more matching line(s)'));
+		});
+
+		test('search clamps long matching lines', async () => {
+			const id = cacheId(mcpResultCache.store('rewst_graphql_query', `${'x'.repeat(600)} target`));
+
+			const output = await resultReadCapability.run({ id, search: 'target' }, ignoredContext());
+			const hit = output.split('\n').find(line => line.startsWith('1: '));
+
+			assert.ok(hit);
+			assert.ok(hit.length < 520);
+			assert.ok(hit.endsWith('...'));
+		});
+
+		test('throws a clear error when id is missing', async () => {
+			await assert.rejects(
+				resultReadCapability.run({}, ignoredContext()),
+				(error: unknown) => error instanceof Error && error.message.includes('requires an "id"'),
+			);
+		});
+
+		test('throws a clear error when the cached id is absent or evicted', async () => {
+			await assert.rejects(
+				resultReadCapability.run({ id: 'missing1' }, ignoredContext()),
+				(error: unknown) =>
+					error instanceof Error &&
+					error.message.includes('No cached MCP result for id "missing1"') &&
+					error.message.includes('rerun the original tool'),
+			);
+		});
+	});
+
+	suite('McpResultCache', () => {
+		test('evicts oldest entries when storing a new result would exceed the budget', () => {
+			const cache = new McpResultCache(10);
+			const first = cacheId(cache.store('first_tool', '123456'));
+			const second = cacheId(cache.store('second_tool', 'abcdef'));
+
+			assert.strictEqual(cache.get(first), undefined);
+			assert.strictEqual(cache.get(second)?.text, 'abcdef');
+			assert.strictEqual(cache.size, 1);
+			assert.strictEqual(cache.usedBytes, 6);
+		});
+	});
+});

--- a/src/capabilities/resultReadCapability.ts
+++ b/src/capabilities/resultReadCapability.ts
@@ -1,0 +1,200 @@
+import { randomUUID } from 'crypto';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability } from './Capability';
+
+export const RESULT_READ_TOOL_NAME = 'result_read';
+export const MCP_MAX_OUTPUT_CHARS = 24_000;
+
+const MCP_RESULT_CACHE_LIMIT_BYTES = 64 * 1024 * 1024;
+const DEFAULT_READ_LIMIT = 6_000;
+const MAX_READ_LIMIT = 8_000;
+const MAX_SEARCH_HITS = 50;
+const SEARCH_OUTPUT_CHARS = 6_000;
+const MAX_LINE_CHARS = 500;
+
+interface CacheEntry {
+	id: string;
+	tool: string;
+	text: string;
+	bytes: number;
+}
+
+type StoreResult = { id: string } | { tooLarge: true; bytes: number };
+
+export class McpResultCache {
+	private entries = new Map<string, CacheEntry>();
+	private totalBytes = 0;
+
+	constructor(private readonly limitBytes: number = MCP_RESULT_CACHE_LIMIT_BYTES) {}
+
+	store(tool: string, text: string): StoreResult {
+		const bytes = Buffer.byteLength(text, 'utf8');
+		if (bytes > this.limitBytes) return { tooLarge: true, bytes };
+		while (this.totalBytes + bytes > this.limitBytes && this.entries.size > 0) this.evictOldest();
+		const id = this.freshId();
+		this.entries.set(id, { id, tool, text, bytes });
+		this.totalBytes += bytes;
+		return { id };
+	}
+
+	get(id: string): CacheEntry | undefined {
+		return this.entries.get(id);
+	}
+
+	get size(): number {
+		return this.entries.size;
+	}
+
+	get usedBytes(): number {
+		return this.totalBytes;
+	}
+
+	clear(): void {
+		this.entries.clear();
+		this.totalBytes = 0;
+	}
+
+	private evictOldest(): void {
+		const oldest = this.entries.keys().next().value as string | undefined;
+		if (oldest === undefined) return;
+		const entry = this.entries.get(oldest);
+		if (entry) this.totalBytes -= entry.bytes;
+		this.entries.delete(oldest);
+	}
+
+	private freshId(): string {
+		let id = randomUUID().slice(0, 8);
+		while (this.entries.has(id)) id = randomUUID().slice(0, 8);
+		return id;
+	}
+}
+
+export const mcpResultCache = new McpResultCache();
+
+export function formatMcpOutput(toolName: string, text: string, cache: McpResultCache = mcpResultCache): string {
+	if (toolName === RESULT_READ_TOOL_NAME) return text;
+	if (text.length <= MCP_MAX_OUTPUT_CHARS) return text;
+
+	const preview = text.slice(0, MCP_MAX_OUTPUT_CHARS);
+	const bytes = Buffer.byteLength(text, 'utf8');
+	const stored = cache.store(toolName, text);
+	if ('tooLarge' in stored) {
+		return [
+			preview,
+			`...(output exceeded ${MCP_MAX_OUTPUT_CHARS} characters; the full ${formatBytes(bytes)} result exceeds the in-memory cache budget and cannot be paged. Narrow the request and rerun the original tool.)`,
+		].join('\n');
+	}
+
+	return [
+		preview,
+		`...(output exceeded ${MCP_MAX_OUTPUT_CHARS} characters; the full result is cached in memory as id "${stored.id}" and is ${formatBytes(bytes)} (${bytes} bytes).)`,
+		`Continue with the ${RESULT_READ_TOOL_NAME} MCP tool: {"id":"${stored.id}","offset":${preview.length}}`,
+		`Search cached result with the ${RESULT_READ_TOOL_NAME} MCP tool: {"id":"${stored.id}","search":"<text>"}`,
+	].join('\n');
+}
+
+const resultReadSpec: ToolSpec = {
+	name: RESULT_READ_TOOL_NAME,
+	description:
+		'Pages or searches an oversized cached Rewst Buddy MCP result by id. The cache is in-memory only; an id can be evicted under memory pressure, so rerun the original tool if it is gone.',
+	args: '{"id": string, "offset"?: number, "limit"?: number, "search"?: string}',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			id: { type: 'string', description: 'Cached result id returned by an oversized MCP tool result.' },
+			offset: { type: 'number', description: 'Character offset to start reading from (default 0).' },
+			limit: {
+				type: 'number',
+				description: `Maximum characters to return (default ${DEFAULT_READ_LIMIT}, max ${MAX_READ_LIMIT}).`,
+			},
+			search: {
+				type: 'string',
+				description: 'Search text; returns matching lines with line numbers instead of a slice.',
+			},
+		},
+		required: ['id'],
+	},
+};
+
+export const resultReadCapability: Capability = {
+	spec: resultReadSpec,
+	group: 'result',
+	access: 'read',
+	chat: false,
+	mcp: true,
+	requiresOrg: false,
+	async run(input: Record<string, unknown>, _ctx): Promise<string> {
+		const id = asString(input, 'id');
+		if (!id) throw new Error('result_read requires an "id" from a previous oversized MCP result.');
+		const entry = mcpResultCache.get(id);
+		if (!entry) {
+			throw new Error(
+				`No cached MCP result for id "${id}". The in-memory cache may have evicted it or it may be absent; rerun the original tool to regenerate it.`,
+			);
+		}
+		const search = asString(input, 'search');
+		if (search !== undefined) return searchCachedOutput(entry, search);
+		const offset = clampInt(input.offset, 0, entry.text.length, 0);
+		const limit = clampInt(input.limit, 1, MAX_READ_LIMIT, DEFAULT_READ_LIMIT);
+		return sliceCachedOutput(entry, offset, limit);
+	},
+};
+
+function sliceCachedOutput(entry: CacheEntry, offset: number, limit: number): string {
+	const end = Math.min(offset + limit, entry.text.length);
+	const chunk = entry.text.slice(offset, end);
+	const header = `Cached result "${entry.id}" (${entry.tool}), characters ${offset}-${end} of ${entry.text.length}.`;
+	const footer =
+		end < entry.text.length
+			? `\n...(more; continue with ${RESULT_READ_TOOL_NAME}: {"id":"${entry.id}","offset":${end}})`
+			: '\n(end of result)';
+	return `${header}\n\n${chunk}${footer}`;
+}
+
+function searchCachedOutput(entry: CacheEntry, query: string): string {
+	const needle = query.toLowerCase();
+	const hits: string[] = [];
+	let matches = 0;
+	let outputChars = 0;
+
+	for (const [index, line] of entry.text.split('\n').entries()) {
+		if (!line.toLowerCase().includes(needle)) continue;
+		matches++;
+		if (hits.length >= MAX_SEARCH_HITS) continue;
+		const rendered = `${index + 1}: ${clampLine(line)}`;
+		const nextChars = outputChars + rendered.length + (hits.length > 0 ? 1 : 0);
+		if (nextChars > SEARCH_OUTPUT_CHARS) continue;
+		hits.push(rendered);
+		outputChars = nextChars;
+	}
+
+	if (matches === 0) return `No lines in cached result "${entry.id}" match "${query}".`;
+	const omitted = matches - hits.length;
+	const tail = omitted > 0 ? `\n...(${omitted} more matching line(s); narrow the search)` : '';
+	return `${matches} matching line(s) in cached result "${entry.id}" for "${query}":\n${hits.join('\n')}${tail}`;
+}
+
+function clampLine(line: string): string {
+	return line.length > MAX_LINE_CHARS ? `${line.slice(0, MAX_LINE_CHARS)}...` : line;
+}
+
+function asString(input: Record<string, unknown>, key: string): string | undefined {
+	const value = input[key];
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+function clampInt(value: unknown, min: number, max: number, fallback: number): number {
+	const n = typeof value === 'number' ? value : typeof value === 'string' ? Number(value) : NaN;
+	if (!Number.isFinite(n)) return fallback;
+	return Math.min(max, Math.max(min, Math.floor(n)));
+}
+
+function formatBytes(bytes: number): string {
+	if (bytes < 1024) return `${bytes} B`;
+	if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+	return `${(bytes / 1024 / 1024).toFixed(1)} MB`;
+}
+
+export function _resetMcpResultCacheForTesting(): void {
+	mcpResultCache.clear();
+}

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -188,6 +188,9 @@ suite('Unit: McpActions', () => {
 			assert.ok(
 				first.text.length < templates.map(template => `${template.name} (${template.id})`).join('\n').length,
 			);
+			const listCalls = wrapper.getCallsFor('listTemplates');
+			assert.strictEqual(listCalls.length, 1, 'the org templates are fetched once for the oversized call');
+			assert.strictEqual(listCalls[0].variables.orgId, 'org-1', 'list_templates is scoped to the requested org');
 
 			const second = await callTool(
 				{ name: RESULT_READ_TOOL_NAME, arguments: { id, offset: MCP_MAX_OUTPUT_CHARS } },
@@ -198,6 +201,11 @@ suite('Unit: McpActions', () => {
 			assert.ok(second.text.startsWith(`Cached result "${id}" (list_templates)`));
 			assert.ok(second.text.includes(`characters ${MCP_MAX_OUTPUT_CHARS}-`));
 			assert.ok(second.text.includes('Template'));
+			assert.strictEqual(
+				wrapper.getCallsFor('listTemplates').length,
+				1,
+				'paging serves from the in-memory cache without re-hitting the API',
+			);
 		});
 
 		test('list_template_links is callable over MCP without an orgId', async () => {

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -179,7 +179,7 @@ suite('Unit: McpActions', () => {
 			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery(templates) });
 
 			const first = await callTool({ name: 'list_templates', arguments: { orgId: 'org-1' } }, settings());
-			const id = /cached in memory as id "([0-9a-f]{8})"/.exec(first.text)?.[1];
+			const id = /"id":"([^"]+)"/.exec(first.text)?.[1];
 
 			assert.ok(id, 'oversized output includes a cached result id');
 			assert.ok(first.text.startsWith('Template 1'));

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -1,5 +1,6 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
+import { MCP_MAX_OUTPUT_CHARS, RESULT_READ_TOOL_NAME, _resetMcpResultCacheForTesting } from '@capabilities';
 import { SessionManager, type Session } from '@sessions';
 import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import { log } from '@utils';
@@ -121,12 +122,14 @@ suite('Unit: McpActions', () => {
 		_resetMcpThrottleForTesting();
 		_resetApprovedMutationScopes();
 		_resetMcpMutationApproverForTesting();
+		_resetMcpResultCacheForTesting();
 	});
 
 	teardown(() => {
 		SessionManager._resetForTesting();
 		_resetApprovedMutationScopes();
 		_resetMcpMutationApproverForTesting();
+		_resetMcpResultCacheForTesting();
 	});
 
 	suite('listTools()', () => {
@@ -139,6 +142,7 @@ suite('Unit: McpActions', () => {
 			assert.ok(names.includes('get_workflow'));
 			assert.ok(names.includes('rewst_graphql_query'), 'read-only GraphQL query is available on MCP');
 			assert.ok(names.includes('list_template_links'), 'workspace helper is available on MCP');
+			assert.ok(names.includes(RESULT_READ_TOOL_NAME), 'cached-result reader is available on MCP');
 			assert.ok(!names.includes('buddy_graphql'), 'chat write tool is not on MCP');
 			assert.ok(names.includes('buddy_graphql_schema'), 'schema introspection is available on MCP');
 			assert.ok(!names.includes('rewst_graphql_mutate'), 'raw GraphQL mutation needs its own dangerous toggle');
@@ -162,6 +166,38 @@ suite('Unit: McpActions', () => {
 			const result = await callTool({ name: 'list_templates', arguments: { orgId: 'org-1' } }, settings());
 			assert.ok(result.text.includes('Welcome (t-1)'));
 			assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 1);
+		});
+
+		test('oversized tool output returns a cached preview that result_read can page', async () => {
+			const { wrapper } = useSession('org-1');
+			const templates = Array.from({ length: 200 }, (_, i) =>
+				Fixtures.template({
+					id: `template-${i + 1}`,
+					name: `Template ${i + 1} ${'x'.repeat(180)}`,
+				}),
+			);
+			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery(templates) });
+
+			const first = await callTool({ name: 'list_templates', arguments: { orgId: 'org-1' } }, settings());
+			const id = /cached in memory as id "([0-9a-f]{8})"/.exec(first.text)?.[1];
+
+			assert.ok(id, 'oversized output includes a cached result id');
+			assert.ok(first.text.startsWith('Template 1'));
+			assert.ok(first.text.includes(`"offset":${MCP_MAX_OUTPUT_CHARS}`));
+			assert.ok(first.text.includes(RESULT_READ_TOOL_NAME));
+			assert.ok(
+				first.text.length < templates.map(template => `${template.name} (${template.id})`).join('\n').length,
+			);
+
+			const second = await callTool(
+				{ name: RESULT_READ_TOOL_NAME, arguments: { id, offset: MCP_MAX_OUTPUT_CHARS } },
+				settings(),
+			);
+
+			assert.ok(!second.isError);
+			assert.ok(second.text.startsWith(`Cached result "${id}" (list_templates)`));
+			assert.ok(second.text.includes(`characters ${MCP_MAX_OUTPUT_CHARS}-`));
+			assert.ok(second.text.includes('Template'));
 		});
 
 		test('list_template_links is callable over MCP without an orgId', async () => {

--- a/src/mcp/McpActions.ts
+++ b/src/mcp/McpActions.ts
@@ -1,4 +1,11 @@
-import { CAPABILITY_REGISTRY, getCapability, type Capability, type CapabilityContext } from '@capabilities';
+import {
+	CAPABILITY_REGISTRY,
+	MCP_MAX_OUTPUT_CHARS,
+	formatMcpOutput,
+	getCapability,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
 import { SessionManager, type Session } from '@sessions';
 import { log } from '@utils';
 import type { McpErrorCode, McpResourceDescriptor, McpToolDescriptor, McpToolResult } from './protocol';
@@ -14,7 +21,6 @@ import { SlidingWindowThrottle } from './throttle';
  * external agent did.
  */
 
-const MCP_MAX_OUTPUT_CHARS = 24_000;
 // An external agent can loop fast and each call hits a real org through the
 // user's cookie session, so cap MCP-originated calls independently of the chat.
 const THROTTLE = new SlidingWindowThrottle(30, 10_000);
@@ -63,11 +69,6 @@ function exposedCapabilities(settings: McpSettings): Capability[] {
 function isCapabilityExposed(name: string, settings: McpSettings): boolean {
 	const capability = getCapability(name);
 	return capability ? isExposed(capability, settings) : false;
-}
-
-function truncate(text: string): string {
-	if (text.length <= MCP_MAX_OUTPUT_CHARS) return text;
-	return `${text.slice(0, MCP_MAX_OUTPUT_CHARS)}\n…(output truncated at ${MCP_MAX_OUTPUT_CHARS} characters; narrow your request to see more)`;
 }
 
 function asString(record: Record<string, unknown> | undefined, key: string): string | undefined {
@@ -203,7 +204,7 @@ export async function callTool(
 		try {
 			const text = await capability.run(args, ctx);
 			auditOutcome = auditOutcomeForText(text);
-			return { text: truncate(text) };
+			return { text: formatMcpOutput(params.name, text) };
 		} catch (error) {
 			const message = error instanceof Error ? error.message : String(error);
 			auditOutcome = `error:${error instanceof McpError ? error.code : 'graphql_error'}`;
@@ -285,7 +286,7 @@ export async function readResource(uri: string, settings: McpSettings = readMcpS
 	const args: Record<string, unknown> = { orgId: parsed.orgId };
 	if (parsed.id) args[parsed.collection === 'templates' ? 'templateId' : 'workflowId'] = parsed.id;
 	const ctx = await resolveContext(capability, args, parsed.orgId);
-	const text = truncate(await capability.run(args, ctx));
+	const text = formatMcpOutput(toolName, await capability.run(args, ctx));
 	log.info(`MCP readResource: ${uri}`);
 	return { uri, mimeType: 'text/plain', text };
 }


### PR DESCRIPTION
Part of the MCP server epic (#52); implements the **result-size / truncation "continue convention"** item of #57.

## Problem
The MCP boundary (`src/mcp/McpActions.ts`) hard-truncated any tool result over `MCP_MAX_OUTPUT_CHARS` (24k) with only a "narrow your request" hint and **no way to retrieve the rest**. The chat side once had `buddy_result_read` for this, but that was retired in the MCP-only migration (#68), leaving MCP with no paging.

## What this does
- **`src/capabilities/resultReadCapability.ts`** (new):
  - `McpResultCache` — in-memory, size-bounded (64 MB), insertion-ordered, evict-oldest store of full oversized results under short ids.
  - `formatMcpOutput(toolName, text)` — returns text inline when ≤ 24k; otherwise caches the full result and returns a 24k preview plus the cached id and explicit continue/search instructions. Passes `result_read`'s own output through untouched (never re-caches paging output).
  - `result_read` MCP capability — read-tier, `requiresOrg: false`, `chat: false`. Pages by `offset`/`limit` (default 6k, max 8k) or searches by line (numbered hits, capped). Evicted/missing id → clear "rerun the original tool" error.
- **`McpActions.callTool` / `readResource`** swap `truncate()` for `formatMcpOutput()`. The audit `try/finally` and three-tier gating are unchanged.
- Placed in `capabilities/` (not `mcp/`) so `McpActions` imports the helper via `@capabilities` without a circular import. `MCP_MAX_OUTPUT_CHARS` moves there as the shared cap.

## Design notes
- **No new setting** — fixed 64 MB cache budget constant (keeps the recently-trimmed MCP settings surface to its three toggles).
- **Not a VS Code LM tool** — Rewst tools are MCP-only since #68, so no `package.json` `languageModelTools` change.
- `result_read` is exposed under `rewst-buddy.mcp.enable` (read tier), so it's always available to retrieve a truncated read.

## Tests
- `resultReadCapability.test.ts` — cache budget/eviction, inline-vs-cache threshold, `result_read` passthrough, slice paging (offset/limit + more-footer + end marker), search (line numbers + hit caps), missing/evicted-id errors.
- `McpActions.test.ts` — oversized `callTool` returns a cached preview + id that a follow-up `result_read` pages through.
- `registry.test.ts` — `result_read` is exposed on the MCP surface.

Full unit suite green (533), tsc + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Oversized MCP tool results now return a truncated preview plus a cached reference ID.
  * Added an MCP-only `result_read` tool to page or search cached results, with continuation offsets and “end of result” markers.
  * Implemented an in-memory cached-result flow with byte-budget eviction for older entries.
* **Documentation**
  * Updated MCP tools documentation to include `result_read` and explain the new cached preview + paging/search model.
* **Tests**
  * Expanded coverage for `result_read` paging/search, continuation formatting, and cache eviction, including oversized `list_templates` paging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->