### PR TITLE
Refresh VS Code's MCP tool list when exposure toggles change (#69)

### DIFF
--- a/changelog.d/mcp-definition-version-tools.md
+++ b/changelog.d/mcp-definition-version-tools.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- Toggling the MCP write or dangerous-mutation switches now changes the advertised MCP server version, so VS Code reconnects to the in-editor MCP server and refreshes its tool list instead of holding the stale set until the window is reloaded.

--- a/docs/features.md
+++ b/docs/features.md
@@ -110,6 +110,8 @@ Rewst-specific actions are exposed through the Rewst Buddy MCP server instead of
 
 The old combined chat tool `buddy_graphql` is not exposed; its MCP replacement is the query/mutate pair. Workflow edits, auto-layout, runs, and raw GraphQL mutations still require approval inside VS Code before anything is sent to Rewst. `rewst_graphql_mutate` is intentionally separate from `enableWriteTools` because it can run arbitrary mutations against the live org.
 
+When the server is registered with VS Code's own MCP client (the `Add MCP Server to VS Code` command), flipping any of these exposure switches re-advertises the server with a new version, so VS Code reconnects and refreshes the tool set in chat — no window reload needed.
+
 Large MCP outputs are bounded at the MCP response boundary; the retired chat-only `buddy_result_read` cache is no longer part of the chat tool protocol.
 
 ### Context and answers

--- a/src/mcp/McpDefinitionProvider.test.ts
+++ b/src/mcp/McpDefinitionProvider.test.ts
@@ -17,6 +17,18 @@ async function setServer(key: 'host' | 'enabled', value: unknown): Promise<void>
 	await vscode.workspace.getConfiguration('rewst-buddy.server').update(key, value, vscode.ConfigurationTarget.Global);
 }
 
+async function setMcpExposure(
+	key: 'enableWriteTools' | 'enableDangerousGraphqlMutation',
+	value: boolean | undefined,
+): Promise<void> {
+	await vscode.workspace.getConfiguration('rewst-buddy.mcp').update(key, value, vscode.ConfigurationTarget.Global);
+}
+
+function versionOf(): string {
+	const defs = McpDefinitionProvider.provideMcpServerDefinitions();
+	return (defs[0] as vscode.McpHttpServerDefinition).version ?? '';
+}
+
 suite('Unit: McpDefinitionProvider', () => {
 	setup(async () => {
 		initTestEnvironment();
@@ -30,6 +42,8 @@ suite('Unit: McpDefinitionProvider', () => {
 	teardown(async () => {
 		await _resetMcpTokenForTesting();
 		await setMcpEnabled(undefined);
+		await setMcpExposure('enableWriteTools', undefined);
+		await setMcpExposure('enableDangerousGraphqlMutation', undefined);
 		await setServer('enabled', undefined);
 		await setServer('host', undefined);
 	});
@@ -56,6 +70,23 @@ suite('Unit: McpDefinitionProvider', () => {
 		const defs = McpDefinitionProvider.provideMcpServerDefinitions();
 		const def = defs[0] as vscode.McpHttpServerDefinition;
 		assert.match(def.uri.toString(), /^http:\/\/\[::1\]:\d+\/mcp$/, 'IPv6 host is bracketed');
+	});
+
+	test('the advertised version changes when the write/dangerous exposure toggles flip', async () => {
+		await setMcpEnabled(true);
+		const base = versionOf();
+
+		await setMcpExposure('enableWriteTools', true);
+		const withWrite = versionOf();
+		assert.notStrictEqual(withWrite, base, 'enabling write tools changes the version so VS Code reconnects');
+
+		await setMcpExposure('enableDangerousGraphqlMutation', true);
+		const withDangerous = versionOf();
+		assert.notStrictEqual(withDangerous, withWrite, 'enabling the dangerous mutation toggle changes the version');
+
+		await setMcpExposure('enableWriteTools', false);
+		await setMcpExposure('enableDangerousGraphqlMutation', false);
+		assert.strictEqual(versionOf(), base, 'reverting both toggles restores the original version');
 	});
 
 	test('refresh fires the change event so VS Code re-reads the definitions', () => {

--- a/src/mcp/McpDefinitionProvider.ts
+++ b/src/mcp/McpDefinitionProvider.ts
@@ -60,14 +60,18 @@ export const McpDefinitionProvider = new (class _ implements vscode.McpServerDef
 	}
 
 	provideMcpServerDefinitions(): vscode.McpServerDefinition[] {
-		if (!readMcpSettings().enable) return [];
+		const settings = readMcpSettings();
+		if (!settings.enable) return [];
 		const { host, port } = getServerConfig();
 		const uri = vscode.Uri.parse(`http://${formatHostPort(host, port)}/mcp`);
 		const headers = { Authorization: mcpAuthorizationHeader(getMcpToken()) };
-		// A version tied to the endpoint makes VS Code refresh the tool list when
-		// the host/port moves. The token stays out of the version string so it is
-		// never surfaced where the version is shown or logged.
-		const version = `${host}:${port}`;
+		// The version tells VS Code when to restart its connection to the server and
+		// re-fetch the tool list. Tie it to the endpoint AND the exposure toggles so
+		// flipping the write/dangerous switches changes the advertised tool set in
+		// chat without a manual reconnect. The token stays out so it is never
+		// surfaced where the version is shown or logged.
+		const exposure = `w${settings.enableWriteTools ? 1 : 0}d${settings.enableDangerousGraphqlMutation ? 1 : 0}`;
+		const version = `${host}:${port}:${exposure}`;
 		return [new vscode.McpHttpServerDefinition(SERVER_LABEL, uri, headers, version)];
 	}
 


### PR DESCRIPTION
Closes #69. Part of the MCP server epic (#52); #57 hardening follow-up.

## Problem
When the in-extension MCP server is registered with VS Code's own MCP client (via `Add MCP Server to VS Code`, used by Cage-Free Rewsty chat), toggling `rewst-buddy.mcp.enableWriteTools` or `enableDangerousGraphqlMutation` did **not** refresh the tool set in chat. The newly-enabled write/dangerous tools wouldn't appear (and disabled ones wouldn't disappear) until the user reloaded the VS Code window.

## Root cause
VS Code restarts its connection to a registered MCP server — and re-fetches `tools/list` — **only when the `McpServerDefinition.version` string changes**. `McpDefinitionProvider` already fires its change event on `rewst-buddy.mcp.*` config changes and VS Code re-queries `provideMcpServerDefinitions()`, but the returned `version` was just `${host}:${port}`. Flipping an exposure toggle doesn't move host/port, so the version was identical → VS Code saw no change → kept its cached tool list.

(The server side already honored the toggles immediately — the MCP HTTP server is stateless per-request and re-reads settings on every `tools/list`/`tools/call`. The gap was purely VS Code's client-side cache.)

## Fix
Fold the two exposure toggles into the advertised `version`:

```
version = `${host}:${port}:w${enableWriteTools?1:0}d${enableDangerousGraphqlMutation?1:0}`
```

Now flipping either toggle re-advertises a new version → VS Code reconnects and refreshes the tool set, no window reload. The token stays out of the version string (never surfaced/logged). `enable` needs no inclusion: turning it off returns `[]` (server removed) and on re-adds it.

## Tests
- `McpDefinitionProvider.test.ts` — new test: the advertised version changes when `enableWriteTools` / `enableDangerousGraphqlMutation` flip, and reverting both restores the original version.

Full unit suite green (533), tsc + lint clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Toggling MCP write and dangerous-mutation switches now properly triggers VS Code to reconnect and refresh the available tool list without requiring a window reload.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->