### PR TITLE
Document the multiple-VS-Code-windows MCP behavior (#57)

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -116,6 +116,8 @@ Oversized MCP results are cached in memory and returned with a preview plus a sh
 
 The local MCP endpoint is guarded by a persistent localhost token. If it is ever exposed, run `Rewst Buddy: Rotate MCP Token` to replace it after a modal confirmation — existing MCP clients holding the old token lose access until you re-copy the config with `Copy MCP Config to Clipboard`.
 
+**Multiple VS Code windows:** the MCP server binds a single localhost port, so only one window can host it — the first window to bind owns the `/mcp` endpoint, and the server exposes **that window's** active Rewst sessions. Other windows still try to start the server but lose the port bind; their sessions are not reachable over MCP while another window owns it. Tools that take an `orgId` resolve it among the owning window's sessions, so to expose a particular org through MCP, make sure that org's session is signed in in the window that owns the server (close the owning window to let another take over the port).
+
 ### Context and answers
 
 - **Attached context** — files attached via the paperclip or `#file`, and editor selections, are included by the chat itself

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -91,6 +91,8 @@ All commands are available via Command Palette (Cmd/Ctrl + Shift + P) under the 
 - `Copy MCP Config to Clipboard` — Copy (and open) a credential-free JSON config that points an **external** MCP client (Claude Desktop, Claude Code, Cursor) at the extension's local MCP server. The config carries the token via the standard `Authorization: Bearer` header, referencing it as the `REWST_BUDDY_MCP_TOKEN` environment variable rather than embedding it. Use the command's **Copy token** action to grab the localhost token (set it as that env var), or paste it in place of `${REWST_BUDDY_MCP_TOKEN}` for clients that don't expand env vars. Requires `rewst-buddy.mcp.enable`.
 - `Rotate MCP Token` — Replace the localhost MCP token after a modal confirmation. Existing MCP clients using the old token lose access until you update them; run `Copy MCP Config to Clipboard` afterward to copy the updated token/config for external clients.
 
+> **Multiple windows:** the MCP server binds one localhost port, so only the first VS Code window to bind it hosts `/mcp`, and it exposes that window's signed-in Rewst sessions. Other windows can't bind the port while it's owned, so their sessions aren't reachable over MCP — sign the org you want exposed into the owning window, or close that window to free the port. See [Rewst MCP tools](features.md#rewst-mcp-tools).
+
 ## Settings
 
 All settings live under the `rewst-buddy.*` namespace. Edit via VS Code Settings (Cmd/Ctrl + ,) → search "rewst-buddy", or `settings.json` directly.


### PR DESCRIPTION
Part of the MCP server epic (#52); closes one of the two remaining #57 hardening items (the **multiple VS Code windows** story). Docs-only — no code change.

## What
The MCP server binds a single localhost port, so only one VS Code window can host it. This documents the resulting behavior so users know which sessions an external MCP client will actually see:

- The **first window to bind** the port owns the `/mcp` endpoint and exposes **that window's** signed-in Rewst sessions.
- Other windows still try to start the server but lose the bind (EADDRINUSE) — their sessions are not reachable over MCP while another window owns the port.
- Tools that take an `orgId` resolve it among the owning window's sessions, so to expose a particular org, sign it in in the owning window (or close that window to free the port for another).

## Where
- `docs/features.md` — a **Multiple VS Code windows** paragraph in the `Rewst MCP tools` section.
- `docs/reference.md` — a short note by the MCP commands, linking to the features section.

## Notes
This is the **(A) doc-only** treatment. The heavier **(B)** option — surfacing which org/sessions the running server exposes inside `Copy MCP Config` / `Add MCP Server to VS Code` — remains available as a follow-up if we want in-product visibility.

`skip-changelog`: documentation of existing behavior, no user-facing code change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented MCP server behavior across multiple VS Code windows: only the first window that binds the localhost port can expose active Rewst sessions over MCP. Other windows' sessions remain unreachable until the owning window closes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->