### PR TITLE
Add read-only MCP query tools from the GraphQL query-surface audit

### DIFF
--- a/.markdownlint-cli2.jsonc
+++ b/.markdownlint-cli2.jsonc
@@ -1,0 +1,16 @@
+{
+	// Catch the structural Markdown issues that CodeRabbit's markdownlint flags
+	// (notably MD040 fenced-code-language) before they reach review. Prose-style
+	// rules that fight our intentionally long doc lines, tab indentation, and
+	// frontmatter-first changelog notes are turned off so the hook only fails on
+	// things worth fixing.
+	"config": {
+		"default": true,
+		"MD013": false, // line length — docs and tables run long on purpose
+		"MD010": false, // hard tabs — the repo indents with tabs
+		"MD041": false, // first-line heading — changelog.d notes start with YAML frontmatter
+		"MD007": false, // unordered list indentation style
+		"MD036": false, // emphasis used as a pseudo-heading (we do this deliberately)
+		"MD038": false // spaces inside code spans (intentional in a few examples)
+	}
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -43,7 +43,7 @@ For `buddy_workflow_get` detail steering specifically, do **not** say or imply t
 
 ## Directory Structure
 
-```
+```text
 src/
 ├── commands/           # VS Code commands (user interactions)
 │   ├── client/        # Session commands (NewSession, ClearSessions)
@@ -88,7 +88,7 @@ src/
 
 User docs are split between a short landing README and three deep-dive files in `docs/`. When adding or editing user-facing documentation, put content in the file whose purpose it matches — don't duplicate across files.
 
-```
+```text
 README.md             # Marketplace/GitHub landing: banner, about, install,
                       #   3-step quick start, features glance, security, links out.
                       #   Keep short (~100 lines). No exhaustive feature detail.
@@ -297,7 +297,7 @@ Capabilities live in `src/capabilities/*Capabilities.ts` and are surfaced to the
     - Strings: `requireString` (required) / `asString` (optional) — never read `input.x` directly.
     - Numbers: clamp — `Math.min(asPositiveInt(input, 'limit') ?? DEFAULT, MAX)`. `asPositiveInt` already rejects `0`, negatives, and fractions (returns `undefined`); preserve that property in any new numeric helper (e.g. `mapWithConcurrency` throws on a non-positive limit).
     - Enums: validate against the allowed set before use — never blind-cast `input.kind as Kind`. An unexpected value must fall back to a safe default or throw, not slip through.
-- **GraphQL error handling:** after every `rawGraphql`, check `errors` and throw _with context_ — `throw new Error(\`GraphQL error: ${JSON.stringify(errors)}\`)`. Never a bare `throw new Error()` (it discards the failure).
+- **GraphQL error handling:** after every `rawGraphql`, check `errors` and throw _with context_ — include the serialized errors in the message (`GraphQL error: ...`), never a bare `throw new Error()` (which discards the failure).
 - **Description ↔ behavior parity:** if a tool's `description`/`inputSchema` says it returns or accepts a field, the handler must actually surface/use it. Drift (e.g. fetching `roleIds` but dropping them from the output) gets flagged.
 - **Build list output from the requested inputs, not the response keys.** Iterate the requested `ids`/`triggerIds` and look each up, so a missing or empty (`{}`) response yields deterministic rows (`unknown`) instead of dropped entries or a blank line.
 - **Tests cover every branch, not just the happy path.** Each `kind`/mode and the error/skip paths need a case (e.g. `find_executions_by_variable` needs an `input` _and_ a `context`-with-failed-fetch test). Mock helpers must mirror the real signature — optional vs required params (the mock `rawGraphql` marks `variables?` optional to match `Session.rawGraphql`).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -289,6 +289,25 @@ All components implement `vscode.Disposable` and push to `context.subscriptions`
 3. **Disposables**: Always push to `context.subscriptions` for cleanup
 4. **Template updates**: After modifying template, update `link.template.updatedAt` to prevent false conflicts
 
+## Capability / MCP Tool Authoring
+
+Capabilities live in `src/capabilities/*Capabilities.ts` and are surfaced to the MCP server and chat. Most review round-trips on these tools trace to a few rules — apply them up front instead of in follow-up commits.
+
+- **MCP inputs are NOT validated against `inputSchema`.** `McpActions` passes the raw `arguments` straight to `capability.run()` (see `src/mcp/McpActions.ts`); the schema is only advertised to the client, never enforced. So `run()` must defensively validate/coerce **every** input:
+    - Strings: `requireString` (required) / `asString` (optional) — never read `input.x` directly.
+    - Numbers: clamp — `Math.min(asPositiveInt(input, 'limit') ?? DEFAULT, MAX)`. `asPositiveInt` already rejects `0`, negatives, and fractions (returns `undefined`); preserve that property in any new numeric helper (e.g. `mapWithConcurrency` throws on a non-positive limit).
+    - Enums: validate against the allowed set before use — never blind-cast `input.kind as Kind`. An unexpected value must fall back to a safe default or throw, not slip through.
+- **GraphQL error handling:** after every `rawGraphql`, check `errors` and throw _with context_ — `throw new Error(\`GraphQL error: ${JSON.stringify(errors)}\`)`. Never a bare `throw new Error()` (it discards the failure).
+- **Description ↔ behavior parity:** if a tool's `description`/`inputSchema` says it returns or accepts a field, the handler must actually surface/use it. Drift (e.g. fetching `roleIds` but dropping them from the output) gets flagged.
+- **Build list output from the requested inputs, not the response keys.** Iterate the requested `ids`/`triggerIds` and look each up, so a missing or empty (`{}`) response yields deterministic rows (`unknown`) instead of dropped entries or a blank line.
+- **Tests cover every branch, not just the happy path.** Each `kind`/mode and the error/skip paths need a case (e.g. `find_executions_by_variable` needs an `input` _and_ a `context`-with-failed-fetch test). Mock helpers must mirror the real signature — optional vs required params (the mock `rawGraphql` marks `variables?` optional to match `Session.rawGraphql`).
+
+## Docs & changelog hygiene (markdownlint runs in review)
+
+- Every fenced code block needs a language label (use ` ```text ` for plain blocks) — markdownlint MD040 fails otherwise.
+- Don't hardcode volatile numbers (passing-test counts, tool counts that change) in docs; they drift and get flagged. Prefer "full suite green".
+- `changelog.d/` takes **multiple** notes per PR and feature-named files are fine; each file carries exactly one `category:`, so a PR spanning `Added` + `Fixed` needs at least two files. Distinct filenames are what keep collation conflict-free — that, not "one file per PR", is the actual rule.
+
 ## Performance (CRITICAL)
 
 This is an editor extension - **workflow speed is paramount**. Every millisecond of latency degrades user experience.

--- a/changelog.d/README.md
+++ b/changelog.d/README.md
@@ -18,7 +18,7 @@ It asks for a category and a one-line summary and writes the file for you,
 filling in the PR/issue number from `gh` or your branch name. Or write the file
 by hand:
 
-```
+```text
 changelog.d/<pr-or-issue-number>.md      e.g. changelog.d/42.md
 ```
 

--- a/changelog.d/find-executions-by-variable.md
+++ b/changelog.d/find-executions-by-variable.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- Added the find_executions_by_variable MCP tool, which finds executions of a workflow whose input, output, or context variable matches a name (and optional value).

--- a/changelog.d/list-org-variables-and-find-action-tools.md
+++ b/changelog.d/list-org-variables-and-find-action-tools.md
@@ -1,0 +1,6 @@
+---
+category: Added
+---
+
+- Add the `list_org_variables` read-only MCP tool for masked organization configuration variables.
+- Add the `find_action` read-only MCP tool for searching installed pack actions.

--- a/changelog.d/list-workflows-visibleworkflows-fix.md
+++ b/changelog.d/list-workflows-visibleworkflows-fix.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- Fixed the `list_workflows` MCP tool, which always failed because its underlying `visibleWorkflows` query is broken server-side; it now uses the `workflows` query.

--- a/changelog.d/org-user-tools.md
+++ b/changelog.d/org-user-tools.md
@@ -1,0 +1,7 @@
+---
+category: Added
+---
+
+- Add the `search_organizations` read-only MCP tool for finding managed organizations by name substring.
+- Add the `list_users` read-only MCP tool for listing users directly in one organization.
+- Add the `list_roles` read-only MCP tool for listing roles defined in one organization.

--- a/changelog.d/pack-integration-tools.md
+++ b/changelog.d/pack-integration-tools.md
@@ -1,0 +1,8 @@
+---
+category: Added
+---
+
+- Added MCP tool to list integration packs and bundles installed in a Rewst organization.
+- Added MCP tool to check whether a pack needs OAuth setup in a Rewst organization.
+- Added MCP tool to list pack (integration) configurations for a Rewst organization.
+- Added MCP tool to list integrations available on the Rewst platform.

--- a/changelog.d/page-template-tools.md
+++ b/changelog.d/page-template-tools.md
@@ -1,0 +1,8 @@
+---
+category: Added
+---
+
+- Added MCP tool to search templates in a Rewst organization by name substring
+- Added MCP tool to list App Platform pages in a Rewst organization
+- Added MCP tool to list App Platform sites in a Rewst organization
+- Added MCP tool to browse the global Jinja filter catalog with optional name filtering

--- a/changelog.d/resolve-reference-tool.md
+++ b/changelog.d/resolve-reference-tool.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- Added the `resolve_reference` MCP tool for name-to-id resolution of Rewst objects.

--- a/changelog.d/trigger-form-tools.md
+++ b/changelog.d/trigger-form-tools.md
@@ -1,0 +1,9 @@
+---
+category: Added
+---
+
+- Add the `list_triggers` read-only MCP tool for trigger summaries in one organization.
+- Add the `list_forms` read-only MCP tool for form summaries in one organization.
+- Add the `list_tags` read-only MCP tool for tag summaries in one organization.
+- Add the `list_org_trigger_instances` read-only MCP tool for trigger activation instance summaries in one organization.
+- Add the `get_trigger_error_status` read-only MCP tool for batch trigger health checks.

--- a/changelog.d/workflow-execution-tools.md
+++ b/changelog.d/workflow-execution-tools.md
@@ -1,0 +1,7 @@
+---
+category: Added
+---
+
+- Add the `list_workflow_executions` read-only MCP tool for recent workflow execution summaries.
+- Add the `latest_workflow_execution` read-only MCP tool for the latest execution of one workflow.
+- Add the `get_workflow_execution_stats` read-only MCP tool for aggregate workflow execution status counts.

--- a/changelog.d/workflow-inspection-tools.md
+++ b/changelog.d/workflow-inspection-tools.md
@@ -1,0 +1,7 @@
+---
+category: Added
+---
+
+- Add the `list_workflow_tasks` read-only MCP tool for listing workflow tasks.
+- Add the `list_workflow_patches` read-only MCP tool for workflow patch metadata history.
+- Add the `get_workflow_patch` read-only MCP tool for fetching one workflow patch with its JSON Patch payload.

--- a/docs/dev/graphql-field-guide.md
+++ b/docs/dev/graphql-field-guide.md
@@ -1,0 +1,485 @@
+# Rewst GraphQL Query Field Guide
+
+> Working engineering artifact for the MCP query-tool audit. Goal: probe every
+> root `Query` field against a live org once, record what actually works and
+> where the schema is misleading, so agents (and the dedicated MCP tools we
+> build) stop re-discovering the same trial-and-error.
+>
+> **Status:** ✅ Query-surface audit complete — all 113 root `Query` fields probed live (2026-06-21).
+> **Scope:** queries only (no mutations/subscriptions this pass).
+> **Live probe org:** Jon's Sandbox — `01940973-8a88-7109-8ba7-d64bfbb18950` (the only org we test against).
+> **Source of truth for tools:** the bulk of each finding gets hardened into a
+> dedicated MCP capability/spec; cross-cutting gotchas are distilled into the
+> "Common gotchas" section below and into steering.
+
+## How to read an entry
+
+Each probed field gets a block:
+
+```
+### fieldName
+- **status:** WORKS | ERROR | EMPTY (callable, no data in sandbox) | NEEDS-ARGS (required input we couldn't satisfy)
+- **minimal working call:** the smallest query + variables that returned data (or the precise args needed)
+- **gotchas:** misleading args, required-looking-optional (and vice-versa), orgId placement (args vs where vs variables), silent nulls, pagination/order behaviour, search-input shape
+- **return shape:** the few fields on the return type worth knowing
+- **tool candidate:** yes/no + why (is a dedicated paginated/ranked tool worth building?)
+```
+
+Status legend for the catalog coverage table: `pending` → not probed yet, `done` → probed + recorded below.
+
+---
+
+## Common gotchas (cross-cutting — fill from findings)
+
+_Distilled rules that apply across many fields. These feed steering + tool descriptions._
+
+- `rewst_graphql_query` is read-only — mutations/subscriptions are rejected at the MCP boundary.
+- The MCP tool injects the caller's `orgId` into variables; a conflicting `variables.orgId` is rejected. It only provides a **top-level** `$orgId` variable — fields that scope org **inside `where`** (e.g. `template`, `templates`) still need `where.orgId` written explicitly (reference `$orgId`).
+- **`where` vs `search` are different filter surfaces that compose.** `where` = exact field equality (`{ orgId, id }`). `search` = comparison-operator expressions (`{ name: { _ilike: "%x%" } }`, also `_eq`, `_in`). Many list fields take both.
+- **`order` is `[[String!]!]`** — a list of `[fieldName, direction]` pairs, e.g. `[["updatedAt", "desc"]]`.
+- **JSON-typed args (`JSON!`) must be passed as GraphQL variables**, never inline literals — inline fails with `Expected Name, found String`.
+- **Several resolvers are broken server-side** (return all-null or crash). Confirmed dead so far: `jinjaTemplate` (crashes), `jinjaFilterDocumentation` (singular — always null; use the plural `jinjaFiltersDocumentation`). Singular-by-id resolvers often crash on not-found instead of returning null (`orgInterpreterSetting`).
+- **No default `limit`** on some list fields (e.g. `templates`) — omitting it returns _everything_. Always cap.
+- Timestamp scalars are sometimes **millisecond-epoch strings**, not ISO (e.g. template `updatedAt`, packConfig `createdAt`/`updatedAt`).
+- **⚠ Cross-org data leak:** global catalog fields (`actions`, `packs`, `actionOptions`) return records from _other_ orgs unless you filter explicitly — they are NOT org-scoped at the resolver. Prefer the `*ForOrg` variants (`actionsForOrg`, `packsForOrg`) for org-aware queries. `packs(where:{orgId})` silently returns `[]` (dead filter path — use `packsForOrg`).
+- **⚠ The schema lies about pagination.** Some fields advertise `limit`/`offset` in introspection but the resolver rejects them at runtime (`packConfigs` → `Unknown argument "limit"`). Don't trust the signature; verify against the live resolver.
+- **Declared-but-unused variables are a validation error.** The MCP tool injects an `$orgId` _value_, but the query document must both declare `query Q($orgId: ID!)` **and** reference `$orgId`. For global fields that don't take org, do NOT declare `$orgId` (else `Variable $orgId is never used`).
+- **UUID vs string-ref is inconsistent across sibling fields.** `commonlyUsedIntegrationActions.integrationId` wants a pack **UUID** (a ref string throws `invalid input syntax for type uuid`); `packAuthUrl.packName` / `pack(where:{ref})` want a **string ref**. Check per field.
+- **Some resolvers are auth-gated** (`verifyUserManagesOrg`) and throw `Not Authorized` from a normal user session (`packActionOptions`); the singular sibling may instead return `null`.
+- **Singular-by-id resolvers return `null` on not-found** (no error) for most catalog types (`action`, `pack`, `packConfig`) — but a few crash instead (see Templates batch). No org-boundary enforcement on bare-id lookups, so they can cross orgs.
+- **Auto-injected `$orgId` scopes auth but does NOT auto-filter results.** For most list fields (`triggers`, `forms`, `workflows`, `users`…) you must still pass `where: { orgId: $orgId }` explicitly, or you get cross-org / arbitrary rows.
+- **Several list fields crash without an explicit scope.** `tags` (and `crateTags`, `tag`) throw a Sequelize `Invalid value` auth-middleware crash when called with no `where`/`search` at all — always pass `where: { orgId }`.
+- **`search.organization` / `search.organizationId` nested joins are broken** on `triggers`, `forms`, `sites` (`missing FROM-clause entry` / `column ... does not exist`). Use `where: { orgId }` for org scoping on those.
+- **Enum-typed args must be unquoted GraphQL enum literals**, not strings: `category: secret` (not `"secret"`), `modelName: PackConfig`. Comparison-exp inputs are Hasura-style (`_eq`, `_ilike`, `_like`, `_substr`, `_in`, `_neq`).
+- **`AUTH_ERR` often means "missing required scope arg," not a permission problem.** `workflowNotes`/`workflowNote` return `AUTH_ERR` unless you pass a scoping `workflowId` (or valid note `id`).
+- **Ordering arg is not uniform.** Most lists use `order: [[String!]!]` (e.g. `[["updatedAt","DESC"]]`), but `workflowPatches` uses a single-enum `orderBy: createdAt_DESC`. Date filters likewise vary: `workflowPatches.createdSince` accepts **only epoch-ms strings** (ISO throws `Invalid time value`).
+- **Secret hygiene:** `orgVariable(s)` return **plaintext secrets** unless you pass `maskSecrets: true` — always set it in tools. `visibleOrgVariables` always masks and includes cascaded/inherited vars (the row's `orgId` identifies the source org).
+- **Some "my/me" fields ignore the request org** and resolve against the _token's_ home org: `me`, `userOrganization`, `user`/`users` only see users _directly_ in the named org (no parent inheritance).
+- **Broken / unusable resolvers found so far (avoid; use the noted replacement):**
+    - `visibleWorkflows` — crashes both with and without `orgId` (SQL join bug: `missing FROM-clause entry for table "visibleForOrganizations"`). ⚠ **CONFIRMED LIVE: our shipped `list_workflows` MCP tool is 100% broken** because it wraps this. Replacement (verified): `workflows(where: { orgId }, order: [["updatedAt","DESC"]])`, mapping the name filter to `search: { name: { _ilike: "%<term>%" } }`.
+    - `jinjaTemplate` — crashes for any input. `jinjaFilterDocumentation` (singular) — always all-null; use plural `jinjaFiltersDocumentation`.
+    - `myAccessibleOrganizations` — server crash (`findAll` of undefined).
+    - `visibleOrgVariablesCount` — returns null for a non-null `Int!` field.
+    - `packActionOptions` — `Not Authorized` (`verifyUserManagesOrg`) from a normal session.
+    - `conversationMessageVotes` (when filtered) & `messageVoteStats` (always) — crash `No info provided to datasource` (resolver calls `findOne` without passing `info`). `conversations` with no `where` also crashes — pass `where:{orgId}` explicitly.
+    - `componentInstances(orgId: ID!)` — broken **via MCP specifically**: the resolver wraps the incoming `orgId` into `{ where: { orgId: [Object] } }` and Sequelize crashes, for every calling pattern. `componentTree` / `recentComponentVersions` crash on not-found ids (null-deref / explicit error) rather than returning null/`[]`.
+    - `organizationsWithFeaturePreviewSettingEnabled` — staff/support only.
+    - `workflows(hasTokens: true)` — crashes (`relation "tokens" does not exist`); other boolean flags work.
+    - `packConfigs(limit:)` — `Unknown argument` despite the schema advertising it (no pagination).
+- **Date args want ISO 8601, output timestamps are epoch-ms — opposite directions.** Date-argument fields (`createdSince`, `startDate`, `endDate`, `date`, `updatedAt` on the stats/exec queries) require ISO strings (`YYYY-MM-DD` or full `…T…Z`); epoch-ms is rejected (`date/time field value out of range`). But object timestamps come back as **epoch-ms strings**. Lone exception: `workflowPatches.createdSince` wants epoch-ms only (ISO throws). Verify per field.
+- **`pendingTasksAggregate` requires `status`** (enum: `pending`/`expired`/`success`/`delayed`/`canceled`) even though the schema marks it optional — omitting crashes (`Named replacement ":status" has no entry`).
+- **For org-scoped `taskLogs`, use `search:{ principalOrgId:{_eq} }`, not `where:{ principalOrgId }`** — the `where` path full-table-scans and times out; `search` (and a specific `workflowExecutionId` in `where`) are fast.
+- **Timeout-prone aggregates (unindexed scans) — avoid or guard ranges in tools:**
+    - `taskExecutionStats` — times out always (use `workflowExecutionStats` or `dailyTaskCountsByDateRange` instead).
+    - `hourlyTimeSavedByDate` — times out always (its sibling `hourlyTaskCountByDate` is fine — reads a pre-agg table).
+    - `timeSavedGroupByWorkflow` / `timeSavedGroupBySubOrg` with `useStatsTable: true` — time out; pass `false`.
+    - `dailyTimeSavedByDateRange` — only safe for short ranges (≤~3 weeks); long ranges time out.
+    - `dailyTaskCountsByDateRange` — fast (pre-agg) but returns **future-dated rows** (projected/pre-filled), so don't treat rows as live counts.
+
+---
+
+## Tool candidates (fill from findings)
+
+_Fields/operations worth a dedicated MCP tool — especially where we can beat
+Rewst's native behaviour by paginating ourselves and ranking locally._
+
+### P0 — ✅ FIXED (branch `feat/mcp-graphql-query-audit`)
+
+- **`list_workflows` was broken in production.** Now swapped from `visibleWorkflows` to `workflows(where:{orgId}, order:[["updatedAt","DESC"]])` with the name filter mapped to `search:{ name:{ _ilike:"%term%" } }`. Source: `src/capabilities/rewstReadCapabilities.ts` (`WORKFLOWS_QUERY` / `runListWorkflows`); colocated unit test `rewstReadCapabilities.test.ts` (passing in the VS Code host); changelog note added. _(Known minor limitation: `%`/`_` in search terms are not escaped — matches prior behaviour.)\_
+
+### ✅ Built this session — 26 new read tools + 1 fix (all type-check + unit-test green)
+
+Status: implemented, type-checked, unit-tested (562 passing). **Not yet live** — needs an extension rebuild + window reload to register on the MCP server. Live-query validation happens with the Haiku pass once the server is back.
+
+**`src/capabilities/rewstReadCapabilities.ts`** (+ `inputHelpers.ts`):
+
+- `list_workflows` (FIX — `workflows(where:{orgId})`, name filter → `_ilike`)
+- `resolve_reference` — universal name→id over `localReferenceOptions` (13 model types)
+- `list_org_variables` — `orgVariables` with `maskSecrets:true`
+- `find_action` — `searchInstalledPackActions`, flatten + cap client-side
+- `list_workflow_executions`, `latest_workflow_execution`, `get_workflow_execution_stats`
+- `list_workflow_tasks`, `list_workflow_patches`, `get_workflow_patch`
+- `find_executions_by_variable` — find a workflow's executions by an input/output/context variable name (+ optional value); input/output inline via `conductor`, context via the N+1 `workflowExecutionContexts` fetch
+
+**`triggerFormCapabilities.ts`**: `list_triggers`, `list_forms`, `list_tags`, `list_org_trigger_instances`, `get_trigger_error_status`
+**`packIntegrationCapabilities.ts`**: `list_installed_packs`, `get_pack_auth_status`, `list_pack_configs`, `list_integrations`
+**`orgUserCapabilities.ts`**: `search_organizations`, `list_users`, `list_roles`
+**`pageTemplateCapabilities.ts`**: `search_templates`, `list_pages`, `list_sites`, `list_jinja_filters`
+
+### Not built (deferred — lower value / informed by Haiku findings)
+
+- Richer org search beyond `search_organizations` (`organizations(where:{managingOrgId},search)` for very large MSPs).
+- Form-for-trigger (`evaluatedForm`), pre-upgrade impact (`workflowsAffectedByBreakingChanges`), workflow-completion listeners.
+- Execution-context debug (`workflowExecutionContexts`), task-count/time-saved dashboards (mind the timeout roster).
+- Crate browse (`crates`/`publicCrates`), App-Platform page nodes (`pageElements`/`pageNode`), RoboRewsty config (`roboRewstyConfigOptions`).
+
+### Cross-cutting tool-design rules (bake into every query tool)
+
+- Always pass `where:{orgId}` for org-scoped fields (auto-injected `$orgId` only scopes auth, not results); never rely on global catalog fields for org data (they leak cross-org).
+- Always set an explicit `limit`; never trust schema-advertised pagination without runtime verification.
+- Mask secrets; use unquoted enum literals; treat epoch-ms timestamp strings on output.
+
+---
+
+## Usability findings — cold Haiku pass (2026-06-21)
+
+A Haiku (weak) model ran 9 realistic tasks against the live tools using **descriptions only** (no field guide). 6 solved cleanly, 2 partial, all completed. Tool-description/narrowing fixes it surfaced:
+
+1. **`find_action` — filter scope unspecified.** Description doesn't say what the `filter` matches (name? ref? description?). It matches the **display name** only (case-insensitive substring) — `filter:"send email"` finds nothing though "Send Mail…" actions exist. → State the scope explicitly.
+2. **`find_action` — return format ambiguous.** `"ref-or-name (id) — pack: description"` doesn't say which token is the ref vs the name, or when `ref` is null (workflow-as-action rows show the name). → Spell out the line format + that `id` is the action id, `ref` the callable reference (null ⇒ name shown).
+3. **`search_organizations` — `orgId` semantics unclear.** It reads as a scope filter but is only session routing; results span **all** managed orgs filtered by name, not sub-orgs of `orgId`. → Say "orgId only selects the session; results span all managed orgs."
+4. **Action `ref` vs `id` usage not documented** — model couldn't tell which to use downstream. → One line in `find_action`.
+5. **`search_organizations` vs `list_orgs` overlap** — two ways to find orgs. → Cross-reference: `search_organizations` is preferred for name lookup; `list_orgs` is the full enumeration.
+6. **`find_action` vs existing `buddy_action_search` overlap** — two action finders. → Cross-reference (find_action = org-scoped installed-pack actions).
+
+Also observed: for "find a workflow by name," Haiku reached for `buddy_workflow_search` over `resolve_reference(Workflow)` — the generic resolver competes with type-specific tools (acceptable; both work). **No tool removals indicated** — all fixes are description tightenings.
+
+## Catalog — coverage tracker (113 root Query fields)
+
+Grouped by domain. `wave` = which explorer batch owns it; `status` updated as findings land.
+
+### Templates & Jinja — _wave 1 · ✅ done_
+
+`template` · `templates` · `jinjaTemplate` · `cratesForTemplate` · `jinjaFiltersDocumentation` · `jinjaFilterDocumentation` · `extractJinjaValues` · `jinjaRenderSession` · `monacoFilterCompletionItems` · `latestInterpreterVersions` · `orgInterpreterSetting` · `orgInterpreterSettings`
+
+### Workflows (core) — _wave 1 · ✅ done_
+
+`workflow` · `workflows` · `visibleWorkflows` · `workflowNote` · `workflowNotes` · `workflowTask` · `workflowTasks` · `workflowPatch` · `workflowPatches` · `workflowIOConfigurations` · `workflowCompletionListeners`
+
+### Workflow executions, tasks & stats — _wave 1 · ✅ done_
+
+`workflowExecution` · `workflowExecutions` · `latestWorkflowExecution` · `workflowExecutionContexts` · `workflowExecutionStats` · `taskLog` · `taskLogs` · `taskExecutionStats` · `dailyTaskCountsByDateRange` · `hourlyTaskCountByDate` · `pendingTasksAggregate` · `timeSavedGroupByWorkflow` · `timeSavedGroupBySubOrg` · `dailyTimeSavedByDateRange` · `hourlyTimeSavedByDate` · `workflowStatsByOrg`
+
+### Actions & Packs — _wave 1 · ✅ done_
+
+`action` · `actions` · `actionsForOrg` · `actionOption` · `actionOptions` · `commonlyUsedIntegrationActions` · `searchInstalledPackActions` · `workflowsAffectedByBreakingChanges` · `pack` · `packs` · `packsByTag` · `packsForOrg` · `packConfig` · `packConfigs` · `packConfigsForOrg` · `packActionOption` · `packActionOptions` · `packBundle` · `packBundles` · `packsAndBundlesByInstalledState` · `resourceTypesByPack` · `packAuthUrl` · `localReferenceOptions`
+
+### Orgs, Users & Variables — _wave 1 · ✅ done_
+
+`organization` · `organizations` · `managedAndSubOrganizations` · `orgSearch` · `searchManagedOrgs` · `myAccessibleOrganizations` · `userOrganization` · `isOrgManagedBy` · `orgBreadcrumb` · `softDeletedOrgs` · `organizationsWithFeaturePreviewSettingEnabled` · `me` · `user` · `users` · `checkUserManagesOrg` · `userInvite` · `userInvites` · `orgVariable` · `orgVariables` · `visibleOrgVariables` · `visibleOrgVariablesCount`
+
+### Triggers, Sensors, Forms, Tags, Sites, Integrations — _wave 1 · ✅ done_
+
+`trigger` · `triggers` · `triggerType` · `triggerTypes` · `triggerDbNotificationErrors` · `getTriggerErrorStatus` · `sensorType` · `sensorTypes` · `orgTriggerInstance` · `orgTriggerInstances` · `form` · `forms` · `evaluatedForm` · `packConfigsForForm` · `tag` · `tags` · `crateTags` · `site` · `sites` · `getAppPermissions` · `getSiteTheme` · `validateSiteDomain` · `integrations`
+
+### Components & Pages — _wave 2 · ✅ done_
+
+`component` · `components` · `componentsByRoots` · `componentTree` · `recentComponentVersions` · `componentInstance` · `componentInstances` · `componentInstancesByPage` · `componentInstancesByComponentVersion` · `page` · `pages` · `pageVars` · `pageNode` · `pageNodes` · `livePage` · `pageElements`
+
+### Conversations & RoboRewsty — _wave 2 · ✅ done_
+
+`conversation` · `conversations` · `conversationMessageVotes` · `messageVoteStats` · `activeConversationRequest` · `activeConversationRequests` · `roboRewstyWorkflowDraftState` · `roboRewstyConfigOption` · `roboRewstyConfigOptions` · `userRoboRewstyPreferences` · `myRoboRewstyPreferences`
+
+### Crates — _wave 2 · ✅ done_
+
+`crate` · `crates` · `crateUseCase` · `crateUseCases` · `crateTokenTypes` · `crateCategories` · `crateExportInfo` · `crateUnpackingArgumentSet` · `publicCrates` · `cratesForForm`
+
+### Permissions, Roles & Audit — _wave 2 · ✅ done_
+
+`permission` · `permissions` · `checkAuthorization` · `check` · `checkSpiceDBPermission` · `formPermissionState` · `bulkFormPermissionsAudit` · `permissionAuditLog` · `warrants` · `roles` · `roleUserCounts` · `roleOrganizationMemberships` · `roleOrganizationMembershipCounts` · `bulkOrganizationsAudit`
+
+### Onboarding, Imports & Admin long-tail — _wave 2 · ✅ done_
+
+`organizationImport` · `organizationImports` · `organizationOnboardingCrateRequirement` · `organizationOnboardingCrateRequirements` · `organizationOnboardingPackRequirement` · `organizationOnboardingPackRequirements` · `organizationOnboardingRequirement` · `onboardingQuestionnaireResponse` · `onboardingQuestionnaireResponses` · `reservedOrganizationName` · `reservedOrganizationNames` · `featurePreviewSetting` · `featurePreviewSettings` · `foreignObjectReference` · `foreignObjectReferences` · `orgFormFieldInstance` · `orgFormFieldInstances` · `orgFormFieldInstanceStatus` · `appPlatformReservedDomain` · `appPlatformReservedDomains`
+
+### External integrations long-tail (CSP / PSA / misc) — _wave 2 · ✅ done_
+
+`microsoftCSPCustomer` · `microsoftCSPCustomers` · `microsoftAllCSPCustomers` · `psaFilterOptions` · `psaOrganizations` · `listDelegatedAccess` · `getHaloLiveChatToken` · `getSkilljarLoginToken` · `getCannyToken` · `getTestUsers` · `getTestUserSession` · `debug` · `login` · `home`
+
+---
+
+## Findings
+
+### Templates & Jinja — _wave 1 · done_
+
+**Batch gotchas:** `template`/`templates` need `orgId` inside `where`. `template` without `id` returns an arbitrary first row (no stable order) — always pass `id`. `templates` has no default limit. `jinjaTemplate` and singular `jinjaFilterDocumentation` are broken. JSON args must be variables.
+
+| field                         | status     | notes                                                                                                                                |
+| ----------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| `template`                    | WORKS      | `where:{ orgId, id }`. Returns full body. `updatedAt` = ms-epoch string.                                                             |
+| `templates`                   | WORKS      | `where` (exact) + `search:{ name:{_ilike} }` compose; `order:[["updatedAt","desc"]]`; `offset` paginates; **no default limit**.      |
+| `jinjaTemplate`               | ERROR      | Crashes `Cannot read properties of null (reading 'override')` for any input — dead resolver.                                         |
+| `cratesForTemplate`           | EMPTY      | `templateId` top-level (no org arg); `[]` unless template came from a crate.                                                         |
+| `jinjaFiltersDocumentation`   | WORKS      | No args/global. ~100+ filters, large → page with `result_read`. param names Title-Cased.                                             |
+| `jinjaFilterDocumentation`    | ERROR      | Singular always returns all-null for any `filterName` — broken; use the plural + filter client-side.                                 |
+| `extractJinjaValues`          | EMPTY      | `fields: JSON!` must be a variable; `orgId` top-level (auto-injected). Returns null in sandbox — likely needs live workflow context. |
+| `jinjaRenderSession`          | NEEDS-ARGS | `id` is a conversation/render-session UUID from a prior render; non-existent id crashes.                                             |
+| `monacoFilterCompletionItems` | WORKS      | No args/global. ~100+ items, large. `kind` always 1; `label.detail` holds signature. Powers IDE autocomplete.                        |
+| `latestInterpreterVersions`   | WORKS      | `language` optional (omit = all). Returns list.                                                                                      |
+| `orgInterpreterSetting`       | EMPTY      | **Must** pass both `orgId` AND `language` — `language`-less call crashes; by-`id` crashes on not-found.                              |
+| `orgInterpreterSettings`      | EMPTY      | `orgId: ID!` top-level. Safe plural — `[]` not crash.                                                                                |
+
+**Tool candidates:** enhance existing `list_templates` with `search`+`order`+pagination (currently it just enumerates); a Jinja-filter-docs search wrapper (large payload → searchable, return signature-only); `cratesForTemplate` clean single-arg lookup.
+
+### Workflows (core) — _wave 1 · done_
+
+**Batch gotchas:** `workflows(where:{orgId})` is the workhorse list (where+search compose, all boolean flags work except `hasTokens`). `visibleWorkflows` is BROKEN — do not use. `order` is `[[String!]!]` except `workflowPatches` (`orderBy: createdAt_DESC` enum). Timestamps are epoch-ms strings.
+
+**Variable fields (input / output / context) — filter CLIENT-SIDE only.** A `Workflow` exposes all three variable kinds inline in the bulk `workflows(...)` list query (no per-workflow round-trip): `input: [String!]!` (declared input var names), `output: [JSON]!` (array of single-key `{varName: "<jinja>"}` objects — names are the keys), and `varsSchema: JSON` (declared Context Variables, keyed by name). **No server-side filter works for any of them:** `where.input` is exact full-array equality only; `search:{input|output:{_ilike}}` crashes at Postgres (`operator does not exist: jsonb ~~* unknown` — the schema mistypes these jsonb columns as `string_comparison_exp`); `varsSchema` has no filter surface at all (`not defined by type "WorkflowSearch"`/`WorkflowWhereInput`). So variable-name filtering = bulk fetch + in-memory match. ⚠ `varsSchema` holds only **declared** CTX vars; runtime-only `CTX.x` set by tasks (e.g. `set_context`) is not captured — scanning that needs task bodies (`tasks`/`tasksObject`). _(Reference only — no workflow-definition variable-filter tool ships; the real need was filtering **executions** by variable, see the executions section's `find_executions_by_variable`.)_
+
+| field                         | status     | notes                                                                                                                                                  |
+| ----------------------------- | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `workflow`                    | WORKS      | `where:{id}`. Ignores org for auth (bare-id crosses orgs). Wrapped by existing `get_workflow`.                                                         |
+| `workflows`                   | WORKS      | ⭐ primary list/search. `where`(exact)+`search`(`_ilike`); flags work **except `hasTokens:true` crashes**; `order:[[String!]!]`; **no default limit**. |
+| `visibleWorkflows`            | ERROR      | ⚠ BROKEN both forms (SQL join). **`list_workflows` MCP tool uses this — verify.** Use `workflows(where:{orgId})`.                                      |
+| `workflowNote`                | NEEDS-ARGS | only by valid `id`; other filters → `AUTH_ERR`.                                                                                                        |
+| `workflowNotes`               | EMPTY      | `where:{workflowId}` required else `AUTH_ERR`.                                                                                                         |
+| `workflowTask`                | WORKS      | task id = **dash-less hex**; `where:{id}` or `{workflowId,name}`.                                                                                      |
+| `workflowTasks`               | WORKS      | `where:{workflowId}`; enumerate tasks; `next`=transition edges.                                                                                        |
+| `workflowPatch`               | WORKS      | `id:ID!` top-level; `patch`=RFC-6902 JSON array; "Patch not found" error (not null).                                                                   |
+| `workflowPatches`             | WORKS      | ⚠ `workflowId` runtime-required; uses `orderBy: createdAt_DESC` enum; `createdSince`=epoch-ms only.                                                    |
+| `workflowIOConfigurations`    | WORKS      | `ids:[ID!]!` batch; IO contract fields (input/output/schemas).                                                                                         |
+| `workflowCompletionListeners` | WORKS      | `where:{orgId\|workflowId}`; **no `limit`/`offset`/`order`** args; name null.                                                                          |
+
+**Tool candidates:** `workflows` list/search (replace the broken `visibleWorkflows` under `list_workflows`); `workflowTasks` (task inspection); `workflowPatches`+`workflowPatch` (revision history/diff); `workflowIOConfigurations` (batch IO contracts for sub-workflow analysis); `workflowCompletionListeners` (who-listens-to-this-workflow).
+
+### Actions & Packs — _wave 1 · done_
+
+**Batch gotchas:** org-scope is inconsistent — `actions`/`packs`/`actionOptions` are global and LEAK cross-org; use `actionsForOrg`/`packsForOrg`. `searchInstalledPackActions` = best "find an action." `commonlyUsedIntegrationActions` needs a pack UUID; `packAuthUrl`/`pack` need a string ref. `packConfigs` lies about `limit`.
+
+| field                                | status        | notes                                                                                                                                                                                                                                        |
+| ------------------------------------ | ------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `action`                             | WORKS         | `where:{id\|ref}`; null on not-found; `Action.orgId` null for global.                                                                                                                                                                        |
+| `actions`                            | WORKS(global) | ⚠ leaks cross-org; don't declare unused `$orgId`; `ActionSearch._ilike`.                                                                                                                                                                     |
+| `actionsForOrg`                      | WORKS         | org-aware (preferred); `orgId` arg; where+search compose.                                                                                                                                                                                    |
+| `actionOption`                       | EMPTY         | null in sandbox; prefer `packConfig.actionOptions`.                                                                                                                                                                                          |
+| `actionOptions`                      | WORKS         | ⚠ leaks cross-org without `where.organizationId`.                                                                                                                                                                                            |
+| `commonlyUsedIntegrationActions`     | EMPTY         | `integrationId`=pack **UUID** (ref string crashes); needs usage history.                                                                                                                                                                     |
+| `searchInstalledPackActions`         | WORKS         | ⭐ best "find an action"; returns `[Pack]` w/ nested matched `actions`. ⚠ nested `actions(limit:N)` is **not respected** (returns far more) and total result is large → a dedicated tool must flatten + cap client-side. No top-level limit. |
+| `workflowsAffectedByBreakingChanges` | EMPTY         | `actions:[{packRef,actionRefs}]` (refs); upgrade-impact analysis.                                                                                                                                                                            |
+| `pack`                               | WORKS         | `where:{ref\|id}`; null on not-found.                                                                                                                                                                                                        |
+| `packs`                              | WORKS(global) | ⚠ `where:{orgId}` silently `[]` — use `packsForOrg`.                                                                                                                                                                                         |
+| `packsByTag`                         | WORKS         | `tagName` string; global; no pagination.                                                                                                                                                                                                     |
+| `packsForOrg`                        | WORKS         | org-aware; `includeSpec:true` for schema fields.                                                                                                                                                                                             |
+| `packConfig`                         | WORKS         | `where:{orgId,packId}`; ts epoch-ms.                                                                                                                                                                                                         |
+| `packConfigs`                        | WORKS         | ⚠ advertises `limit`/`offset` but resolver rejects `limit` — no pagination.                                                                                                                                                                  |
+| `packConfigsForOrg`                  | WORKS         | `packIds:[ID!]!` required, non-empty.                                                                                                                                                                                                        |
+| `packActionOption`                   | EMPTY         | null; singular.                                                                                                                                                                                                                              |
+| `packActionOptions`                  | ERROR         | `Not Authorized` (`verifyUserManagesOrg`).                                                                                                                                                                                                   |
+| `packBundle`                         | WORKS         | `where:PackBundleWhereInput!` required; nested packs.                                                                                                                                                                                        |
+| `packBundles`                        | WORKS         | `search.ref` plain String (inconsistent).                                                                                                                                                                                                    |
+| `packsAndBundlesByInstalledState`    | WORKS         | ⭐ installed vs marketplace; best install-state call.                                                                                                                                                                                        |
+| `resourceTypesByPack`                | WORKS         | no args/global; large.                                                                                                                                                                                                                       |
+| `packAuthUrl`                        | WORKS         | `packName`=string **ref**; null if already authed.                                                                                                                                                                                           |
+| `localReferenceOptions`              | WORKS         | ⭐ generic dropdown options; `modelName` enum (Crate/Organization/PackConfig/Template/Workflow/Trigger/Form/Site/Page/Role/User…); name→id resolver.                                                                                         |
+
+**Tool candidates:** `searchInstalledPackActions` (find-an-action); `localReferenceOptions` (universal name→id resolver — high value); `packsAndBundlesByInstalledState` (install state); `actionsForOrg` (org action catalog); `workflowsAffectedByBreakingChanges` (pre-upgrade impact).
+
+### Orgs, Users & Variables — _wave 1 · done_
+
+**Batch gotchas:** `searchManagedOrgs(input:{search})` = simplest "find org by name" (server substring, case-insensitive). `organizations` needs an explicit `limit` (3315-org account!). Always `maskSecrets:true`. Enum literals unquoted. Several broken resolvers (see roster).
+
+| field                                           | status | notes                                                                                                                |
+| ----------------------------------------------- | ------ | -------------------------------------------------------------------------------------------------------------------- |
+| `organization`                                  | WORKS  | `where:{id\|orgSlug}`+search; single.                                                                                |
+| `organizations`                                 | WORKS  | where(exact)+search(`_ilike`); ⚠ **no default limit**; search-alone is global.                                       |
+| `managedAndSubOrganizations`                    | WORKS  | `parentOrgId!` (not auto-orgId); includes self; search only.                                                         |
+| `orgSearch`                                     | WORKS  | `rootOrgId!`+`breadcrumbRootOrgId!`; ⚠ rootOrgId scoping unreliable (global tree); breadcrumbs null when in-subtree. |
+| `searchManagedOrgs`                             | WORKS  | ⭐ `input:{search,limit,offset}`; substring/case-insensitive; `managingOrgId` null on results.                       |
+| `myAccessibleOrganizations`                     | ERROR  | server crash (`findAll` undefined).                                                                                  |
+| `userOrganization`                              | WORKS  | token's **home** org (ignores request orgId).                                                                        |
+| `isOrgManagedBy`                                | WORKS  | `orgId,parentOrgId`; transitive; Boolean.                                                                            |
+| `orgBreadcrumb`                                 | WORKS  | ancestors **above** rootOrgId (inverted); empty if in-subtree.                                                       |
+| `softDeletedOrgs`                               | EMPTY  | `managingOrgId!`; no limit.                                                                                          |
+| `organizationsWithFeaturePreviewSettingEnabled` | ERROR  | staff-only.                                                                                                          |
+| `me`                                            | WORKS  | auth user; home org may ≠ session org.                                                                               |
+| `user`                                          | WORKS  | `where.orgId: ID!` required; only users _directly_ in org; null on not-found.                                        |
+| `users`                                         | WORKS  | `where:{orgId}` required; `search._ilike`.                                                                           |
+| `checkUserManagesOrg`                           | WORKS  | Boolean; cheap auth check.                                                                                           |
+| `userInvite` / `userInvites`                    | EMPTY  | scope w/ `where.orgId`.                                                                                              |
+| `orgVariable`                                   | WORKS  | `where:{orgId,name}`; ⚠ plaintext secrets unless `maskSecrets:true`; category enum unquoted.                         |
+| `orgVariables`                                  | WORKS  | ⭐ pass `maskSecrets:true`; where+`search._ilike`.                                                                   |
+| `visibleOrgVariables`                           | WORKS  | `visibleForOrgId!`; always masks; includes cascaded (row `orgId`=source).                                            |
+| `visibleOrgVariablesCount`                      | ERROR  | returns null for `Int!` — broken.                                                                                    |
+
+**Tool candidates:** `searchManagedOrgs` (find-org-by-name — the common case); `organizations` scoped search (`where:{managingOrgId}`+`search._ilike`); `orgVariables`/`visibleOrgVariables` (always mask); `me`+`checkUserManagesOrg` (auth/whoami); `users` list.
+
+### Triggers, Sensors, Forms, Tags, Sites, Integrations — _wave 1 · done_
+
+**Batch gotchas:** org scope via `where:{orgId}` everywhere (search.organization joins are broken). `tags` crashes with no scope. `sensorTypes`/`triggerTypes`/`integrations` are global catalogs. `nextFireTime`=epoch-ms, `state`=JSON.
+
+| field                                        | status        | notes                                                                            |
+| -------------------------------------------- | ------------- | -------------------------------------------------------------------------------- |
+| `trigger`                                    | WORKS         | `where:{orgId\|id}`; first match.                                                |
+| `triggers`                                   | WORKS         | `where:{orgId}` to filter; `hasTagIds`/`excludeTagIds` `[ID!]`.                  |
+| `triggerType`                                | WORKS(global) | `where:{ref}`; no `search` on singular.                                          |
+| `triggerTypes`                               | WORKS(global) | `search.isPoll`/`isWebhook` plain Boolean.                                       |
+| `triggerDbNotificationErrors`                | EMPTY         | `triggerId` req; field `raised_at` snake_case.                                   |
+| `getTriggerErrorStatus`                      | WORKS         | batch JSON map `{id:bool}`; health check.                                        |
+| `sensorType` / `sensorTypes`                 | WORKS(global) | infra catalog; low agent utility.                                                |
+| `orgTriggerInstance` / `orgTriggerInstances` | WORKS         | schedule/state; `nextFireTime` epoch-ms; `state` JSON (cron/tz).                 |
+| `form`                                       | WORKS         | `where:{orgId,name}`; `orgContextId` for shared; `search.organizationId` broken. |
+| `forms`                                      | WORKS         | `where:{orgId}` only; `hasTagIds` `[ID]`.                                        |
+| `evaluatedForm`                              | WORKS         | `where:{orgId!,triggerId!}`; the form for a trigger.                             |
+| `packConfigsForForm`                         | EMPTY         | `formId!,orgId!`; pass `orgId:$orgId` explicitly.                                |
+| `tag`                                        | WORKS         | `where:{orgId,name}`; crashes w/o orgId.                                         |
+| `tags`                                       | WORKS         | ⚠ crashes with no scope; `search.orgId` bypasses scope (global).                 |
+| `crateTags`                                  | EMPTY         | crate-marketplace tags; not org-owned.                                           |
+| `site`                                       | WORKS         | `where:{orgId,name}`; `search.organizationId` broken.                            |
+| `sites`                                      | WORKS         | **no `limit`/`offset`/`order`** args.                                            |
+| `getAppPermissions`                          | WORKS         | `orgId!`; sites the org can access (perm-filtered).                              |
+| `getSiteTheme`                               | WORKS         | `domain\|id`; large MUI JSON; not agent-useful.                                  |
+| `validateSiteDomain`                         | WORKS         | pre-create check; `isValid`+`message`.                                           |
+| `integrations`                               | WORKS(global) | no org filter; `numInstalled` platform-wide.                                     |
+
+**Tool candidates:** `triggers` list (workflow-invocation context); `orgTriggerInstances` (schedule view); `getTriggerErrorStatus` (batch health); `forms` + `evaluatedForm` (form for a trigger); `tags` list (resolve ids for `hasTagIds`); `getAppPermissions`/`sites`.
+
+### Workflow executions, tasks & stats — _wave 1 · done_
+
+**Batch gotchas:** date args = ISO 8601, output ts = epoch-ms. Several aggregates time out (see roster). `pendingTasksAggregate` needs `status`. Org-scoped `taskLogs` → use `search`, not `where`. Stats fields take `orgId` as a named arg (`$orgId`), not auto-filter.
+
+**Execution variable fields (input / output / context) — filter CLIENT-SIDE only, scoped to ONE workflow.** Run input/output live on the nested `WorkflowExecution.conductor` object: `conductor.input` (JSON `{varName: value}`, the values a run started with) and `conductor.output` (JSON, same; `null` until the run completes) — both selectable **inline** in the bulk `workflowExecutions(...)` list, so one round-trip. The run's CTX is NOT on `WorkflowExecution`; it is the separate root field `workflowExecutionContexts(workflowExecutionId)` (JSON array of frames, each a flat `{key: value}`), so context = **one extra call per execution** (N+1, ~1–3 KB each; `conductor.state.contexts` is always `[]` — not the CTX source). **No server-side variable filter exists at all** — `WorkflowExecutionWhereInput`/`WorkflowExecutionSearchInput` expose no input/output/context/conductor field (attempts fail at GraphQL validation, stricter than the `Workflow`-def case). Filterable fields are only `id, orgId, status, originatingExecutionId, numAwaitingResponseTasks, workflowId, createdAt, processedCompletionAt`. ⚠ `workflowExecutions` with no `where` leaks other orgs' runs — always pass `where:{orgId, workflowId}`. Org-wide var search is infeasible (100+ runs/workflow), so the tool requires `workflowId`. Built as `find_executions_by_variable` (`kind: input|output|context`, optional `value`).
+
+| field                        | status  | notes                                                                                                             |
+| ---------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `workflowExecution`          | WORKS   | `where`(exact)+`search`(ops); first match; ts epoch-ms.                                                           |
+| `workflowExecutions`         | WORKS   | ⭐ list; `where:{orgId}` + `order:[["createdAt","DESC"]]`; `search.status._eq`.                                   |
+| `latestWorkflowExecution`    | WORKS   | `workflowId!`+`orgId!` named args; optional `status`.                                                             |
+| `workflowExecutionContexts`  | WORKS   | `workflowExecutionId` literal (no `$orgId` — would be unused); returns raw JSON context array. Unique debug data. |
+| `workflowExecutionStats`     | WORKS   | ⭐ `orgId`+`createdSince!` (ISO); fast status counts + `humanSecondsSaved`.                                       |
+| `taskLog`                    | WORKS   | `where:{workflowExecutionId}`; `executionTime`=Python duration string.                                            |
+| `taskLogs`                   | WORKS   | `search:{principalOrgId:{_eq}}` (⚠ `where:{principalOrgId}` times out); `order` pairs.                            |
+| `taskExecutionStats`         | ERROR   | times out always — avoid.                                                                                         |
+| `dailyTaskCountsByDateRange` | WORKS   | `startDate!`/`endDate!` ISO; ⚠ returns future-dated rows (pre-agg).                                               |
+| `hourlyTaskCountByDate`      | WORKS   | `date!` ISO; always 24 rows (`"HH:00"`), UTC, zero-filled.                                                        |
+| `pendingTasksAggregate`      | WORKS   | ⚠ `status` required (crash without); `where.workflowExecution.orgId` for scope; `{count}`.                        |
+| `timeSavedGroupByWorkflow`   | EMPTY   | `updatedAt!` ISO + `useStatsTable: false` (true times out); empty unless time-saved configured.                   |
+| `timeSavedGroupBySubOrg`     | EMPTY   | MSP-tier; same caveats; `ranForOrg`=org name.                                                                     |
+| `dailyTimeSavedByDateRange`  | WORKS\* | short ranges only (≤~3 wks; longer times out); `seconds` per day.                                                 |
+| `hourlyTimeSavedByDate`      | ERROR   | times out always (unlike `hourlyTaskCountByDate`) — avoid.                                                        |
+| `workflowStatsByOrg`         | WORKS   | ⭐ `startDate!`/`endDate!` ISO; reliable per-workflow cumulative stats; good `timeSaved*` alternative.            |
+
+**Tool candidates:** `workflowExecutions` list + `latestWorkflowExecution` (run history/debug); `workflowExecutionStats` + `workflowStatsByOrg` (reliable dashboards); `workflowExecutionContexts` (execution-context debugging — unique data); `taskLogs` (with `search` scoping); `pendingTasksAggregate` (monitoring, status required). Avoid the timeout-prone aggregates or guard ranges tightly.
+
+<!-- WAVE-1 FINDINGS APPENDED ABOVE THIS LINE -->
+
+### Conversations & RoboRewsty — _wave 2 · done_
+
+**Batch gotchas:** `conversations` needs explicit `where:{orgId}` (no-where crashes). Vote resolvers broken. `myRoboRewstyPreferences` (no-arg) beats the userId-scoped `userRoboRewstyPreferences`. RoboRewsty config is global (not org-scoped).
+
+| field                                                      | status | notes                                                                                                                                                |
+| ---------------------------------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `conversation`                                             | WORKS  | `id` arg; `messages(limit:)`, `metadata`=full workflow snapshot; `firstUserMessage` has no `id`.                                                     |
+| `conversations`                                            | WORKS  | `where:{orgId}` required (no-where crashes); filter by `type`/`userId`. RoboRewsty chat history.                                                     |
+| `conversationMessageVotes`                                 | ERROR  | crashes when filtered (`No info provided to datasource`); `[]` unfiltered.                                                                           |
+| `messageVoteStats`                                         | ERROR  | crashes always (same bug).                                                                                                                           |
+| `activeConversationRequest` / `activeConversationRequests` | WORKS  | ephemeral in-flight state; null/`[]` outside active streaming.                                                                                       |
+| `roboRewstyWorkflowDraftState`                             | WORKS  | `orgId!`+`workflowId!`; null unless Rewsty mid-edit.                                                                                                 |
+| `roboRewstyConfigOption`                                   | WORKS  | `where:{configName,configKey,id}`; single AI config record.                                                                                          |
+| `roboRewstyConfigOptions`                                  | WORKS  | global AI config (prompts/models/functions); `configName`: jinja_autocomplete, documentation_generator, component_generator, chart_generator; large. |
+| `userRoboRewstyPreferences`                                | WORKS  | `where:{userId}` = own id only (else Unauthorized); prefer `my…`.                                                                                    |
+| `myRoboRewstyPreferences`                                  | WORKS  | ⭐ no-arg; current user's `alwaysAllowedTools` allowlist + `customInstructions`.                                                                     |
+
+**Tool candidates:** `conversations`+`conversation` (read RoboRewsty chat history); `roboRewstyConfigOptions` (inspect AI config); `myRoboRewstyPreferences` (tool allowlist). Most of the rest is ephemeral/broken.
+
+### Crates — _wave 2 · done_
+
+**Batch gotchas:** `crate.orgId` = **authoring** org (not caller's) — don't filter by it; use `selectedOrgId` + `isUnpackedForSelectedOrg` for "installed here?". `crateCategories.selectedOrgId` is required. `crateExportInfo` = 13 MB (always page). UseCases empty in sandbox.
+
+| field                            | status | notes                                                                                                      |
+| -------------------------------- | ------ | ---------------------------------------------------------------------------------------------------------- |
+| `crate`                          | WORKS  | `where:{name\|id}`+`selectedOrgId` (optional; populates `isUnpackedForSelectedOrg`); `where.orgId`=author. |
+| `crates`                         | WORKS  | ⭐ browse marketplace w/ per-org install status via `selectedOrgId`.                                       |
+| `crateUseCase` / `crateUseCases` | EMPTY  | no records in sandbox; callable, no error.                                                                 |
+| `crateTokenTypes`                | WORKS  | no-arg static `[String!]` enum list.                                                                       |
+| `crateCategories`                | WORKS  | `selectedOrgId: ID!` **required**; JSON `[{label,description}]` (6 cats).                                  |
+| `crateExportInfo`                | WORKS  | `workflowId`=crate's primary wf; ⚠ **13 MB** JSON → always `result_read`.                                  |
+| `crateUnpackingArgumentSet`      | WORKS  | by `id` (or `orgId`); null by `crateId` alone; saved install args.                                         |
+| `publicCrates`                   | WORKS  | no auth/org; trimmed `PublicCrate` type; `limit`/`offset` only.                                            |
+| `cratesForForm`                  | EMPTY  | `formId` req; `[]` everywhere tested.                                                                      |
+
+**Tool candidates:** `crates`/`crate` (marketplace browse + install-status); `publicCrates` (unauth discovery); `crateTokenTypes`/`crateCategories` (static UI enums). Skip the empty/oversized ones for agents.
+
+### Permissions, Roles & Audit — _wave 2 · done_
+
+**Batch gotchas:** mostly walled. Three auth tiers, all unclearable by a normal session: `requiresSuperuser` (`warrants`) > `requiresStaffOrSupportRole` (`checkSpiceDBPermission`) > SpiceDB-feature-flag (`formPermissionState`, `bulkFormPermissionsAudit`, `bulkOrganizationsAudit`). `checkAuthorization`/`check` use **WorkOS** (not SpiceDB) and reject `objectType:"organization"` (`resource-type organization not found` — correct type unknown). `permissions` leaks cross-org with sparse/null fields. The `roles` family is the usable part.
+
+| field                              | status | notes                                                                           |
+| ---------------------------------- | ------ | ------------------------------------------------------------------------------- |
+| `permission`                       | WORKS  | sparse — only `id`/`relation` reliably populated.                               |
+| `permissions`                      | WORKS  | ⚠ cross-org, 9 MB, mostly-null fields — too noisy.                              |
+| `checkAuthorization` / `check`     | ERROR  | WorkOS; `resource-type organization not found` (correct type unknown).          |
+| `checkSpiceDBPermission`           | ERROR  | staff/support only.                                                             |
+| `formPermissionState`              | ERROR  | SpiceDB flag required.                                                          |
+| `bulkFormPermissionsAudit`         | ERROR  | SpiceDB flag required.                                                          |
+| `permissionAuditLog`               | ERROR  | crashes (null for non-null `!`); org-enrollment gated.                          |
+| `warrants`                         | ERROR  | superuser only.                                                                 |
+| `roles`                            | WORKS  | `where:{orgId}` (else cross-org); `userCount` null here — use `roleUserCounts`. |
+| `roleUserCounts`                   | WORKS  | `roleIds!`+`orgId!`; batch user counts.                                         |
+| `roleOrganizationMemberships`      | WORKS  | `roleId!`; orgs assigned a role; paginates.                                     |
+| `roleOrganizationMembershipCounts` | WORKS  | `roleIds!`+`orgId!`; batch org-membership counts.                               |
+| `bulkOrganizationsAudit`           | ERROR  | SpiceDB flag required.                                                          |
+
+**Tool candidates:** `roles` + `roleUserCounts`/`roleOrganizationMemberships(Counts)` (role inspection). Everything else is auth-gated or broken — skip.
+
+### Onboarding, Imports & Admin long-tail — _wave 2 · done_
+
+**Batch gotchas:** onboarding tables are empty in sandbox (callable, `[]`/null). `reservedOrganizationName(s)` + `appPlatformReservedDomain(s)` are superuser-only. `onboardingQuestionnaireResponses` (plural) is `verifyUserManagesOrg`-gated though the singular returns null. Onboarding `*SearchInput` are plain-equality despite the name. `organizationImport`/`orgFormFieldInstanceStatus` throw NOT_FOUND (not null) on bad ids.
+
+| field                                                    | status | notes                                                                                   |
+| -------------------------------------------------------- | ------ | --------------------------------------------------------------------------------------- |
+| `organizationImport`                                     | WORKS  | `id` arg; NOT_FOUND on bad id; import-job status.                                       |
+| `organizationImports`                                    | EMPTY  | `orgId` positional; `status`/`importType` enum filters; `[]` in sandbox.                |
+| `organizationOnboardingCrateRequirement(s)`              | EMPTY  | `where.orgId: ID!` required; search=plain equality.                                     |
+| `organizationOnboardingPackRequirement(s)`               | EMPTY  | `where.orgId` required; pack install/config state.                                      |
+| `organizationOnboardingRequirement`                      | EMPTY  | ⭐(if populated) one-call onboarding summary w/ nested pack+crate reqs + questionnaire. |
+| `onboardingQuestionnaireResponse`                        | EMPTY  | no `orgId` in where; filter by `onboardingRequirementId`.                               |
+| `onboardingQuestionnaireResponses`                       | ERROR  | `verifyUserManagesOrg` auth-gated.                                                      |
+| `reservedOrganizationName` / `reservedOrganizationNames` | ERROR  | superuser-only (`where!` / `order!` required).                                          |
+| `featurePreviewSetting`                                  | WORKS  | singular, arbitrary first; filter by `label`/`id`.                                      |
+| `featurePreviewSettings`                                 | WORKS  | full list (no pagination); `order!` required; feature-flag discovery.                   |
+| `foreignObjectReference(s)`                              | EMPTY  | niche cross-object tracing; no pagination on plural.                                    |
+| `orgFormFieldInstance`                                   | EMPTY  | by `id` only; silent null on miss.                                                      |
+| `orgFormFieldInstances`                                  | EMPTY  | `formFieldId` positional; no discovery path.                                            |
+| `orgFormFieldInstanceStatus`                             | WORKS  | `formId`+`orgId` positional; Boolean; NOT_FOUND on bad form.                            |
+| `appPlatformReservedDomain(s)`                           | ERROR  | superuser-only.                                                                         |
+
+**Tool candidates:** `organizationImports`+`organizationImport` (import-job monitoring); `organizationOnboardingRequirement` (onboarding summary, if a real onboarding org); `featurePreviewSettings` (feature-flag discovery). Rest is empty/superuser-gated.
+
+### Components & Pages — _wave 2 · done_
+
+**Batch gotchas:** Pages family is solid; Components are empty in sandbox (need an App-Platform org). `componentInstances` is broken via MCP. `components`/`pages` take `orgId` (inline literal / nested `where.orgId`) — don't rely on a top-level `$orgId` here. `encoded` fields are compressed craft.js trees. `livePage` needs `domain`+`path` despite schema optionality.
+
+| field                                  | status | notes                                                                                               |
+| -------------------------------------- | ------ | --------------------------------------------------------------------------------------------------- |
+| `component`                            | EMPTY  | `id`; null on miss; no components in sandbox.                                                       |
+| `components`                           | WORKS  | `orgId` **inline literal** (not `$orgId`); `[]` in sandbox.                                         |
+| `componentsByRoots`                    | EMPTY  | `rootIds`; unclear semantics (component roots?).                                                    |
+| `componentTree`                        | ERROR  | crashes on not-found (`reading 'versions'`); `encoded` craft.js tree.                               |
+| `recentComponentVersions`              | ERROR  | crashes on not-found (`Component … not found`); version history.                                    |
+| `componentInstance`                    | EMPTY  | by `id`; null on miss; `pageNodes` encoded string.                                                  |
+| `componentInstances`                   | ERROR  | broken via MCP (orgId-injection collision).                                                         |
+| `componentInstancesByPage`             | WORKS  | `pageId`; `[]` in sandbox.                                                                          |
+| `componentInstancesByComponentVersion` | WORKS  | `componentVersionId`; impact analysis.                                                              |
+| `page`                                 | WORKS  | `where:PageWhereInput!` (`id`/`path`/`orgId`); single page.                                         |
+| `pages`                                | WORKS  | ⭐ `where:{orgId}`(inline) + `search:{name,siteId}` (plain, no `_ilike`) + `order`. Page discovery. |
+| `pageVars`                             | WORKS  | `id`; JSON array of page vars; `[]` in sandbox.                                                     |
+| `pageNode`                             | WORKS  | `id`; single node w/ full `props`/`type` JSON.                                                      |
+| `pageNodes`                            | WORKS  | `where:PageWhereInput!`; `encoded` full node tree (bulk).                                           |
+| `livePage`                             | WORKS  | `domain`+`path` (both effectively required); resolves page as a visitor.                            |
+| `pageElements`                         | WORKS  | ⭐ `pageId`; flat list of all page nodes (omit `props` unless needed). Page inspection.             |
+
+**Tool candidates:** `pages`+`page` (App-Platform page discovery/fetch); `pageElements`+`pageNode` (page UI inspection); `components`+`componentTree`/`recentComponentVersions` (component inspection, for orgs that use them). Skip the broken `componentInstances`.
+
+### External integrations long-tail (CSP / PSA / misc) — _wave 2 · done_
+
+**Batch gotchas:** CSP needs a caller-owned `cspPackConfigId` (`microsoftAllCSPCustomers` is feature-flag gated). PSA `psaRef` is an **undocumented string allowlist** (`connectwise`/`autotask`/`halo` all rejected as `Unsupported PSA type`) — no enum exposed. `login`/`home` are `!`-typed but crash (null) on standard domains (white-label only). `debug` is always null. `PsaAccountType`/`PsaStatus` expose `label`, not `name`.
+
+| field                                                              | status | notes                                                                    |
+| ------------------------------------------------------------------ | ------ | ------------------------------------------------------------------------ |
+| `microsoftCSPCustomer` / `microsoftCSPCustomers`                   | ERROR  | `verifyUserManagesCSPCustomer`; need caller-owned `cspPackConfigId`.     |
+| `microsoftAllCSPCustomers`                                         | ERROR  | org feature-flag gated.                                                  |
+| `psaFilterOptions` / `psaOrganizations`                            | ERROR  | NEEDS valid `psaRef` (undocumented allowlist) + configured PSA pack.     |
+| `listDelegatedAccess`                                              | ERROR  | `Partner delegated access feature not enabled`; arg is `organizationId`. |
+| `getHaloLiveChatToken` / `getSkilljarLoginToken` / `getCannyToken` | WORKS  | return short-lived auth tokens (don't surface values); no MCP utility.   |
+| `getTestUsers`                                                     | EMPTY  | `where.orgId: ID!` required; `[]` in sandbox.                            |
+| `getTestUserSession`                                               | EMPTY  | null; test infra.                                                        |
+| `debug`                                                            | EMPTY  | always null (vestigial).                                                 |
+| `login`                                                            | ERROR  | `Login!` but null-crashes on standard domains (white-label only).        |
+| `home`                                                             | ERROR  | `String!` but null-crashes on standard domains.                          |
+
+**Tool candidates:** none — all pack/flag/white-label-gated or vestigial.
+
+<!-- WAVE-2 FINDINGS APPENDED ABOVE THIS LINE -->
+
+_All 113 root Query fields probed. See the coverage tracker above and the prioritized tool plan near the top._

--- a/docs/dev/graphql-field-guide.md
+++ b/docs/dev/graphql-field-guide.md
@@ -16,7 +16,7 @@
 
 Each probed field gets a block:
 
-```
+```text
 ### fieldName
 - **status:** WORKS | ERROR | EMPTY (callable, no data in sandbox) | NEEDS-ARGS (required input we couldn't satisfy)
 - **minimal working call:** the smallest query + variables that returned data (or the precise args needed)
@@ -89,7 +89,7 @@ Rewst's native behaviour by paginating ourselves and ranking locally._
 
 ### ✅ Built this session — 26 new read tools + 1 fix (all type-check + unit-test green)
 
-Status: implemented, type-checked, unit-tested (562 passing). **Not yet live** — needs an extension rebuild + window reload to register on the MCP server. Live-query validation happens with the Haiku pass once the server is back.
+Status: implemented, type-checked, unit-tested (full unit suite green), and live-smoke-tested over MCP against the sandbox org.
 
 **`src/capabilities/rewstReadCapabilities.ts`** (+ `inputHelpers.ts`):
 

--- a/docs/dev/rewst-ai-api.md
+++ b/docs/dev/rewst-ai-api.md
@@ -30,9 +30,11 @@ NEXT_PUBLIC_API_URI    = https://api.rewst.io/graphql
 NEXT_PUBLIC_API_WS_URI = wss://api.rewst.io/subscriptions
 ```
 
-For multi-region support, fetch `__ENV.js` from the region's app host (or add a
-`wsUrl` field to `RegionConfig` defaulting to the graphql URL with `/graphql` →
-`/subscriptions`). A WS upgrade attempt against `/graphql` returns HTTP 400 — the
+For multi-region support, fetch `__ENV.js` from the region's app host, or set the
+optional `subscriptionsUrl` field on `RegionConfig`. When it is omitted,
+`getSubscriptionsUrl()` derives the endpoint from `graphqlUrl` by swapping the
+scheme to `ws` and `/graphql` → `/subscriptions`. A WS upgrade attempt against
+`/graphql` returns HTTP 400 — the
 upgrade falls through to Apollo Server's HTTP handler (Apollo Server 4 + Express;
 its CSRF guard generates the 400 body).
 

--- a/docs/dev/rewst-ai-api.md
+++ b/docs/dev/rewst-ai-api.md
@@ -25,7 +25,7 @@ no further events. This cost us a debugging round; don't repeat it.
 The WS endpoint is not guessable from the schema. It comes from the web app's runtime
 config at `https://app.rewst.io/__ENV.js`:
 
-```
+```text
 NEXT_PUBLIC_API_URI    = https://api.rewst.io/graphql
 NEXT_PUBLIC_API_WS_URI = wss://api.rewst.io/subscriptions
 ```
@@ -109,7 +109,7 @@ subscription ConversationMessageSubscription(
 
 One subscription produces a stream of events. `status` values observed live, in order:
 
-```
+```text
 request_registered        metadata: { requestId }            ← save requestId for resume
 thinking                  conversation_id now populated      ← save conversation_id for multi-turn
 summarizing               metadata: { agentName: "roborewsty_supervisor" }
@@ -132,7 +132,7 @@ citations in `metadata.sources`.
 Additional statuses handled by the web app (not all observed live, extracted from
 its bundle — treat as the complete set):
 
-```
+```text
 message, success, error, interrupted, conversation_killed, approval_required,
 streaming_thinking, resume_attached, resume_not_found, resume_forbidden
 ```
@@ -269,7 +269,7 @@ Notes:
 
 `scripts/probe-ai.mjs` — standalone exploration/regression tool, no extension code.
 
-```
+```text
 REWST_TEST_TOKEN=<appSession token> node scripts/probe-ai.mjs <command>
 
 whoami                       validate token; prints user + org

--- a/package-lock.json
+++ b/package-lock.json
@@ -43,6 +43,7 @@
 				"graphql-ws": "^6.0.6",
 				"husky": "^9.1.7",
 				"lint-staged": "^15.5.2",
+				"markdownlint-cli2": "^0.22.1",
 				"npm-run-all": "^4.1.5",
 				"prettier": "^3.7.4",
 				"ts-loader": "^9.5.4",
@@ -5014,6 +5015,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@sindresorhus/merge-streams": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-4.0.0.tgz",
+			"integrity": "sha512-tlqY9xq5ukxTUZBmoOp+m61cqwQD5pHJtFY3Mn8CA8ps6yghLH/Hw8UPdqg4OLmFW3IFlcXnQNmo/dh8HzXYIQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/@stylistic/eslint-plugin": {
 			"version": "5.6.1",
 			"resolved": "https://registry.npmjs.org/@stylistic/eslint-plugin/-/eslint-plugin-5.6.1.tgz",
@@ -5070,6 +5084,16 @@
 			"optional": true,
 			"dependencies": {
 				"tslib": "^2.4.0"
+			}
+		},
+		"node_modules/@types/debug": {
+			"version": "4.1.13",
+			"resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+			"integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/ms": "*"
 			}
 		},
 		"node_modules/@types/eslint": {
@@ -5133,6 +5157,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/katex": {
+			"version": "0.16.8",
+			"resolved": "https://registry.npmjs.org/@types/katex/-/katex-0.16.8.tgz",
+			"integrity": "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/minimatch": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-5.1.2.tgz",
@@ -5147,6 +5178,13 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/@types/ms": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+			"integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/@types/node": {
 			"version": "25.0.3",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-25.0.3.tgz",
@@ -5156,6 +5194,13 @@
 			"dependencies": {
 				"undici-types": "~7.16.0"
 			}
+		},
+		"node_modules/@types/unist": {
+			"version": "2.0.11",
+			"resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+			"integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/vscode": {
 			"version": "1.120.0",
@@ -6850,6 +6895,39 @@
 				"upper-case-first": "^2.0.2"
 			}
 		},
+		"node_modules/character-entities": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+			"integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-entities-legacy": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+			"integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/character-reference-invalid": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+			"integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/chardet": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-2.1.1.tgz",
@@ -7388,6 +7466,20 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/decode-named-character-reference": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+			"integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"character-entities": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/deep-is": {
 			"version": "0.1.4",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -7450,6 +7542,16 @@
 				"node": ">= 0.6.0"
 			}
 		},
+		"node_modules/dequal": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+			"integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/detect-indent": {
 			"version": "6.1.0",
 			"resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-6.1.0.tgz",
@@ -7471,6 +7573,20 @@
 			},
 			"engines": {
 				"node": ">=0.10"
+			}
+		},
+		"node_modules/devlop": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+			"integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"dequal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/diff": {
@@ -7592,6 +7708,19 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
+			}
+		},
+		"node_modules/entities": {
+			"version": "4.5.0",
+			"resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+			"integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+			"dev": true,
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=0.12"
+			},
+			"funding": {
+				"url": "https://github.com/fb55/entities?sponsor=1"
 			}
 		},
 		"node_modules/env-paths": {
@@ -9374,9 +9503,9 @@
 			}
 		},
 		"node_modules/ignore": {
-			"version": "7.0.4",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.4.tgz",
-			"integrity": "sha512-gJzzk+PQNznz8ysRrC0aOkBNVRBDtE1n53IqyqEf3PXrYwomFs5q4pGMizBMJF+ykh03insJ27hB8gSrD2Hn8A==",
+			"version": "7.0.5",
+			"resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.5.tgz",
+			"integrity": "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9545,6 +9674,32 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-alphabetical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+			"integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
+		"node_modules/is-alphanumerical": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+			"integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-alphabetical": "^2.0.0",
+				"is-decimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/is-array-buffer": {
 			"version": "3.0.5",
 			"resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.5.tgz",
@@ -9710,6 +9865,17 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-decimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+			"integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9776,6 +9942,17 @@
 			},
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/is-hexadecimal": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+			"integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
 			}
 		},
 		"node_modules/is-interactive": {
@@ -10378,6 +10555,23 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/jsonc-parser": {
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/jsonc-parser/-/jsonc-parser-3.3.1.tgz",
+			"integrity": "sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/jsonpointer": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-5.0.1.tgz",
+			"integrity": "sha512-p/nXbhSEcu3pZRdkW1OfJhpsVtW1gd4Wa1fnQc9YLiTfAjn0312eMKimbdIQzuZl9aa9xUGaRlP9T/CJE/ditQ==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/jszip": {
 			"version": "3.10.1",
 			"resolved": "https://registry.npmjs.org/jszip/-/jszip-3.10.1.tgz",
@@ -10389,6 +10583,33 @@
 				"pako": "~1.0.2",
 				"readable-stream": "~2.3.6",
 				"setimmediate": "^1.0.5"
+			}
+		},
+		"node_modules/katex": {
+			"version": "0.16.47",
+			"resolved": "https://registry.npmjs.org/katex/-/katex-0.16.47.tgz",
+			"integrity": "sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==",
+			"dev": true,
+			"funding": [
+				"https://opencollective.com/katex",
+				"https://github.com/sponsors/katex"
+			],
+			"license": "MIT",
+			"dependencies": {
+				"commander": "^8.3.0"
+			},
+			"bin": {
+				"katex": "cli.js"
+			}
+		},
+		"node_modules/katex/node_modules/commander": {
+			"version": "8.3.0",
+			"resolved": "https://registry.npmjs.org/commander/-/commander-8.3.0.tgz",
+			"integrity": "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 12"
 			}
 		},
 		"node_modules/keyv": {
@@ -10454,6 +10675,26 @@
 			"integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/linkify-it": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.1.tgz",
+			"integrity": "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/puzrin"
+				},
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/markdown-it"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"uc.micro": "^2.0.0"
+			}
 		},
 		"node_modules/lint-staged": {
 			"version": "15.5.2",
@@ -10957,6 +11198,152 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/markdown-it": {
+			"version": "14.1.1",
+			"resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.1.1.tgz",
+			"integrity": "sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"argparse": "^2.0.1",
+				"entities": "^4.4.0",
+				"linkify-it": "^5.0.0",
+				"mdurl": "^2.0.0",
+				"punycode.js": "^2.3.1",
+				"uc.micro": "^2.1.0"
+			},
+			"bin": {
+				"markdown-it": "bin/markdown-it.mjs"
+			}
+		},
+		"node_modules/markdownlint": {
+			"version": "0.40.0",
+			"resolved": "https://registry.npmjs.org/markdownlint/-/markdownlint-0.40.0.tgz",
+			"integrity": "sha512-UKybllYNheWac61Ia7T6fzuQNDZimFIpCg2w6hHjgV1Qu0w1TV0LlSgryUGzM0bkKQCBhy2FDhEELB73Kb0kAg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"micromark": "4.0.2",
+				"micromark-core-commonmark": "2.0.3",
+				"micromark-extension-directive": "4.0.0",
+				"micromark-extension-gfm-autolink-literal": "2.1.0",
+				"micromark-extension-gfm-footnote": "2.1.0",
+				"micromark-extension-gfm-table": "2.1.1",
+				"micromark-extension-math": "3.1.0",
+				"micromark-util-types": "2.0.2",
+				"string-width": "8.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/DavidAnson"
+			}
+		},
+		"node_modules/markdownlint-cli2": {
+			"version": "0.22.1",
+			"resolved": "https://registry.npmjs.org/markdownlint-cli2/-/markdownlint-cli2-0.22.1.tgz",
+			"integrity": "sha512-X14ZbytybDCXAViDmtN4DKLt9ZTrRn+oOrxTYlg3a65jS6QcYYbAkGPh/En2L/GDNbFYJ6lKaQSUNrrbN1bPrw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"globby": "16.2.0",
+				"js-yaml": "4.1.1",
+				"jsonc-parser": "3.3.1",
+				"jsonpointer": "5.0.1",
+				"markdown-it": "14.1.1",
+				"markdownlint": "0.40.0",
+				"markdownlint-cli2-formatter-default": "0.0.6",
+				"micromatch": "4.0.8",
+				"smol-toml": "1.6.1"
+			},
+			"bin": {
+				"markdownlint-cli2": "markdownlint-cli2-bin.mjs"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/DavidAnson"
+			}
+		},
+		"node_modules/markdownlint-cli2-formatter-default": {
+			"version": "0.0.6",
+			"resolved": "https://registry.npmjs.org/markdownlint-cli2-formatter-default/-/markdownlint-cli2-formatter-default-0.0.6.tgz",
+			"integrity": "sha512-VVDGKsq9sgzu378swJ0fcHfSicUnMxnL8gnLm/Q4J/xsNJ4e5bA6lvAz7PCzIl0/No0lHyaWdqVD2jotxOSFMQ==",
+			"dev": true,
+			"license": "MIT",
+			"funding": {
+				"url": "https://github.com/sponsors/DavidAnson"
+			},
+			"peerDependencies": {
+				"markdownlint-cli2": ">=0.0.4"
+			}
+		},
+		"node_modules/markdownlint-cli2/node_modules/globby": {
+			"version": "16.2.0",
+			"resolved": "https://registry.npmjs.org/globby/-/globby-16.2.0.tgz",
+			"integrity": "sha512-QrJia2qDf5BB/V6HYlDTs0I0lBahyjLzpGQg3KT7FnCdTonAyPy2RtY802m2k4ALx6Dp752f82WsOczEVr3l6Q==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sindresorhus/merge-streams": "^4.0.0",
+				"fast-glob": "^3.3.3",
+				"ignore": "^7.0.5",
+				"is-path-inside": "^4.0.0",
+				"slash": "^5.1.0",
+				"unicorn-magic": "^0.4.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/markdownlint-cli2/node_modules/is-path-inside": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+			"integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/markdownlint-cli2/node_modules/slash": {
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+			"integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.16"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/markdownlint/node_modules/string-width": {
+			"version": "8.1.0",
+			"resolved": "https://registry.npmjs.org/string-width/-/string-width-8.1.0.tgz",
+			"integrity": "sha512-Kxl3KJGb/gxkaUMOjRsQ8IrXiGW75O4E3RPjFIINOVH8AMl2SQ/yWdTzWwF3FevIX9LcMAjJW+GRwAlAbTSXdg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"get-east-asian-width": "^1.3.0",
+				"strip-ansi": "^7.1.0"
+			},
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/math-intrinsics": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
@@ -10965,6 +11352,13 @@
 			"engines": {
 				"node": ">= 0.4"
 			}
+		},
+		"node_modules/mdurl": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.0.0.tgz",
+			"integrity": "sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/media-typer": {
 			"version": "1.1.0",
@@ -11030,6 +11424,542 @@
 					"optional": true
 				}
 			}
+		},
+		"node_modules/micromark": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+			"integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"@types/debug": "^4.0.0",
+				"debug": "^4.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-combine-extensions": "^2.0.0",
+				"micromark-util-decode-numeric-character-reference": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-core-commonmark": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+			"integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"decode-named-character-reference": "^1.0.0",
+				"devlop": "^1.0.0",
+				"micromark-factory-destination": "^2.0.0",
+				"micromark-factory-label": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-title": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-classify-character": "^2.0.0",
+				"micromark-util-html-tag-name": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-resolve-all": "^2.0.0",
+				"micromark-util-subtokenize": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-extension-directive": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-directive/-/micromark-extension-directive-4.0.0.tgz",
+			"integrity": "sha512-/C2nqVmXXmiseSSuCdItCMho7ybwwop6RrrRPk0KbOHW21JKoCldC+8rFOaundDoRBUWBnJJcxeA/Kvi34WQXg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-factory-whitespace": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0",
+				"parse-entities": "^4.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-autolink-literal": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+			"integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-footnote": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+			"integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-core-commonmark": "^2.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-normalize-identifier": "^2.0.0",
+				"micromark-util-sanitize-uri": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-gfm-table": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+			"integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-extension-math": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-extension-math/-/micromark-extension-math-3.1.0.tgz",
+			"integrity": "sha512-lvEqd+fHjATVs+2v/8kg9i5Q0AP2k85H0WUOwpIVvUML8BapsMvh1XAogmQjOCsLpoKRCVQqEkQBB3NhVBcsOg==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/katex": "^0.16.0",
+				"devlop": "^1.0.0",
+				"katex": "^0.16.0",
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			},
+			"funding": {
+				"type": "opencollective",
+				"url": "https://opencollective.com/unified"
+			}
+		},
+		"node_modules/micromark-factory-destination": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+			"integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-label": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+			"integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-space": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+			"integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-title": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+			"integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-factory-whitespace": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+			"integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-factory-space": "^2.0.0",
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-character": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+			"integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-chunked": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+			"integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-classify-character": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+			"integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-combine-extensions": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+			"integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-decode-numeric-character-reference": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+			"integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-encode": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+			"integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-html-tag-name": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+			"integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-normalize-identifier": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+			"integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-resolve-all": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+			"integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-sanitize-uri": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+			"integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"micromark-util-character": "^2.0.0",
+				"micromark-util-encode": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-subtokenize": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+			"integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"devlop": "^1.0.0",
+				"micromark-util-chunked": "^2.0.0",
+				"micromark-util-symbol": "^2.0.0",
+				"micromark-util-types": "^2.0.0"
+			}
+		},
+		"node_modules/micromark-util-symbol": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+			"integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
+		},
+		"node_modules/micromark-util-types": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+			"integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+			"dev": true,
+			"funding": [
+				{
+					"type": "GitHub Sponsors",
+					"url": "https://github.com/sponsors/unifiedjs"
+				},
+				{
+					"type": "OpenCollective",
+					"url": "https://opencollective.com/unified"
+				}
+			],
+			"license": "MIT"
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
@@ -12027,6 +12957,26 @@
 				"node": ">=6"
 			}
 		},
+		"node_modules/parse-entities": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+			"integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@types/unist": "^2.0.0",
+				"character-entities-legacy": "^3.0.0",
+				"character-reference-invalid": "^2.0.0",
+				"decode-named-character-reference": "^1.0.0",
+				"is-alphanumerical": "^2.0.0",
+				"is-decimal": "^2.0.0",
+				"is-hexadecimal": "^2.0.0"
+			},
+			"funding": {
+				"type": "github",
+				"url": "https://github.com/sponsors/wooorm"
+			}
+		},
 		"node_modules/parse-filepath": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/parse-filepath/-/parse-filepath-1.0.2.tgz",
@@ -12379,6 +13329,16 @@
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
 			"integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/punycode.js": {
+			"version": "2.3.1",
+			"resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+			"integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13276,6 +14236,19 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/smol-toml": {
+			"version": "1.6.1",
+			"resolved": "https://registry.npmjs.org/smol-toml/-/smol-toml-1.6.1.tgz",
+			"integrity": "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg==",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"engines": {
+				"node": ">= 18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/cyyynthia"
 			}
 		},
 		"node_modules/snake-case": {
@@ -14238,6 +15211,13 @@
 				"node": "*"
 			}
 		},
+		"node_modules/uc.micro": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+			"integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/unbox-primitive": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.1.0.tgz",
@@ -14273,6 +15253,19 @@
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/unicorn-magic": {
+			"version": "0.4.0",
+			"resolved": "https://registry.npmjs.org/unicorn-magic/-/unicorn-magic-0.4.0.tgz",
+			"integrity": "sha512-wH590V9VNgYH9g3lH9wWjTrUoKsjLF6sGLjhR4sH1LWpLmCOH0Zf7PukhDA8BiS7KHe4oPNkcTHqYkj7SOGUOw==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=20"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
 		},
 		"node_modules/unixify": {
 			"version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -697,6 +697,7 @@
 		"graphql-ws": "^6.0.6",
 		"husky": "^9.1.7",
 		"lint-staged": "^15.5.2",
+		"markdownlint-cli2": "^0.22.1",
 		"npm-run-all": "^4.1.5",
 		"prettier": "^3.7.4",
 		"ts-loader": "^9.5.4",
@@ -714,8 +715,12 @@
 			"eslint --fix",
 			"prettier --write"
 		],
-		"*.{json,md}": [
+		"*.json": [
 			"prettier --write"
+		],
+		"*.md": [
+			"prettier --write",
+			"markdownlint-cli2 --fix"
 		]
 	},
 	"dependencies": {

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -38,4 +38,25 @@ suite('Unit: inputHelpers', () => {
 
 		assert.deepStrictEqual(result, [10, 20, 30, 40]);
 	});
+
+	test('mapWithConcurrency rejects zero concurrency limit', async () => {
+		await assert.rejects(
+			() => mapWithConcurrency([1], 0, async (item: number) => item),
+			/"limit" must be a positive integer\./,
+		);
+	});
+
+	test('mapWithConcurrency rejects negative concurrency limit', async () => {
+		await assert.rejects(
+			() => mapWithConcurrency([1], -1, async (item: number) => item),
+			/"limit" must be a positive integer\./,
+		);
+	});
+
+	test('mapWithConcurrency rejects non-integer concurrency limit', async () => {
+		await assert.rejects(
+			() => mapWithConcurrency([1], 1.5, async (item: number) => item),
+			/"limit" must be a positive integer\./,
+		);
+	});
 });

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -1,0 +1,41 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { mapWithConcurrency } from './inputHelpers';
+const { suite, test } = Mocha;
+
+function delay(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+suite('Unit: inputHelpers', () => {
+	test('mapWithConcurrency preserves order', async () => {
+		const result = await mapWithConcurrency([3, 1, 2], 2, async (item: number) => {
+			await delay((4 - item) * 5);
+			return `item-${item}`;
+		});
+
+		assert.deepStrictEqual(result, ['item-3', 'item-1', 'item-2']);
+	});
+
+	test('mapWithConcurrency never exceeds concurrency limit', async () => {
+		let running = 0;
+		let peak = 0;
+
+		await mapWithConcurrency([0, 1, 2, 3, 4, 5, 6, 7], 3, async (item: number) => {
+			running += 1;
+			peak = Math.max(peak, running);
+			assert.ok(running <= 3);
+			await delay(5);
+			running -= 1;
+			return item;
+		});
+
+		assert.strictEqual(peak, 3);
+	});
+
+	test('mapWithConcurrency returns all results', async () => {
+		const result = await mapWithConcurrency([1, 2, 3, 4], 2, async (item: number) => item * 10);
+
+		assert.deepStrictEqual(result, [10, 20, 30, 40]);
+	});
+});

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -22,6 +22,24 @@ export function asPositiveInt(input: Record<string, unknown>, key: string): numb
 	return normalized > 0 ? normalized : undefined;
 }
 
+export async function mapWithConcurrency<T, R>(
+	items: readonly T[],
+	limit: number,
+	fn: (item: T, index: number) => Promise<R>,
+): Promise<R[]> {
+	const results: R[] = new Array(items.length);
+	let next = 0;
+	const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {
+		while (true) {
+			const index = next++;
+			if (index >= items.length) return;
+			results[index] = await fn(items[index], index);
+		}
+	});
+	await Promise.all(workers);
+	return results;
+}
+
 /** Standard orgId property block for capability inputSchemas. */
 export const ORG_ID_PROP = {
 	orgId: { type: 'string', description: 'Rewst organization id the operation runs against (from list_orgs).' },

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -1,0 +1,27 @@
+/**
+ * Shared input-coercion helpers for read capabilities. Mirrors the private
+ * helpers in rewstReadCapabilities.ts so additional capability modules can share
+ * one consistent argument-parsing contract.
+ */
+
+export function asString(input: Record<string, unknown>, key: string): string | undefined {
+	const value = input[key];
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
+}
+
+export function requireString(input: Record<string, unknown>, key: string): string {
+	const value = asString(input, key);
+	if (!value) throw new Error(`Missing required string argument "${key}".`);
+	return value;
+}
+
+export function asPositiveInt(input: Record<string, unknown>, key: string): number | undefined {
+	const value = input[key];
+	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
+	return Math.floor(value);
+}
+
+/** Standard orgId property block for capability inputSchemas. */
+export const ORG_ID_PROP = {
+	orgId: { type: 'string', description: 'Rewst organization id the operation runs against (from list_orgs).' },
+} as const;

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -18,7 +18,8 @@ export function requireString(input: Record<string, unknown>, key: string): stri
 export function asPositiveInt(input: Record<string, unknown>, key: string): number | undefined {
 	const value = input[key];
 	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
-	return Math.floor(value);
+	const normalized = Math.floor(value);
+	return normalized > 0 ? normalized : undefined;
 }
 
 /** Standard orgId property block for capability inputSchemas. */

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -27,6 +27,9 @@ export async function mapWithConcurrency<T, R>(
 	limit: number,
 	fn: (item: T, index: number) => Promise<R>,
 ): Promise<R[]> {
+	if (!Number.isInteger(limit) || limit <= 0) {
+		throw new Error('"limit" must be a positive integer.');
+	}
 	const results: R[] = new Array(items.length);
 	let next = 0;
 	const workers = Array.from({ length: Math.min(limit, items.length) }, async () => {

--- a/src/capabilities/orgUserCapabilities.test.ts
+++ b/src/capabilities/orgUserCapabilities.test.ts
@@ -1,0 +1,60 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import type { Session } from '@sessions';
+import type { CapabilityContext } from './Capability';
+import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
+const { suite, test, setup } = Mocha;
+function fakeCtx(response: unknown) {
+	const calls: { query: string; variables: Record<string, unknown> }[] = [];
+	const session = {
+		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
+			calls.push({ query, variables });
+			return response as { data?: unknown; errors?: unknown };
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+	return { ctx, calls };
+}
+function cap(name: string) {
+	const c = ORG_USER_CAPABILITIES.find(x => x.spec.name === name);
+	if (!c) throw new Error('missing ' + name);
+	return c;
+}
+suite('Unit: orgUserCapabilities', () => {
+	setup(() => initTestEnvironment());
+
+	test('search_organizations forwards name search and formats organizations', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: { searchManagedOrgs: [{ id: 'o1', name: 'Acme', isEnabled: true }] },
+		});
+
+		const output = await cap('search_organizations').run({ orgId: 'org-1', search: 'acme' }, ctx);
+
+		assert.strictEqual(calls[0].variables.search, 'acme');
+		assert.ok(output.includes('Acme'));
+	});
+
+	test('list_users uses users query, maps username search, and formats users', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: { users: [{ id: 'u1', username: 'foo.user', isApiUser: false, roleIds: ['r1'] }] },
+		});
+
+		const output = await cap('list_users').run({ orgId: 'org-1', search: 'foo' }, ctx);
+
+		assert.ok(calls[0].query.includes('users('));
+		assert.deepStrictEqual(calls[0].variables.search, { username: { _ilike: '%foo%' } });
+		assert.ok(output.includes('foo.user'));
+	});
+
+	test('list_roles uses roles query and formats role rows', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: { roles: [{ id: 'r1', name: 'Admin', description: 'Full access' }] },
+		});
+
+		const output = await cap('list_roles').run({ orgId: 'org-1' }, ctx);
+
+		assert.ok(calls[0].query.includes('roles('));
+		assert.ok(output.includes('Admin (r1)'));
+	});
+});

--- a/src/capabilities/orgUserCapabilities.test.ts
+++ b/src/capabilities/orgUserCapabilities.test.ts
@@ -37,7 +37,7 @@ suite('Unit: orgUserCapabilities', () => {
 
 	test('list_users uses users query, maps username search, and formats users', async () => {
 		const { ctx, calls } = fakeCtx({
-			data: { users: [{ id: 'u1', username: 'foo.user', isApiUser: false, roleIds: ['r1'] }] },
+			data: { users: [{ id: 'u1', username: 'foo.user', isApiUser: false, roleIds: ['role-1'] }] },
 		});
 
 		const output = await cap('list_users').run({ orgId: 'org-1', search: 'foo' }, ctx);
@@ -45,6 +45,7 @@ suite('Unit: orgUserCapabilities', () => {
 		assert.ok(calls[0].query.includes('users('));
 		assert.deepStrictEqual(calls[0].variables.search, { username: { _ilike: '%foo%' } });
 		assert.ok(output.includes('foo.user'));
+		assert.ok(output.includes('roles: role-1'));
 	});
 
 	test('list_roles uses roles query and formats role rows', async () => {

--- a/src/capabilities/orgUserCapabilities.test.ts
+++ b/src/capabilities/orgUserCapabilities.test.ts
@@ -1,26 +1,9 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
-import type { Session } from '@sessions';
-import type { CapabilityContext } from './Capability';
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
 const { suite, test, setup } = Mocha;
-function fakeCtx(response: unknown) {
-	const calls: { query: string; variables: Record<string, unknown> }[] = [];
-	const session = {
-		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
-			calls.push({ query, variables });
-			return response as { data?: unknown; errors?: unknown };
-		},
-	} as unknown as Session;
-	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
-	return { ctx, calls };
-}
-function cap(name: string) {
-	const c = ORG_USER_CAPABILITIES.find(x => x.spec.name === name);
-	if (!c) throw new Error('missing ' + name);
-	return c;
-}
+const { fakeCtx, cap } = createCapabilityTestHarness(ORG_USER_CAPABILITIES);
 suite('Unit: orgUserCapabilities', () => {
 	setup(() => initTestEnvironment());
 

--- a/src/capabilities/orgUserCapabilities.test.ts
+++ b/src/capabilities/orgUserCapabilities.test.ts
@@ -14,7 +14,7 @@ suite('Unit: orgUserCapabilities', () => {
 
 		const output = await cap('search_organizations').run({ orgId: 'org-1', search: 'acme' }, ctx);
 
-		assert.strictEqual(calls[0].variables.search, 'acme');
+		assert.strictEqual(calls[0].variables!.search, 'acme');
 		assert.ok(output.includes('Acme'));
 	});
 
@@ -26,7 +26,7 @@ suite('Unit: orgUserCapabilities', () => {
 		const output = await cap('list_users').run({ orgId: 'org-1', search: 'foo' }, ctx);
 
 		assert.ok(calls[0].query.includes('users('));
-		assert.deepStrictEqual(calls[0].variables.search, { username: { _ilike: '%foo%' } });
+		assert.deepStrictEqual(calls[0].variables!.search, { username: { _ilike: '%foo%' } });
 		assert.ok(output.includes('foo.user'));
 		assert.ok(output.includes('roles: role-1'));
 	});

--- a/src/capabilities/orgUserCapabilities.ts
+++ b/src/capabilities/orgUserCapabilities.ts
@@ -86,7 +86,12 @@ async function runListUsers(input: Record<string, unknown>, ctx: CapabilityConte
 	}[];
 	if (users.length === 0) return 'No users found for this organization.';
 	return users
-		.map(user => `${user.username ?? '(unnamed)'} (${user.id})${user.isApiUser ? ' [api]' : ''}`)
+		.map(
+			user =>
+				`${user.username ?? '(unnamed)'} (${user.id})${user.isApiUser ? ' [api]' : ''}${
+					user.roleIds?.length ? ` — roles: ${user.roleIds.join(', ')}` : ''
+				}`,
+		)
 		.join('\n');
 }
 

--- a/src/capabilities/orgUserCapabilities.ts
+++ b/src/capabilities/orgUserCapabilities.ts
@@ -1,0 +1,115 @@
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asString, requireString, asPositiveInt, ORG_ID_PROP } from './inputHelpers';
+
+const SEARCH_ORGANIZATIONS_QUERY =
+	'query($search: String, $limit: Int){ searchManagedOrgs(input:{ search:$search, limit:$limit }){ id name isEnabled } }';
+const LIST_USERS_QUERY =
+	'query($orgId: ID!, $search: UserSearchInput, $limit: Int){ users(where:{ orgId:$orgId }, search:$search, limit:$limit){ id username isApiUser roleIds } }';
+const LIST_ROLES_QUERY = 'query($orgId: ID!){ roles(where:{ orgId:$orgId }){ id name description } }';
+
+const searchOrganizationsSpec: ToolSpec = {
+	name: 'search_organizations',
+	args: '{"orgId": string, "search"?: string, "limit"?: number}',
+	description:
+		'Find organizations by a case-insensitive name substring. orgId only selects which signed-in session to use — results are not limited to that org; they span all organizations the session manages. Returns id, name, isEnabled. Preferred over list_orgs for finding an org by name (list_orgs enumerates every managed org).',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'integer', description: 'Max organizations to return (default 25, max 100).' },
+		},
+		required: ['orgId'],
+	},
+};
+
+const listUsersSpec: ToolSpec = {
+	name: 'list_users',
+	args: '{"orgId": string, "search"?: string, "limit"?: number}',
+	description:
+		'List the users directly in one Rewst organization (id, username, isApiUser, roleIds). Only users in the named org are returned; parent-org users are not inherited.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			search: { type: 'string', description: 'Optional username substring.' },
+			limit: { type: 'integer', description: 'Max users to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+};
+
+const listRolesSpec: ToolSpec = {
+	name: 'list_roles',
+	args: '{"orgId": string}',
+	description: 'List the roles defined in one Rewst organization (id, name, description).',
+	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+};
+
+async function runSearchOrganizations(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	requireString(input, 'orgId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? 25, 100);
+	const search = asString(input, 'search');
+	const variables: Record<string, unknown> = { limit };
+	if (search) variables.search = search;
+	const { data, errors } = await ctx.session.rawGraphql(SEARCH_ORGANIZATIONS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const organizations = ((data as { searchManagedOrgs?: unknown[] } | undefined)?.searchManagedOrgs ?? []) as {
+		id?: string;
+		name?: string;
+		isEnabled?: boolean;
+	}[];
+	if (organizations.length === 0) return 'No organizations found.';
+	return organizations
+		.map(org => `${org.name ?? '(unnamed)'} (${org.id})${org.isEnabled ? '' : ' [disabled]'}`)
+		.join('\n');
+}
+
+async function runListUsers(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const search = asString(input, 'search');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? 50, 200);
+	const variables: Record<string, unknown> = { orgId, limit };
+	if (search) variables.search = { username: { _ilike: `%${search}%` } };
+	const { data, errors } = await ctx.session.rawGraphql(LIST_USERS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const users = ((data as { users?: unknown[] } | undefined)?.users ?? []) as {
+		id?: string;
+		username?: string;
+		isApiUser?: boolean;
+		roleIds?: unknown[];
+	}[];
+	if (users.length === 0) return 'No users found for this organization.';
+	return users
+		.map(user => `${user.username ?? '(unnamed)'} (${user.id})${user.isApiUser ? ' [api]' : ''}`)
+		.join('\n');
+}
+
+async function runListRoles(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const variables: Record<string, unknown> = { orgId };
+	const { data, errors } = await ctx.session.rawGraphql(LIST_ROLES_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const roles = ((data as { roles?: unknown[] } | undefined)?.roles ?? []) as {
+		id?: string;
+		name?: string;
+		description?: string | null;
+	}[];
+	if (roles.length === 0) return 'No roles found for this organization.';
+	return roles
+		.map(role => `${role.name ?? '(unnamed)'} (${role.id})${role.description ? ' — ' + role.description : ''}`)
+		.join('\n');
+}
+
+export const ORG_USER_CAPABILITIES: Capability[] = [
+	{ spec: searchOrganizationsSpec, access: 'read', chat: false, mcp: true, run: runSearchOrganizations },
+	{ spec: listUsersSpec, access: 'read', chat: false, mcp: true, run: runListUsers },
+	{ spec: listRolesSpec, access: 'read', chat: false, mcp: true, run: runListRoles },
+];

--- a/src/capabilities/packIntegrationCapabilities.test.ts
+++ b/src/capabilities/packIntegrationCapabilities.test.ts
@@ -80,7 +80,7 @@ suite('Unit: packIntegrationCapabilities', () => {
 			},
 		});
 		const result = await cap('list_integrations').run({ orgId: 'org-1' }, ctx);
-		assert.ok(typeof result === 'string' && result.includes('integrations(') === false);
+		assert.ok(typeof result === 'string' && !result.includes('integrations('));
 		assert.ok(typeof result === 'string' && result.includes('Slack'));
 	});
 });

--- a/src/capabilities/packIntegrationCapabilities.test.ts
+++ b/src/capabilities/packIntegrationCapabilities.test.ts
@@ -1,0 +1,86 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import type { Session } from '@sessions';
+import type { CapabilityContext } from './Capability';
+import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
+const { suite, test, setup } = Mocha;
+
+function fakeCtx(response: unknown) {
+	const calls: { query: string; variables: Record<string, unknown> }[] = [];
+	const session = {
+		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
+			calls.push({ query, variables });
+			return response as { data?: unknown; errors?: unknown };
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+	return { ctx, calls };
+}
+function cap(name: string) {
+	const c = PACK_INTEGRATION_CAPABILITIES.find(x => x.spec.name === name);
+	if (!c) throw new Error('missing ' + name);
+	return c;
+}
+
+suite('Unit: packIntegrationCapabilities', () => {
+	setup(() => initTestEnvironment());
+
+	test('list_installed_packs formats rows', async () => {
+		const { ctx } = fakeCtx({
+			data: {
+				packsAndBundlesByInstalledState: {
+					installedPacksAndBundles: [
+						{
+							id: 'p1',
+							name: 'Microsoft Graph',
+							ref: 'microsoft_graph',
+							status: 'installed',
+							isBundle: false,
+							packType: 'integration',
+						},
+					],
+				},
+			},
+		});
+		const result = await cap('list_installed_packs').run({ orgId: 'org-1' }, ctx);
+		assert.ok(typeof result === 'string' && result.includes('microsoft_graph'));
+	});
+
+	test('get_pack_auth_status returns configured when url is null', async () => {
+		const { ctx } = fakeCtx({ data: { packAuthUrl: null } });
+		const result = await cap('get_pack_auth_status').run({ orgId: 'org-1', packName: 'microsoft_graph' }, ctx);
+		assert.ok(typeof result === 'string' && result.includes('configured'));
+	});
+
+	test('get_pack_auth_status returns setup url when present', async () => {
+		const { ctx } = fakeCtx({ data: { packAuthUrl: 'https://example.com/auth' } });
+		const result = await cap('get_pack_auth_status').run({ orgId: 'org-1', packName: 'microsoft_graph' }, ctx);
+		assert.ok(typeof result === 'string' && result.includes('needs setup'));
+	});
+
+	test('list_pack_configs query has no limit arg', async () => {
+		let capturedQuery = '';
+		const session = {
+			rawGraphql: async (q: string, _v: unknown) => {
+				capturedQuery = q;
+				return { data: { packConfigs: [] } };
+			},
+		} as unknown as Session;
+		const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+		await cap('list_pack_configs').run({ orgId: 'org-1' }, ctx);
+		assert.ok(capturedQuery.includes('packConfigs('));
+		assert.ok(!capturedQuery.includes('limit'));
+	});
+
+	test('list_integrations formats rows', async () => {
+		const { ctx } = fakeCtx({
+			data: {
+				integrations: [{ name: 'Slack', description: 'Slack integration', numInstalled: 5, isPublic: true }],
+			},
+		});
+		const result = await cap('list_integrations').run({ orgId: 'org-1' }, ctx);
+		assert.ok(typeof result === 'string' && result.includes('integrations(') === false);
+		assert.ok(typeof result === 'string' && result.includes('Slack'));
+	});
+});

--- a/src/capabilities/packIntegrationCapabilities.test.ts
+++ b/src/capabilities/packIntegrationCapabilities.test.ts
@@ -1,27 +1,10 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
-import type { Session } from '@sessions';
-import type { CapabilityContext } from './Capability';
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
 const { suite, test, setup } = Mocha;
 
-function fakeCtx(response: unknown) {
-	const calls: { query: string; variables: Record<string, unknown> }[] = [];
-	const session = {
-		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
-			calls.push({ query, variables });
-			return response as { data?: unknown; errors?: unknown };
-		},
-	} as unknown as Session;
-	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
-	return { ctx, calls };
-}
-function cap(name: string) {
-	const c = PACK_INTEGRATION_CAPABILITIES.find(x => x.spec.name === name);
-	if (!c) throw new Error('missing ' + name);
-	return c;
-}
+const { fakeCtx, cap } = createCapabilityTestHarness(PACK_INTEGRATION_CAPABILITIES);
 
 suite('Unit: packIntegrationCapabilities', () => {
 	setup(() => initTestEnvironment());
@@ -60,15 +43,9 @@ suite('Unit: packIntegrationCapabilities', () => {
 	});
 
 	test('list_pack_configs query has no limit arg', async () => {
-		let capturedQuery = '';
-		const session = {
-			rawGraphql: async (q: string, _v: unknown) => {
-				capturedQuery = q;
-				return { data: { packConfigs: [] } };
-			},
-		} as unknown as Session;
-		const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+		const { ctx, calls } = fakeCtx({ data: { packConfigs: [] } });
 		await cap('list_pack_configs').run({ orgId: 'org-1' }, ctx);
+		const capturedQuery = calls[0].query;
 		assert.ok(capturedQuery.includes('packConfigs('));
 		assert.ok(!capturedQuery.includes('limit'));
 	});

--- a/src/capabilities/packIntegrationCapabilities.ts
+++ b/src/capabilities/packIntegrationCapabilities.ts
@@ -1,0 +1,187 @@
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asString, requireString, asPositiveInt, ORG_ID_PROP } from './inputHelpers';
+
+const MAX_INTEGRATIONS_LIMIT = 200;
+
+function optionalString(value: unknown): string | undefined {
+	return asString({ value }, 'value');
+}
+
+const listInstalledPacksSpec: ToolSpec = {
+	name: 'list_installed_packs',
+	args: '{"orgId": string}',
+	description:
+		'List the integration packs and bundles installed in one Rewst organization (id, name, ref, isBundle, status, packType).',
+	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+};
+
+const getPackAuthStatusSpec: ToolSpec = {
+	name: 'get_pack_auth_status',
+	args: '{"orgId": string, "packName": string}',
+	description:
+		"Check whether a pack needs OAuth setup in one Rewst organization. packName is a pack ref (e.g. microsoft_graph). Returns 'configured' when already authenticated, or the setup URL when authorization is needed.",
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			packName: { type: 'string', description: 'A pack ref, e.g. microsoft_graph' },
+		},
+		required: ['orgId', 'packName'],
+	},
+};
+
+const listPackConfigsSpec: ToolSpec = {
+	name: 'list_pack_configs',
+	args: '{"orgId": string}',
+	description:
+		'List the pack (integration) configurations for one Rewst organization (id, name, packId, default). Returns all configs (this field has no pagination).',
+	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+};
+
+const listIntegrationsSpec: ToolSpec = {
+	name: 'list_integrations',
+	args: '{"orgId": string, "limit"?: number}',
+	description:
+		'List integrations available on the Rewst platform (name, description, numInstalled). Global catalog; the orgId only selects which signed-in session to use.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			limit: { type: 'number', description: 'Max integrations to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+};
+
+async function runListInstalledPacks(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const QUERY = `query RewstBuddyMcpInstalledPacks($orgId: ID!) {
+  packsAndBundlesByInstalledState(orgId: $orgId) {
+    installedPacksAndBundles {
+      id
+      name
+      ref
+      isBundle
+      status
+      packType
+    }
+  }
+}`;
+	const orgId = requireString(input, 'orgId');
+	const variables = { orgId };
+	const { data, errors } = await ctx.session.rawGraphql(QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const installedPacksAndBundles = ((
+		data as
+			| {
+					packsAndBundlesByInstalledState?: { installedPacksAndBundles?: unknown[] | null } | null;
+			  }
+			| undefined
+	)?.packsAndBundlesByInstalledState?.installedPacksAndBundles ?? []) as {
+		id?: string | null;
+		name?: string | null;
+		ref?: string | null;
+		isBundle?: boolean | null;
+		status?: string | null;
+		packType?: string | null;
+	}[];
+	return installedPacksAndBundles
+		.map(pack => {
+			const name = optionalString(pack.name) ?? '(unnamed)';
+			const refOrId = optionalString(pack.ref) ?? optionalString(pack.id) ?? 'unknown';
+			const status = optionalString(pack.status);
+			return `${name} (${refOrId})${pack.isBundle ? ' [bundle]' : ''}${status ? ' — ' + status : ''}`;
+		})
+		.join('\n');
+}
+
+async function runGetPackAuthStatus(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const QUERY = `query RewstBuddyMcpPackAuthUrl($orgId: ID!, $packName: String!) {
+  packAuthUrl(packName: $packName, orgId: $orgId)
+}`;
+	const orgId = requireString(input, 'orgId');
+	const packName = requireString(input, 'packName');
+	const variables = { orgId, packName };
+	const { data, errors } = await ctx.session.rawGraphql(QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const url = (data as { packAuthUrl?: unknown } | undefined)?.packAuthUrl;
+	if (url == null) return 'configured (no auth URL needed)';
+	return `needs setup: ${url}`;
+}
+
+async function runListPackConfigs(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const QUERY = `query RewstBuddyMcpPackConfigs($orgId: ID!) {
+  packConfigs(where: { orgId: $orgId }) {
+    id
+    name
+    packId
+    default
+    createdAt
+  }
+}`;
+	const orgId = requireString(input, 'orgId');
+	const variables = { orgId };
+	const { data, errors } = await ctx.session.rawGraphql(QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const packConfigs = ((data as { packConfigs?: unknown[] | null } | undefined)?.packConfigs ?? []) as {
+		id?: string | null;
+		name?: string | null;
+		packId?: string | null;
+		default?: boolean | null;
+		createdAt?: string | null;
+	}[];
+	return packConfigs
+		.map(config => {
+			const name = optionalString(config.name) ?? '(unnamed)';
+			const id = optionalString(config.id) ?? 'unknown';
+			const packId = optionalString(config.packId) ?? 'unknown';
+			return `${name} (${id}) — pack ${packId}${config['default'] ? ' [default]' : ''}`;
+		})
+		.join('\n');
+}
+
+async function runListIntegrations(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const QUERY = `query RewstBuddyMcpIntegrations($limit: Int) {
+  integrations(limit: $limit) {
+    name
+    description
+    numInstalled
+    isPublic
+  }
+}`;
+	requireString(input, 'orgId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? 50, MAX_INTEGRATIONS_LIMIT);
+	const variables = { limit };
+	const { data, errors } = await ctx.session.rawGraphql(QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const integrations = ((data as { integrations?: unknown[] | null } | undefined)?.integrations ?? []) as {
+		name?: string | null;
+		description?: string | null;
+		numInstalled?: number | null;
+		isPublic?: boolean | null;
+	}[];
+	return integrations
+		.map(integration => {
+			const name = optionalString(integration.name) ?? '(unnamed)';
+			const description = optionalString(integration.description);
+			return `${name}${integration.numInstalled != null ? ' (' + integration.numInstalled + ' installed)' : ''}${
+				description ? ' — ' + description : ''
+			}`;
+		})
+		.join('\n');
+}
+
+export const PACK_INTEGRATION_CAPABILITIES: Capability[] = [
+	{ spec: listInstalledPacksSpec, access: 'read', chat: false, mcp: true, run: runListInstalledPacks },
+	{ spec: getPackAuthStatusSpec, access: 'read', chat: false, mcp: true, run: runGetPackAuthStatus },
+	{ spec: listPackConfigsSpec, access: 'read', chat: false, mcp: true, run: runListPackConfigs },
+	{ spec: listIntegrationsSpec, access: 'read', chat: false, mcp: true, run: runListIntegrations },
+];

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -25,7 +25,7 @@ suite('Unit: pageTemplateCapabilities', () => {
 		const output = await cap('search_templates').run({ orgId: 'org-1', search: 'foo', limit: 10 }, ctx);
 
 		assert.ok(calls[0].query.includes('templates('));
-		assert.deepStrictEqual(calls[0].variables.search, { name: { _ilike: '%foo%' } });
+		assert.deepStrictEqual(calls[0].variables!.search, { name: { _ilike: '%foo%' } });
 		assert.ok(output.includes('Foo'));
 	});
 

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -1,0 +1,87 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import type { Session } from '@sessions';
+import type { CapabilityContext } from './Capability';
+import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
+const { suite, test, setup } = Mocha;
+function fakeCtx(response: unknown) {
+	const calls: { query: string; variables: Record<string, unknown> }[] = [];
+	const session = {
+		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
+			calls.push({ query, variables });
+			return response as { data?: unknown; errors?: unknown };
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+	return { ctx, calls };
+}
+function cap(name: string) {
+	const c = PAGE_TEMPLATE_CAPABILITIES.find(x => x.spec.name === name);
+	if (!c) throw new Error('missing ' + name);
+	return c;
+}
+suite('Unit: pageTemplateCapabilities', () => {
+	setup(() => initTestEnvironment());
+
+	test('search_templates maps name search and formats template rows', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: {
+				templates: [
+					{
+						id: 't1',
+						name: 'Foo',
+						language: 'JINJA',
+						contentType: 'text/plain',
+						updatedAt: '2024-01-01',
+					},
+				],
+			},
+		});
+
+		const output = await cap('search_templates').run({ orgId: 'org-1', search: 'foo', limit: 10 }, ctx);
+
+		assert.ok(calls[0].query.includes('templates('));
+		assert.deepStrictEqual(calls[0].variables.search, { name: { _ilike: '%foo%' } });
+		assert.ok(output.includes('Foo'));
+	});
+
+	test('list_pages uses pages query and formats page rows', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: { pages: [{ id: 'p1', name: 'Home', path: 'home', siteId: 's1' }] },
+		});
+
+		const output = await cap('list_pages').run({ orgId: 'org-1' }, ctx);
+
+		assert.ok(calls[0].query.includes('pages('));
+		assert.ok(output.includes('Home (p1)'));
+	});
+
+	test('list_sites uses sites query without pagination and formats live state', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: { sites: [{ id: 's1', name: 'My Site', domain: 'example.com', isLive: true }] },
+		});
+
+		const output = await cap('list_sites').run({ orgId: 'org-1' }, ctx);
+
+		assert.ok(calls[0].query.includes('sites('));
+		assert.ok(!calls[0].query.includes('limit'));
+		assert.ok(output.includes('[live]'));
+	});
+
+	test('list_jinja_filters filters the global catalog client-side', async () => {
+		const { ctx } = fakeCtx({
+			data: {
+				jinjaFiltersDocumentation: [
+					{ name: 'default', signature: 'default(value, default_value)' },
+					{ name: 'abs', signature: 'abs(x)' },
+				],
+			},
+		});
+
+		const output = await cap('list_jinja_filters').run({ orgId: 'org-1', search: 'abs' }, ctx);
+
+		assert.ok(output.includes('abs'));
+		assert.ok(!output.includes('default'));
+	});
+});

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -84,4 +84,15 @@ suite('Unit: pageTemplateCapabilities', () => {
 		assert.ok(output.includes('abs'));
 		assert.ok(!output.includes('default'));
 	});
+
+	test('search_templates reports GraphQL errors with details', async () => {
+		const { ctx } = fakeCtx({
+			errors: [{ message: 'boom' }],
+		});
+
+		await assert.rejects(
+			() => cap('search_templates').run({ orgId: 'org-1' }, ctx),
+			/GraphQL error: \[{"message":"boom"}\]/,
+		);
+	});
 });

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -1,26 +1,9 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
-import type { Session } from '@sessions';
-import type { CapabilityContext } from './Capability';
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 const { suite, test, setup } = Mocha;
-function fakeCtx(response: unknown) {
-	const calls: { query: string; variables: Record<string, unknown> }[] = [];
-	const session = {
-		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
-			calls.push({ query, variables });
-			return response as { data?: unknown; errors?: unknown };
-		},
-	} as unknown as Session;
-	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
-	return { ctx, calls };
-}
-function cap(name: string) {
-	const c = PAGE_TEMPLATE_CAPABILITIES.find(x => x.spec.name === name);
-	if (!c) throw new Error('missing ' + name);
-	return c;
-}
+const { fakeCtx, cap } = createCapabilityTestHarness(PAGE_TEMPLATE_CAPABILITIES);
 suite('Unit: pageTemplateCapabilities', () => {
 	setup(() => initTestEnvironment());
 

--- a/src/capabilities/pageTemplateCapabilities.ts
+++ b/src/capabilities/pageTemplateCapabilities.ts
@@ -72,7 +72,7 @@ async function runSearchTemplates(input: Record<string, unknown>, ctx: Capabilit
 	if (search) variables.search = { name: { _ilike: `%${search}%` } };
 	const { data, errors } = await ctx.session.rawGraphql(SEARCH_TEMPLATES_QUERY, variables);
 	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
-		throw new Error();
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
 	}
 	const templates = ((data as { templates?: unknown[] } | undefined)?.templates ?? []) as {
 		id?: string | null;
@@ -102,7 +102,7 @@ async function runListPages(input: Record<string, unknown>, ctx: CapabilityConte
 	const variables = { orgId, limit };
 	const { data, errors } = await ctx.session.rawGraphql(LIST_PAGES_QUERY, variables);
 	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
-		throw new Error();
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
 	}
 	const pages = ((data as { pages?: unknown[] } | undefined)?.pages ?? []) as {
 		id?: string | null;
@@ -124,7 +124,7 @@ async function runListSites(input: Record<string, unknown>, ctx: CapabilityConte
 	const variables = { orgId };
 	const { data, errors } = await ctx.session.rawGraphql(LIST_SITES_QUERY, variables);
 	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
-		throw new Error();
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
 	}
 	const sites = ((data as { sites?: unknown[] } | undefined)?.sites ?? []) as {
 		id?: string | null;
@@ -149,7 +149,7 @@ async function runListJinjaFilters(input: Record<string, unknown>, ctx: Capabili
 	const variables = {};
 	const { data, errors } = await ctx.session.rawGraphql(LIST_JINJA_FILTERS_QUERY, variables);
 	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
-		throw new Error();
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
 	}
 	const filters = ((data as { jinjaFiltersDocumentation?: unknown[] } | undefined)?.jinjaFiltersDocumentation ??
 		[]) as {

--- a/src/capabilities/pageTemplateCapabilities.ts
+++ b/src/capabilities/pageTemplateCapabilities.ts
@@ -1,0 +1,178 @@
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asString, requireString, asPositiveInt, ORG_ID_PROP } from './inputHelpers';
+
+const DEFAULT_LIMIT = 50;
+const MAX_LIMIT = 200;
+
+const SEARCH_TEMPLATES_QUERY = `query($orgId: ID!, $search: TemplateSearch, $limit: Int){ templates(where:{ orgId:$orgId }, search:$search, order:[["updatedAt","desc"]], limit:$limit){ id name language contentType updatedAt } }`;
+const LIST_PAGES_QUERY = `query($orgId: ID!, $limit: Int){ pages(where:{ orgId:$orgId }, limit:$limit){ id name path siteId } }`;
+const LIST_SITES_QUERY = `query($orgId: ID!){ sites(where:{ orgId:$orgId }){ id name domain isLive } }`;
+const LIST_JINJA_FILTERS_QUERY = `query{ jinjaFiltersDocumentation { name signature } }`;
+
+const searchTemplatesSpec: ToolSpec = {
+	name: 'search_templates',
+	args: '{"orgId": string, "search"?: string, "limit"?: number}',
+	description:
+		'Search templates in one Rewst organization by name substring (case-insensitive), newest first (id, name, language, contentType, updatedAt). Use get_template for a full body.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'number', description: 'Max templates to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+};
+
+const listPagesSpec: ToolSpec = {
+	name: 'list_pages',
+	args: '{"orgId": string, "limit"?: number}',
+	description: 'List App Platform pages in one Rewst organization (id, name, path, siteId).',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			limit: { type: 'number', description: 'Max pages to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+};
+
+const listSitesSpec: ToolSpec = {
+	name: 'list_sites',
+	args: '{"orgId": string}',
+	description:
+		'List App Platform sites in one Rewst organization (id, name, domain, isLive). Returns all sites (this field has no pagination).',
+	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+};
+
+const listJinjaFiltersSpec: ToolSpec = {
+	name: 'list_jinja_filters',
+	args: '{"orgId": string, "search"?: string, "limit"?: number}',
+	description:
+		'List Rewst available Jinja filters with their signatures (global catalog, ~100 entries). Optionally filter by a name substring. Use this instead of the broken singular jinjaFilterDocumentation.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'number', description: 'Max filters to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+};
+
+async function runSearchTemplates(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const search = asString(input, 'search');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const variables: Record<string, unknown> = { orgId, limit };
+	if (search) variables.search = { name: { _ilike: `%${search}%` } };
+	const { data, errors } = await ctx.session.rawGraphql(SEARCH_TEMPLATES_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error();
+	}
+	const templates = ((data as { templates?: unknown[] } | undefined)?.templates ?? []) as {
+		id?: string | null;
+		name?: string | null;
+		language?: string | null;
+		contentType?: string | null;
+		updatedAt?: string | null;
+	}[];
+	if (templates.length === 0) return 'No templates found for this organization.';
+	return templates
+		.map(template => {
+			const details = [
+				template.language,
+				template.contentType,
+				template.updatedAt ? `updated ${template.updatedAt}` : undefined,
+			]
+				.filter(Boolean)
+				.join(', ');
+			return `${template.name ?? '(unnamed)'} (${template.id ?? '(unknown id)'})${details ? ` - ${details}` : ''}`;
+		})
+		.join('\n');
+}
+
+async function runListPages(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const variables = { orgId, limit };
+	const { data, errors } = await ctx.session.rawGraphql(LIST_PAGES_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error();
+	}
+	const pages = ((data as { pages?: unknown[] } | undefined)?.pages ?? []) as {
+		id?: string | null;
+		name?: string | null;
+		path?: string | null;
+		siteId?: string | null;
+	}[];
+	if (pages.length === 0) return 'No pages found for this organization.';
+	return pages
+		.map(page => {
+			const details = [page.path, page.siteId ? `site ${page.siteId}` : undefined].filter(Boolean).join(', ');
+			return `${page.name ?? '(unnamed)'} (${page.id ?? '(unknown id)'})${details ? ` - ${details}` : ''}`;
+		})
+		.join('\n');
+}
+
+async function runListSites(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const variables = { orgId };
+	const { data, errors } = await ctx.session.rawGraphql(LIST_SITES_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error();
+	}
+	const sites = ((data as { sites?: unknown[] } | undefined)?.sites ?? []) as {
+		id?: string | null;
+		name?: string | null;
+		domain?: string | null;
+		isLive?: boolean | null;
+	}[];
+	if (sites.length === 0) return 'No sites found for this organization.';
+	return sites
+		.map(site => {
+			const domain = site.domain ? ` - ${site.domain}` : '';
+			const live = site.isLive ? ' [live]' : ' [not live]';
+			return `${site.name ?? '(unnamed)'} (${site.id ?? '(unknown id)'})${domain}${live}`;
+		})
+		.join('\n');
+}
+
+async function runListJinjaFilters(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	requireString(input, 'orgId');
+	const search = asString(input, 'search');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const variables = {};
+	const { data, errors } = await ctx.session.rawGraphql(LIST_JINJA_FILTERS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error();
+	}
+	const filters = ((data as { jinjaFiltersDocumentation?: unknown[] } | undefined)?.jinjaFiltersDocumentation ??
+		[]) as {
+		name?: string | null;
+		signature?: string | null;
+	}[];
+	const matched = search
+		? filters.filter(filter => (filter.name ?? '').toLowerCase().includes(search.toLowerCase()))
+		: filters;
+	const capped = matched.slice(0, limit);
+	if (capped.length === 0) return search ? `No Jinja filters found matching "${search}".` : 'No Jinja filters found.';
+	const lines = capped.map(
+		filter => `${filter.name ?? '(unnamed)'}${filter.signature ? ` - ${filter.signature}` : ''}`,
+	);
+	if (matched.length > limit) {
+		lines.push(`...(${matched.length - limit} more not shown; refine the search)`);
+	}
+	return lines.join('\n');
+}
+
+export const PAGE_TEMPLATE_CAPABILITIES: Capability[] = [
+	{ spec: searchTemplatesSpec, access: 'read', chat: false, mcp: true, run: runSearchTemplates },
+	{ spec: listPagesSpec, access: 'read', chat: false, mcp: true, run: runListPages },
+	{ spec: listSitesSpec, access: 'read', chat: false, mcp: true, run: runListSites },
+	{ spec: listJinjaFiltersSpec, access: 'read', chat: false, mcp: true, run: runListJinjaFilters },
+];

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -4,6 +4,10 @@ import { GRAPHQL_CAPABILITIES } from './graphqlCapabilities';
 import { graphqlMutateCapability } from './graphqlMutateCapability';
 import { resultReadCapability } from './resultReadCapability';
 import { READ_CAPABILITIES } from './rewstReadCapabilities';
+import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
+import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
+import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
+import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -15,6 +19,10 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...WORKFLOW_CHAT_CAPABILITIES,
 	...GRAPHQL_CAPABILITIES,
 	...READ_CAPABILITIES,
+	...TRIGGER_FORM_CAPABILITIES,
+	...PACK_INTEGRATION_CAPABILITIES,
+	...ORG_USER_CAPABILITIES,
+	...PAGE_TEMPLATE_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/rewstReadCapabilities.test.ts
+++ b/src/capabilities/rewstReadCapabilities.test.ts
@@ -287,6 +287,71 @@ suite('Unit: rewstReadCapabilities', () => {
 		assert.ok(noMatch.startsWith('No executions'), 'reports no match');
 	});
 
+	test('find_executions_by_variable scans execution contexts and reports skipped failed fetches', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when(
+			'rawGraphql',
+			(arg: {
+				query: string;
+				variables: Record<string, unknown>;
+			}): { data?: { data: Record<string, unknown> }; error?: Error } => {
+				if (arg.query.includes('workflowExecutionContexts')) {
+					const id = arg.variables.workflowExecutionId;
+					if (id === 'exec-1') {
+						return {
+							data: { data: { workflowExecutionContexts: [{ ticket_id: '12345' }, { stage: 'done' }] } },
+						};
+					}
+					if (id === 'exec-2') {
+						return { data: { data: { workflowExecutionContexts: [{ unrelated: 'x' }] } } };
+					}
+					return { error: new Error('context fetch failed') };
+				}
+				return {
+					data: {
+						data: {
+							workflowExecutions: [
+								{
+									id: 'exec-1',
+									status: 'succeeded',
+									createdAt: '1700000000000',
+									conductor: { input: {}, output: {} },
+								},
+								{
+									id: 'exec-2',
+									status: 'succeeded',
+									createdAt: '1700000001000',
+									conductor: { input: {}, output: {} },
+								},
+								{
+									id: 'exec-3',
+									status: 'failed',
+									createdAt: '1700000002000',
+									conductor: { input: {}, output: {} },
+								},
+							],
+						},
+					},
+				};
+			},
+		);
+		const findExec = getCapability('find_executions_by_variable');
+		assert.ok(findExec, 'find_executions_by_variable is registered');
+		const ctx = { session, orgId: 'org-1', sessions: [session] } satisfies CapabilityContext;
+
+		const out = await findExec.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'ticket', kind: 'context' }, ctx);
+
+		assert.ok(out.includes('exec-1') && out.includes('ticket_id=12345'), 'matches a context variable');
+		assert.ok(!out.includes('exec-2'), 'omits executions whose context does not match');
+		assert.ok(/1 execution context fetch/.test(out), 'reports the failed context fetch as skipped');
+
+		const contextCalls = wrapper
+			.getCallsFor('rawGraphql')
+			.filter(c => c.variables.query.includes('workflowExecutionContexts'));
+		assert.strictEqual(contextCalls.length, 3, 'issues one context fetch per scanned execution');
+	});
+
 	test('latest_workflow_execution uses latestWorkflowExecution query, forwards workflowId, and handles missing execution', async () => {
 		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
 		useRawGraphqlWrapper(session, wrapper);

--- a/src/capabilities/rewstReadCapabilities.test.ts
+++ b/src/capabilities/rewstReadCapabilities.test.ts
@@ -1,0 +1,501 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { createMockSession, initTestEnvironment } from '@test';
+import type { Session } from '@sessions';
+import type { CapabilityContext } from './Capability';
+import { getCapability } from './registry';
+
+const { suite, test, setup } = Mocha;
+
+function useRawGraphqlWrapper(session: Session, wrapper: ReturnType<typeof createMockSession>['wrapper']): void {
+	const wrap = wrapper.getWrapper();
+	(session as { rawGraphql: Session['rawGraphql'] }).rawGraphql = async (query, variables) => {
+		return wrap(
+			async () => ({ data: undefined, errors: undefined }),
+			'rawGraphql',
+			'query RewstBuddyMcpWorkflows',
+			{
+				query,
+				variables,
+			},
+		);
+	};
+}
+
+suite('Unit: rewstReadCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+	});
+
+	test('list_workflows uses workflows query, maps name search, and parses workflows results', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflows: [
+						{
+							id: 'wf-1',
+							name: 'Foo workflow',
+							description: 'Found by search',
+						},
+					],
+				},
+			},
+		});
+		const listWorkflows = getCapability('list_workflows');
+		assert.ok(listWorkflows, 'list_workflows is registered');
+
+		const output = await listWorkflows.run({ orgId: 'org-1', search: 'foo', limit: 25 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('workflows('), 'query uses workflows');
+		assert.ok(!calls[0].variables.query.includes('visibleWorkflows'), 'query does not use visibleWorkflows');
+		assert.deepStrictEqual(calls[0].variables.variables.search, { name: { _ilike: '%foo%' } });
+		assert.ok(output.includes('Foo workflow (wf-1) — Found by search'));
+	});
+
+	test('list_org_variables uses masked orgVariables query, maps name search, and formats variables', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					orgVariables: [
+						{
+							name: 'api_key',
+							value: '********',
+							category: 'secret',
+							cascade: true,
+						},
+					],
+				},
+			},
+		});
+		const listOrgVariables = getCapability('list_org_variables');
+		assert.ok(listOrgVariables, 'list_org_variables is registered');
+
+		const output = await listOrgVariables.run({ orgId: 'org-1', search: 'term', limit: 10 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('orgVariables('), 'query uses orgVariables');
+		assert.ok(calls[0].variables.query.includes('maskSecrets: true'), 'query masks secrets');
+		assert.deepStrictEqual(calls[0].variables.variables.search, { name: { _ilike: '%term%' } });
+		assert.ok(output.includes('api_key = ********  [secret, cascade]'));
+	});
+
+	test('find_action flattens pack actions, caps output, falls back to name, and includes pack names', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					searchInstalledPackActions: [
+						{
+							id: 'pack-1',
+							name: 'Core Pack',
+							ref: 'core',
+							actions: [
+								{
+									id: 'action-1',
+									name: 'Create Ticket',
+									ref: null,
+									description: 'Open a ticket',
+								},
+								{
+									id: 'action-2',
+									name: 'Update Ticket',
+									ref: 'ticket_update',
+									description: 'Update a ticket',
+								},
+							],
+						},
+						{
+							id: 'pack-2',
+							name: 'Automation Pack',
+							ref: 'automation',
+							actions: [
+								{
+									id: 'action-3',
+									name: 'Close Ticket',
+									ref: 'ticket_close',
+									description: 'Close a ticket',
+								},
+							],
+						},
+					],
+				},
+			},
+		});
+		const findAction = getCapability('find_action');
+		assert.ok(findAction, 'find_action is registered');
+
+		const output = await findAction.run({ orgId: 'org-1', filter: 'ticket', limit: 2 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const lines = output.split('\n');
+		assert.strictEqual(lines.length, 3);
+		assert.strictEqual(lines[0], 'Create Ticket (action-1) — Core Pack: Open a ticket');
+		assert.strictEqual(lines[1], 'ticket_update (action-2) — Core Pack: Update a ticket');
+		assert.strictEqual(lines[2], '…(1 more not shown; refine the filter)');
+		assert.ok(output.includes('Core Pack'), 'pack name is included in output');
+		assert.ok(!output.includes('ticket_close (action-3)'), 'output is capped to the requested limit');
+	});
+
+	test('resolve_reference uses localReferenceOptions query, forwards model and search, and formats options', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					localReferenceOptions: [
+						{
+							label: 'Foo workflow',
+							value: 'wf-1',
+						},
+					],
+				},
+			},
+		});
+		const resolveReference = getCapability('resolve_reference');
+		assert.ok(resolveReference, 'resolve_reference is registered');
+
+		const output = await resolveReference.run({ orgId: 'org-1', modelType: 'Workflow', search: 'foo', limit: 25 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('localReferenceOptions('), 'query uses localReferenceOptions');
+		assert.strictEqual(calls[0].variables.variables.modelName, 'Workflow');
+		assert.strictEqual(calls[0].variables.variables.search, 'foo');
+		assert.strictEqual(output, 'Foo workflow (wf-1)');
+	});
+
+	test('resolve_reference rejects invalid model types', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		const resolveReference = getCapability('resolve_reference');
+		assert.ok(resolveReference, 'resolve_reference is registered');
+
+		await assert.rejects(
+			() =>
+				resolveReference.run({ orgId: 'org-1', modelType: 'Widget' }, {
+					session,
+					orgId: 'org-1',
+					sessions: [session],
+				} satisfies CapabilityContext),
+			/Invalid modelType "Widget". Valid modelType values: Crate, CustomDatabase, Organization, PackConfig, Role, Template, TemplateExport, User, Workflow, Trigger, Form, Site, Page/,
+		);
+	});
+
+	test('list_workflow_executions uses workflowExecutions query, maps status search, and formats executions', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflowExecutions: [
+						{
+							id: 'exec-1',
+							status: 'succeeded',
+							createdAt: '1735689600000',
+							workflow: { id: 'wf-1' },
+							numSuccessfulTasks: 4,
+						},
+					],
+				},
+			},
+		});
+		const listWorkflowExecutions = getCapability('list_workflow_executions');
+		assert.ok(listWorkflowExecutions, 'list_workflow_executions is registered');
+
+		const output = await listWorkflowExecutions.run({ orgId: 'org-1', status: 'succeeded', limit: 10 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('workflowExecutions('), 'query uses workflowExecutions');
+		assert.ok(calls[0].variables.query.includes('workflow {'), 'query requests nested workflow id');
+		assert.deepStrictEqual(calls[0].variables.variables.search, { status: { _eq: 'succeeded' } });
+		assert.ok(output.includes('succeeded — exec-1 (workflow wf-1, 4 ok, created 1735689600000)'));
+	});
+
+	test('find_executions_by_variable scans conductor input and matches name and value', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflowExecutions: [
+						{
+							id: 'exec-1',
+							status: 'succeeded',
+							createdAt: '1700000000000',
+							conductor: { input: { timezone: 'UTC', requestor: 'alice' }, output: {} },
+						},
+						{
+							id: 'exec-2',
+							status: 'failed',
+							createdAt: '1700000001000',
+							conductor: { input: { timezone: 'PST' }, output: {} },
+						},
+					],
+				},
+			},
+		});
+		const findExec = getCapability('find_executions_by_variable');
+		assert.ok(findExec, 'find_executions_by_variable is registered');
+
+		const ctx = { session, orgId: 'org-1', sessions: [session] } satisfies CapabilityContext;
+
+		const byName = await findExec.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'timezone', kind: 'input' }, ctx);
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.ok(calls[0].variables.query.includes('conductor'), 'bulk query selects conductor');
+		assert.ok(calls[0].variables.variables.workflowId === 'wf-1', 'scopes to the workflow');
+		assert.ok(byName.includes('exec-1') && byName.includes('timezone=UTC'), 'matches and shows the variable value');
+		assert.ok(byName.includes('exec-2'), 'matches both executions by name');
+
+		const byValue = await findExec.run(
+			{ orgId: 'org-1', workflowId: 'wf-1', name: 'timezone', kind: 'input', value: 'utc' },
+			ctx,
+		);
+		assert.ok(byValue.includes('exec-1') && !byValue.includes('exec-2'), 'value filter narrows to UTC run');
+
+		const noMatch = await findExec.run(
+			{ orgId: 'org-1', workflowId: 'wf-1', name: 'nonexistent', kind: 'input' },
+			ctx,
+		);
+		assert.ok(noMatch.startsWith('No executions'), 'reports no match');
+	});
+
+	test('latest_workflow_execution uses latestWorkflowExecution query, forwards workflowId, and handles missing execution', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					latestWorkflowExecution: null,
+				},
+			},
+		});
+		const latestWorkflowExecution = getCapability('latest_workflow_execution');
+		assert.ok(latestWorkflowExecution, 'latest_workflow_execution is registered');
+
+		const output = await latestWorkflowExecution.run({ orgId: 'org-1', workflowId: 'wf-1' }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('latestWorkflowExecution('), 'query uses latestWorkflowExecution');
+		assert.strictEqual(calls[0].variables.variables.workflowId, 'wf-1');
+		assert.ok(output.includes('No execution found for workflow wf-1'));
+	});
+
+	test('get_workflow_execution_stats uses workflowExecutionStats query, forwards createdSince, and formats stats', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflowExecutionStats: {
+						succeeded: 11,
+						failed: 2,
+						running: 3,
+						pending: 5,
+						paused: 7,
+						delayed: 13,
+						humanSecondsSaved: 610,
+					},
+				},
+			},
+		});
+		const getWorkflowExecutionStats = getCapability('get_workflow_execution_stats');
+		assert.ok(getWorkflowExecutionStats, 'get_workflow_execution_stats is registered');
+
+		const output = await getWorkflowExecutionStats.run({ orgId: 'org-1', createdSince: '2025-01-01T00:00:00Z' }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('workflowExecutionStats('), 'query uses workflowExecutionStats');
+		assert.strictEqual(calls[0].variables.variables.createdSince, '2025-01-01T00:00:00Z');
+		assert.strictEqual(
+			output,
+			[
+				'succeeded: 11',
+				'failed: 2',
+				'running: 3',
+				'pending: 5',
+				'paused: 7',
+				'delayed: 13',
+				'humanSecondsSaved: 610',
+			].join('\n'),
+		);
+	});
+
+	test('list_workflow_tasks uses workflowTasks query, forwards workflowId, and formats tasks', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflowTasks: [
+						{
+							id: 'abc123def456',
+							name: 'Create ticket',
+							actionId: 'action-1',
+							workflowId: 'wf-1',
+							isMocked: false,
+							timeout: 120,
+							description: 'Open a ticket',
+						},
+						{
+							id: 'fed456cba123',
+							name: 'Notify team',
+							actionId: null,
+							workflowId: 'wf-1',
+							isMocked: false,
+							timeout: null,
+							description: null,
+						},
+					],
+				},
+			},
+		});
+		const listWorkflowTasks = getCapability('list_workflow_tasks');
+		assert.ok(listWorkflowTasks, 'list_workflow_tasks is registered');
+
+		const output = await listWorkflowTasks.run({ orgId: 'org-1', workflowId: 'wf-1', limit: 10 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('workflowTasks('), 'query uses workflowTasks');
+		assert.strictEqual(calls[0].variables.variables.workflowId, 'wf-1');
+		assert.strictEqual(calls[0].variables.variables.limit, 10);
+		assert.strictEqual(
+			output,
+			['Create ticket (abc123def456) — action action-1', 'Notify team (fed456cba123)'].join('\n'),
+		);
+	});
+
+	test('list_workflow_patches uses workflowPatches query, forwards workflowId, and formats patches', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflowPatches: [
+						{
+							id: 'patch-1',
+							patchType: 'update',
+							comment: 'Rename task',
+							commentDescription: 'Task name cleanup',
+							workflowId: 'wf-1',
+							createdAt: '1735689600000',
+						},
+						{
+							id: 'patch-2',
+							patchType: 'create',
+							comment: null,
+							commentDescription: null,
+							workflowId: 'wf-1',
+							createdAt: '1735603200000',
+						},
+					],
+				},
+			},
+		});
+		const listWorkflowPatches = getCapability('list_workflow_patches');
+		assert.ok(listWorkflowPatches, 'list_workflow_patches is registered');
+
+		const output = await listWorkflowPatches.run({ orgId: 'org-1', workflowId: 'wf-1', limit: 5 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('workflowPatches('), 'query uses workflowPatches');
+		assert.ok(calls[0].variables.query.includes('orderBy: createdAt_DESC'), 'query sorts patches newest first');
+		assert.strictEqual(calls[0].variables.variables.workflowId, 'wf-1');
+		assert.strictEqual(calls[0].variables.variables.limit, 5);
+		assert.strictEqual(
+			output,
+			['update — patch-1: Rename task (created 1735689600000)', 'create — patch-2 (created 1735603200000)'].join(
+				'\n',
+			),
+		);
+	});
+
+	test('get_workflow_patch uses workflowPatch query, forwards id, and serializes the patch JSON', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		const workflowPatch = {
+			id: 'patch-1',
+			patchType: 'update',
+			patch: [
+				{
+					op: 'replace',
+					path: '/tasks/abc123def456/name',
+					value: 'Create ticket',
+				},
+			],
+			comment: 'Rename task',
+			commentDescription: 'Task name cleanup',
+			workflowId: 'wf-1',
+			createdAt: '1735689600000',
+		};
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflowPatch,
+				},
+			},
+		});
+		const getWorkflowPatch = getCapability('get_workflow_patch');
+		assert.ok(getWorkflowPatch, 'get_workflow_patch is registered');
+
+		const output = await getWorkflowPatch.run({ orgId: 'org-1', patchId: 'patch-1' }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('workflowPatch(id: $id)'), 'query uses workflowPatch by id');
+		assert.strictEqual(calls[0].variables.variables.id, 'patch-1');
+		assert.deepStrictEqual(JSON.parse(output), workflowPatch);
+		assert.strictEqual(output, JSON.stringify(workflowPatch, null, 2));
+	});
+});

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -1,6 +1,7 @@
 import { runReadonlyGraphql } from '../ui/chat/tools/graphqlTool';
 import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
+import { mapWithConcurrency } from './inputHelpers';
 
 /**
  * Read-only Rewst capabilities exposed over the MCP server. Each operates on the
@@ -667,29 +668,27 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 	}[];
 
 	let skipped = 0;
-	const varsByExecution = await Promise.all(
-		executions.map(async execution => {
-			if (kind === 'input' || kind === 'output') {
-				const raw = execution.conductor?.[kind];
-				return raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
-			}
-			try {
-				const res = await ctx.session.rawGraphql(EXECUTION_CONTEXTS_QUERY, {
-					workflowExecutionId: execution.id,
-				});
-				if (Array.isArray(res.errors) ? res.errors.length > 0 : res.errors != null) {
-					skipped += 1;
-					return {};
-				}
-				return flattenExecutionContextFrames(
-					(res.data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts,
-				);
-			} catch {
+	const varsByExecution = await mapWithConcurrency(executions, 10, async execution => {
+		if (kind === 'input' || kind === 'output') {
+			const raw = execution.conductor?.[kind];
+			return raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+		}
+		try {
+			const res = await ctx.session.rawGraphql(EXECUTION_CONTEXTS_QUERY, {
+				workflowExecutionId: execution.id,
+			});
+			if (Array.isArray(res.errors) ? res.errors.length > 0 : res.errors != null) {
 				skipped += 1;
 				return {};
 			}
-		}),
-	);
+			return flattenExecutionContextFrames(
+				(res.data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts,
+			);
+		} catch {
+			skipped += 1;
+			return {};
+		}
+	});
 
 	const lines: string[] = [];
 	executions.forEach((execution, index) => {
@@ -713,6 +712,7 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 	return result;
 }
 
+// orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by workflow id alone.
 async function runListWorkflowTasks(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	requireString(input, 'orgId');
 	const workflowId = requireString(input, 'workflowId');
@@ -736,6 +736,7 @@ async function runListWorkflowTasks(input: Record<string, unknown>, ctx: Capabil
 		.join('\n');
 }
 
+// orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by workflow id alone.
 async function runListWorkflowPatches(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	requireString(input, 'orgId');
 	const workflowId = requireString(input, 'workflowId');
@@ -763,6 +764,7 @@ async function runListWorkflowPatches(input: Record<string, unknown>, ctx: Capab
 		.join('\n');
 }
 
+// orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by patch id alone.
 async function runGetWorkflowPatch(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	requireString(input, 'orgId');
 	const patchId = requireString(input, 'patchId');

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -651,7 +651,8 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 	const nameNeedle = rawName.toLowerCase();
 	const valueArg = asString(input, 'value');
 	const valueNeedle = valueArg ? valueArg.toLowerCase() : undefined;
-	const kind = (asString(input, 'kind') ?? 'input') as ExecutionVariableKind;
+	const rawKind = asString(input, 'kind') ?? 'input';
+	const kind: ExecutionVariableKind = rawKind === 'output' || rawKind === 'context' ? rawKind : 'input';
 	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_EXECUTION_LIMIT, MAX_EXECUTION_LIMIT);
 
 	const { data, errors } = await ctx.session.rawGraphql(EXECUTIONS_WITH_IO_QUERY, { orgId, workflowId, limit });

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -16,7 +16,35 @@ import type { Capability, CapabilityContext } from './Capability';
 // Bounds list responses so a large org cannot flood an agent's context.
 const DEFAULT_TEMPLATE_LIMIT = 200;
 const DEFAULT_WORKFLOW_LIMIT = 100;
+const DEFAULT_REFERENCE_LIMIT = 25;
+const DEFAULT_ORG_VARIABLE_LIMIT = 50;
+const DEFAULT_ACTION_LIMIT = 25;
+const DEFAULT_EXECUTION_LIMIT = 25;
+const DEFAULT_TASK_LIMIT = 100;
+const DEFAULT_PATCH_LIMIT = 25;
 const MAX_WORKFLOW_LIMIT = 500;
+const MAX_REFERENCE_LIMIT = 100;
+const MAX_ORG_VARIABLE_LIMIT = 200;
+const MAX_ACTION_LIMIT = 100;
+const MAX_EXECUTION_LIMIT = 100;
+const MAX_TASK_LIMIT = 500;
+const MAX_PATCH_LIMIT = 100;
+
+const LOCAL_REFERENCE_MODELS = [
+	'Crate',
+	'CustomDatabase',
+	'Organization',
+	'PackConfig',
+	'Role',
+	'Template',
+	'TemplateExport',
+	'User',
+	'Workflow',
+	'Trigger',
+	'Form',
+	'Site',
+	'Page',
+] as const;
 
 function asString(input: Record<string, unknown>, key: string): string | undefined {
 	const value = input[key];
@@ -85,6 +113,206 @@ const listWorkflowsSpec: ToolSpec = {
 	},
 };
 
+const listOrgVariablesSpec: ToolSpec = {
+	name: 'list_org_variables',
+	args: '{"orgId": string, "search"?: string, "limit"?: number}',
+	description:
+		'List configuration variables for one Rewst organization (name, value, category, cascade). Secret-category values are returned masked. Optionally filter by a case-insensitive name substring.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			search: { type: 'string', description: 'Optional case-insensitive name substring filter.' },
+			limit: {
+				type: 'number',
+				description: `Max variables to return (default ${DEFAULT_ORG_VARIABLE_LIMIT}, max ${MAX_ORG_VARIABLE_LIMIT}).`,
+			},
+		},
+		required: ['orgId'],
+	},
+};
+
+const listWorkflowExecutionsSpec: ToolSpec = {
+	name: 'list_workflow_executions',
+	args: '{"orgId": string, "status"?: string, "limit"?: number}',
+	description:
+		'List recent workflow executions for one Rewst organization (id, status, workflowId, createdAt, numSuccessfulTasks), newest first. Optionally filter by an exact status (e.g. succeeded, failed, running). createdAt is an epoch-millisecond string.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			status: { type: 'string', description: 'Optional exact execution status filter.' },
+			limit: {
+				type: 'number',
+				description: `Max executions to return (default ${DEFAULT_EXECUTION_LIMIT}, max ${MAX_EXECUTION_LIMIT}).`,
+			},
+		},
+		required: ['orgId'],
+	},
+};
+
+const findExecutionsByVariableSpec: ToolSpec = {
+	name: 'find_executions_by_variable',
+	args: '{"orgId": string, "workflowId": string, "name": string, "kind"?: "input"|"output"|"context", "value"?: string, "limit"?: number}',
+	description:
+		"Find executions of ONE Rewst workflow whose input, output, or context variable matches a name (and optionally a value). Scans the most-recently-created executions of the given workflow and filters client-side. kind selects which variable surface to search: input (the values the run was started with), output (the values it produced — absent until a run completes), or context (the run's CTX). name is matched case-insensitively as a substring against variable names; pass value to also require the variable's value to contain that text. Returns one line per matching execution with its id, status, created time, and the matched variable(s). Both orgId and workflowId are required — there is no way to search executions across a whole org by variable, and kind=context issues one extra request per scanned execution.",
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			workflowId: { type: 'string', description: 'The workflow whose executions to scan.' },
+			name: { type: 'string', description: 'Case-insensitive substring matched against variable names.' },
+			kind: {
+				type: 'string',
+				enum: ['input', 'output', 'context'],
+				description: "Which variable surface to search: input (default), output, or context (the run's CTX).",
+			},
+			value: {
+				type: 'string',
+				description: "Optional case-insensitive substring the matched variable's value must contain.",
+			},
+			limit: {
+				type: 'number',
+				description: `Max executions to scan, most-recent first (default ${DEFAULT_EXECUTION_LIMIT}, max ${MAX_EXECUTION_LIMIT}). For kind=context this is also the number of extra context requests issued.`,
+			},
+		},
+		required: ['orgId', 'workflowId', 'name'],
+	},
+};
+
+const listWorkflowTasksSpec: ToolSpec = {
+	name: 'list_workflow_tasks',
+	args: '{"orgId": string, "workflowId": string, "limit"?: number}',
+	description:
+		'List the tasks (steps) in one Rewst workflow (id, name, actionId, isMocked, timeout, description). Task ids are dash-less hex strings.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			workflowId: { type: 'string', description: 'Workflow id whose tasks to list.' },
+			limit: {
+				type: 'number',
+				description: `Max tasks to return (default ${DEFAULT_TASK_LIMIT}, max ${MAX_TASK_LIMIT}).`,
+			},
+		},
+		required: ['orgId', 'workflowId'],
+	},
+};
+
+const listWorkflowPatchesSpec: ToolSpec = {
+	name: 'list_workflow_patches',
+	args: '{"orgId": string, "workflowId": string, "limit"?: number}',
+	description:
+		'List the revision history (patch metadata) for one Rewst workflow, newest first (id, patchType, comment, createdAt). Use get_workflow_patch with a patch id to see the actual change. createdAt is an epoch-millisecond string.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			workflowId: { type: 'string', description: 'Workflow id whose patch history to list.' },
+			limit: {
+				type: 'number',
+				description: `Max patches to return (default ${DEFAULT_PATCH_LIMIT}, max ${MAX_PATCH_LIMIT}).`,
+			},
+		},
+		required: ['orgId', 'workflowId'],
+	},
+};
+
+const getWorkflowPatchSpec: ToolSpec = {
+	name: 'get_workflow_patch',
+	args: '{"orgId": string, "patchId": string}',
+	description:
+		'Get one Rewst workflow patch by id, including `patch` — the actual change as an RFC-6902 JSON Patch array. Pair with list_workflow_patches to find a patch id.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			patchId: { type: 'string', description: 'Workflow patch id to fetch.' },
+		},
+		required: ['orgId', 'patchId'],
+	},
+};
+
+const latestWorkflowExecutionSpec: ToolSpec = {
+	name: 'latest_workflow_execution',
+	args: '{"orgId": string, "workflowId": string, "status"?: string}',
+	description:
+		'Get the most recent execution of one workflow in a Rewst organization (id, status, createdAt, task counts). Optionally constrain to a specific status.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			workflowId: { type: 'string', description: 'Workflow id to inspect.' },
+			status: { type: 'string', description: 'Optional exact execution status constraint.' },
+		},
+		required: ['orgId', 'workflowId'],
+	},
+};
+
+const getWorkflowExecutionStatsSpec: ToolSpec = {
+	name: 'get_workflow_execution_stats',
+	args: '{"orgId": string, "createdSince": string}',
+	description:
+		'Get aggregate workflow-execution status counts for one Rewst organization since a date (succeeded, failed, running, pending, paused, delayed, humanSecondsSaved). createdSince must be an ISO-8601 date string (e.g. 2025-01-01 or 2025-01-01T00:00:00Z) — epoch milliseconds are rejected.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			createdSince: {
+				type: 'string',
+				description: 'ISO-8601 date string such as 2025-01-01 or 2025-01-01T00:00:00Z.',
+			},
+		},
+		required: ['orgId', 'createdSince'],
+	},
+};
+
+const findActionSpec: ToolSpec = {
+	name: 'find_action',
+	args: '{"orgId": string, "filter"?: string, "limit"?: number}',
+	description:
+		"Search the actions available in one Rewst organization's installed packs. The filter is matched case-insensitively against each action's display name. Returns one line per match — `<ref> (<id>) — <pack>: <description>` — where `<id>` is the action id and `<ref>` is its callable reference; rows with no ref (workflow-as-action entries) show the action name in place of the ref. Capped to `limit`; omitting the filter returns many results, so prefer a filter. For the platform-wide action catalog rather than this org's installed packs, use buddy_action_search.",
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			filter: {
+				type: 'string',
+				description: "Optional text matched case-insensitively against the action's display name.",
+			},
+			limit: {
+				type: 'number',
+				description: `Max flattened actions to return (default ${DEFAULT_ACTION_LIMIT}, max ${MAX_ACTION_LIMIT}).`,
+			},
+		},
+		required: ['orgId'],
+	},
+};
+
+const resolveReferenceSpec: ToolSpec = {
+	name: 'resolve_reference',
+	args: '{"orgId": string, "modelType": string, "search"?: string, "limit"?: number}',
+	description:
+		'Resolve Rewst object names to ids for one organization and a model type (Workflow, Template, Trigger, Form, Organization, User, Role, PackConfig, Site, Page, Crate, CustomDatabase, TemplateExport). Optionally filter by a case-insensitive name substring. Returns matching options as name (id). Use this when you have a name and need the id.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			modelType: {
+				type: 'string',
+				enum: LOCAL_REFERENCE_MODELS,
+				description: 'Which kind of Rewst object to resolve.',
+			},
+			search: { type: 'string', description: 'Optional case-insensitive name substring filter.' },
+			limit: {
+				type: 'number',
+				description: `Max references to return (default ${DEFAULT_REFERENCE_LIMIT}, max ${MAX_REFERENCE_LIMIT}).`,
+			},
+		},
+		required: ['orgId', 'modelType'],
+	},
+};
+
 const getWorkflowSpec: ToolSpec = {
 	name: 'get_workflow',
 	args: '{"orgId": string, "workflowId": string}',
@@ -117,15 +345,125 @@ const graphqlQuerySpec: ToolSpec = {
 
 // GraphQL for workflow reads: the typed SDK has no workflow operations, so these
 // use the session's rawGraphql against the documented schema fields.
-const VISIBLE_WORKFLOWS_QUERY = `query RewstBuddyMcpWorkflows($orgId: ID!, $limit: Int, $search: WorkflowSearch) {
-	visibleWorkflows(orgId: $orgId, limit: $limit, search: $search) {
-		id
-		name
-		description
-		orgId
-		createdAt
-		updatedAt
-	}
+/** Lists workflows for one org through the working workflows query. */
+const WORKFLOWS_QUERY = `query RewstBuddyMcpWorkflows($orgId: ID!, $limit: Int, $search: WorkflowSearch) {
+  workflows(where: { orgId: $orgId }, search: $search, limit: $limit, order: [["updatedAt", "DESC"]]) {
+    id
+    name
+    description
+    orgId
+    createdAt
+    updatedAt
+  }
+}`;
+
+const ORG_VARIABLES_QUERY = `query RewstBuddyMcpOrgVariables($orgId: ID!, $search: OrgVariableSearchInput, $limit: Int) {
+  orgVariables(where: { orgId: $orgId }, search: $search, maskSecrets: true, limit: $limit, order: [["name", "asc"]]) {
+    name
+    value
+    category
+    cascade
+  }
+}`;
+
+const WORKFLOW_EXECUTIONS_QUERY = `query RewstBuddyMcpWorkflowExecutions($orgId: ID!, $search: WorkflowExecutionSearchInput, $limit: Int) {
+  workflowExecutions(where: { orgId: $orgId }, search: $search, order: [["createdAt", "DESC"]], limit: $limit) {
+    id
+    status
+    createdAt
+    workflow {
+      id
+    }
+    numSuccessfulTasks
+  }
+}`;
+
+const EXECUTIONS_WITH_IO_QUERY = `query RewstBuddyMcpExecutionsWithIO($orgId: ID!, $workflowId: ID!, $limit: Int) {
+  workflowExecutions(where: { orgId: $orgId, workflowId: $workflowId }, order: [["createdAt", "DESC"]], limit: $limit) {
+    id
+    status
+    createdAt
+    numSuccessfulTasks
+    conductor {
+      input
+      output
+    }
+  }
+}`;
+
+const EXECUTION_CONTEXTS_QUERY = `query RewstBuddyMcpExecutionContexts($workflowExecutionId: ID!) {
+  workflowExecutionContexts(workflowExecutionId: $workflowExecutionId)
+}`;
+
+const WORKFLOW_TASKS_QUERY = `query RewstBuddyMcpWorkflowTasks($workflowId: ID!, $limit: Int) {
+  workflowTasks(where: { workflowId: $workflowId }, limit: $limit, order: [["name", "ASC"]]) {
+    id
+    name
+    actionId
+    workflowId
+    isMocked
+    timeout
+    description
+  }
+}`;
+
+const WORKFLOW_PATCHES_QUERY = `query RewstBuddyMcpWorkflowPatches($workflowId: ID!, $limit: Int) {
+  workflowPatches(where: { workflowId: $workflowId }, orderBy: createdAt_DESC, limit: $limit) {
+    id
+    patchType
+    comment
+    commentDescription
+    workflowId
+    createdAt
+  }
+}`;
+
+const WORKFLOW_PATCH_QUERY = `query RewstBuddyMcpWorkflowPatch($id: ID!) {
+  workflowPatch(id: $id) {
+    id
+    patchType
+    patch
+    comment
+    commentDescription
+    workflowId
+    createdAt
+  }
+}`;
+
+const LATEST_WORKFLOW_EXECUTION_QUERY = `query RewstBuddyMcpLatestWorkflowExecution($orgId: ID!, $workflowId: ID!, $status: String) {
+  latestWorkflowExecution(workflowId: $workflowId, orgId: $orgId, status: $status) {
+    id
+    status
+    createdAt
+    numSuccessfulTasks
+    numAwaitingResponseTasks
+  }
+}`;
+
+const WORKFLOW_EXECUTION_STATS_QUERY = `query RewstBuddyMcpWorkflowExecutionStats($orgId: ID!, $createdSince: String!) {
+  workflowExecutionStats(orgId: $orgId, createdSince: $createdSince) {
+    succeeded
+    failed
+    running
+    pending
+    paused
+    delayed
+    humanSecondsSaved
+  }
+}`;
+
+const FIND_ACTION_QUERY = `query RewstBuddyMcpFindAction($orgId: ID!, $filter: String) {
+  searchInstalledPackActions(orgId: $orgId, actionFilter: $filter) {
+    id
+    name
+    ref
+    actions {
+      id
+      name
+      ref
+      description
+    }
+  }
 }`;
 
 const WORKFLOW_QUERY = `query RewstBuddyMcpWorkflow($id: ID!) {
@@ -141,6 +479,13 @@ const WORKFLOW_QUERY = `query RewstBuddyMcpWorkflow($id: ID!) {
 			name
 		}
 	}
+}`;
+
+const RESOLVE_REFERENCE_QUERY = `query RewstBuddyMcpResolveReference($orgId: ID!, $modelName: LocalReferenceModel!, $search: String, $limit: Int) {
+  localReferenceOptions(modelName: $modelName, orgId: $orgId, search: $search, limit: $limit) {
+    label
+    value
+  }
 }`;
 
 async function runListOrgs(_input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
@@ -187,12 +532,12 @@ async function runListWorkflows(input: Record<string, unknown>, ctx: CapabilityC
 	const search = asString(input, 'search');
 	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_WORKFLOW_LIMIT, MAX_WORKFLOW_LIMIT);
 	const variables: Record<string, unknown> = { orgId, limit };
-	if (search) variables.search = { name: search };
-	const { data, errors } = await ctx.session.rawGraphql(VISIBLE_WORKFLOWS_QUERY, variables);
+	if (search) variables.search = { name: { _ilike: `%${search}%` } };
+	const { data, errors } = await ctx.session.rawGraphql(WORKFLOWS_QUERY, variables);
 	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
 		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
 	}
-	const workflows = ((data as { visibleWorkflows?: unknown[] } | undefined)?.visibleWorkflows ?? []) as {
+	const workflows = ((data as { workflows?: unknown[] } | undefined)?.workflows ?? []) as {
 		id?: string;
 		name?: string;
 		description?: string;
@@ -204,6 +549,370 @@ async function runListWorkflows(input: Record<string, unknown>, ctx: CapabilityC
 				`${workflow.name ?? '(unnamed)'} (${workflow.id})${workflow.description ? ` — ${workflow.description}` : ''}`,
 		)
 		.join('\n');
+}
+
+async function runListOrgVariables(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const search = asString(input, 'search');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_ORG_VARIABLE_LIMIT, MAX_ORG_VARIABLE_LIMIT);
+	const variables: Record<string, unknown> = { orgId, limit };
+	if (search) variables.search = { name: { _ilike: `%${search}%` } };
+	const { data, errors } = await ctx.session.rawGraphql(ORG_VARIABLES_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const orgVariables = ((data as { orgVariables?: unknown[] } | undefined)?.orgVariables ?? []) as {
+		name?: string;
+		value?: unknown;
+		category?: string;
+		cascade?: boolean;
+	}[];
+	if (orgVariables.length === 0) return 'No configuration variables found for this organization.';
+	return orgVariables
+		.map(variable => {
+			const category = variable.category ?? 'unknown';
+			return `${variable.name ?? '(unnamed)'} = ${variable.value ?? ''}  [${category}${variable.cascade ? ', cascade' : ''}]`;
+		})
+		.join('\n');
+}
+
+async function runListWorkflowExecutions(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_EXECUTION_LIMIT, MAX_EXECUTION_LIMIT);
+	const status = asString(input, 'status');
+	const variables: Record<string, unknown> = { orgId, limit };
+	if (status) variables.search = { status: { _eq: status } };
+	const { data, errors } = await ctx.session.rawGraphql(WORKFLOW_EXECUTIONS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const executions = ((data as { workflowExecutions?: unknown[] } | undefined)?.workflowExecutions ?? []) as {
+		id?: string;
+		status?: string;
+		createdAt?: string;
+		workflow?: { id?: string };
+		numSuccessfulTasks?: number;
+	}[];
+	if (executions.length === 0) return 'No workflow executions found for this organization.';
+	return executions
+		.map(
+			execution =>
+				`${execution.status ?? '(unknown status)'} — ${execution.id} (workflow ${execution.workflow?.id ?? '?'}, ${
+					execution.numSuccessfulTasks ?? 0
+				} ok, created ${execution.createdAt})`,
+		)
+		.join('\n');
+}
+
+type ExecutionVariableKind = 'input' | 'output' | 'context';
+
+function renderVariableValue(value: unknown): string {
+	if (value === null || value === undefined) return String(value);
+	if (typeof value === 'string') return value;
+	if (typeof value === 'number' || typeof value === 'boolean') return String(value);
+	try {
+		return JSON.stringify(value);
+	} catch {
+		return String(value);
+	}
+}
+
+function flattenExecutionContextFrames(frames: unknown): Record<string, unknown> {
+	const flat: Record<string, unknown> = {};
+	if (!Array.isArray(frames)) return flat;
+	for (const frame of frames) {
+		if (frame && typeof frame === 'object') {
+			for (const [key, value] of Object.entries(frame as Record<string, unknown>)) flat[key] = value;
+		}
+	}
+	return flat;
+}
+
+function matchExecutionVariables(
+	vars: Record<string, unknown>,
+	nameNeedle: string,
+	valueNeedle: string | undefined,
+): string[] {
+	const matches: string[] = [];
+	for (const [key, value] of Object.entries(vars)) {
+		if (!key.toLowerCase().includes(nameNeedle)) continue;
+		const rendered = renderVariableValue(value);
+		if (valueNeedle && !rendered.toLowerCase().includes(valueNeedle)) continue;
+		const shown = rendered.length > 80 ? `${rendered.slice(0, 80)}...` : rendered;
+		matches.push(`${key}=${shown}`);
+	}
+	return matches;
+}
+
+async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const workflowId = requireString(input, 'workflowId');
+	const rawName = requireString(input, 'name');
+	const nameNeedle = rawName.toLowerCase();
+	const valueArg = asString(input, 'value');
+	const valueNeedle = valueArg ? valueArg.toLowerCase() : undefined;
+	const kind = (asString(input, 'kind') ?? 'input') as ExecutionVariableKind;
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_EXECUTION_LIMIT, MAX_EXECUTION_LIMIT);
+
+	const { data, errors } = await ctx.session.rawGraphql(EXECUTIONS_WITH_IO_QUERY, { orgId, workflowId, limit });
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const executions = ((data as { workflowExecutions?: unknown[] } | undefined)?.workflowExecutions ?? []) as {
+		id?: string;
+		status?: string;
+		createdAt?: string;
+		conductor?: { input?: unknown; output?: unknown };
+	}[];
+
+	let skipped = 0;
+	const varsByExecution = await Promise.all(
+		executions.map(async execution => {
+			if (kind === 'input' || kind === 'output') {
+				const raw = execution.conductor?.[kind];
+				return raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
+			}
+			try {
+				const res = await ctx.session.rawGraphql(EXECUTION_CONTEXTS_QUERY, {
+					workflowExecutionId: execution.id,
+				});
+				if (Array.isArray(res.errors) ? res.errors.length > 0 : res.errors != null) {
+					skipped += 1;
+					return {};
+				}
+				return flattenExecutionContextFrames(
+					(res.data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts,
+				);
+			} catch {
+				skipped += 1;
+				return {};
+			}
+		}),
+	);
+
+	const lines: string[] = [];
+	executions.forEach((execution, index) => {
+		const matches = matchExecutionVariables(varsByExecution[index], nameNeedle, valueNeedle);
+		if (matches.length > 0) {
+			lines.push(
+				`${execution.status ?? '(unknown status)'} — ${execution.id} (created ${execution.createdAt}) — ${kind}: ${matches.join(', ')}`,
+			);
+		}
+	});
+
+	if (lines.length === 0) {
+		const valuePart = valueArg ? ` with value containing "${valueArg}"` : '';
+		return `No executions of this workflow (scanned ${executions.length}) had a ${kind} variable matching "${rawName}"${valuePart}.`;
+	}
+	let result = lines.join('\n');
+	if (skipped > 0) result += `\n\n(${skipped} execution context fetch(es) failed and were skipped.)`;
+	if (executions.length >= limit) {
+		result += `\n\n(Scanned the ${limit} most-recent executions; raise limit — max ${MAX_EXECUTION_LIMIT} — to scan more.)`;
+	}
+	return result;
+}
+
+async function runListWorkflowTasks(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	requireString(input, 'orgId');
+	const workflowId = requireString(input, 'workflowId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_TASK_LIMIT, MAX_TASK_LIMIT);
+	const { data, errors } = await ctx.session.rawGraphql(WORKFLOW_TASKS_QUERY, { workflowId, limit });
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const workflowTasks = ((data as { workflowTasks?: unknown[] } | undefined)?.workflowTasks ?? []) as {
+		id?: string;
+		name?: string;
+		actionId?: string | null;
+		workflowId?: string;
+		isMocked?: boolean;
+		timeout?: number | null;
+		description?: string | null;
+	}[];
+	if (workflowTasks.length === 0) return `No workflow tasks found for workflow ${workflowId}.`;
+	return workflowTasks
+		.map(task => `${task.name ?? '(unnamed)'} (${task.id})${task.actionId ? ` — action ${task.actionId}` : ''}`)
+		.join('\n');
+}
+
+async function runListWorkflowPatches(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	requireString(input, 'orgId');
+	const workflowId = requireString(input, 'workflowId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_PATCH_LIMIT, MAX_PATCH_LIMIT);
+	const { data, errors } = await ctx.session.rawGraphql(WORKFLOW_PATCHES_QUERY, { workflowId, limit });
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const workflowPatches = ((data as { workflowPatches?: unknown[] } | undefined)?.workflowPatches ?? []) as {
+		id?: string;
+		patchType?: string;
+		comment?: string | null;
+		commentDescription?: string | null;
+		workflowId?: string;
+		createdAt?: string;
+	}[];
+	if (workflowPatches.length === 0) return `No workflow patches found for workflow ${workflowId}.`;
+	return workflowPatches
+		.map(
+			patch =>
+				`${patch.patchType ?? '(unknown patch type)'} — ${patch.id}${patch.comment ? `: ${patch.comment}` : ''} (created ${
+					patch.createdAt
+				})`,
+		)
+		.join('\n');
+}
+
+async function runGetWorkflowPatch(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	requireString(input, 'orgId');
+	const patchId = requireString(input, 'patchId');
+	const { data, errors } = await ctx.session.rawGraphql(WORKFLOW_PATCH_QUERY, { id: patchId });
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const workflowPatch = (data as { workflowPatch?: unknown | null } | undefined)?.workflowPatch;
+	if (!workflowPatch) return `No workflow patch found for patch id ${patchId}.`;
+	return JSON.stringify(workflowPatch, null, 2);
+}
+
+async function runLatestWorkflowExecution(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const workflowId = requireString(input, 'workflowId');
+	const status = asString(input, 'status');
+	const variables: Record<string, unknown> = { orgId, workflowId };
+	if (status) variables.status = status;
+	const { data, errors } = await ctx.session.rawGraphql(LATEST_WORKFLOW_EXECUTION_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const execution = (
+		data as
+			| {
+					latestWorkflowExecution?: {
+						id?: string;
+						status?: string;
+						createdAt?: string;
+						numSuccessfulTasks?: number;
+						numAwaitingResponseTasks?: number;
+					} | null;
+			  }
+			| undefined
+	)?.latestWorkflowExecution;
+	if (!execution) return `No execution found for workflow ${workflowId}.`;
+	return `${execution.status ?? '(unknown status)'} — ${execution.id} (created ${
+		execution.createdAt
+	}, ${execution.numSuccessfulTasks ?? 0} ok, ${execution.numAwaitingResponseTasks ?? 0} awaiting response)`;
+}
+
+async function runGetWorkflowExecutionStats(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const createdSince = requireString(input, 'createdSince');
+	if (/^\d+$/.test(createdSince)) {
+		throw new Error('createdSince must be an ISO-8601 date string; epoch milliseconds are not supported.');
+	}
+	const variables = { orgId, createdSince };
+	const { data, errors } = await ctx.session.rawGraphql(WORKFLOW_EXECUTION_STATS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const stats = (
+		data as
+			| {
+					workflowExecutionStats?: {
+						succeeded?: number;
+						failed?: number;
+						running?: number;
+						pending?: number;
+						paused?: number;
+						delayed?: number;
+						humanSecondsSaved?: number;
+					} | null;
+			  }
+			| undefined
+	)?.workflowExecutionStats;
+	if (!stats) return `No workflow execution stats found since ${createdSince}.`;
+	return [
+		`succeeded: ${stats.succeeded ?? 0}`,
+		`failed: ${stats.failed ?? 0}`,
+		`running: ${stats.running ?? 0}`,
+		`pending: ${stats.pending ?? 0}`,
+		`paused: ${stats.paused ?? 0}`,
+		`delayed: ${stats.delayed ?? 0}`,
+		`humanSecondsSaved: ${stats.humanSecondsSaved ?? 0}`,
+	].join('\n');
+}
+
+async function runFindAction(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const filter = asString(input, 'filter');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_ACTION_LIMIT, MAX_ACTION_LIMIT);
+	const variables: Record<string, unknown> = { orgId };
+	if (filter) variables.filter = filter;
+	const { data, errors } = await ctx.session.rawGraphql(FIND_ACTION_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const packs = ((data as { searchInstalledPackActions?: unknown[] } | undefined)?.searchInstalledPackActions ??
+		[]) as {
+		id?: string;
+		name?: string;
+		ref?: string;
+		actions?: {
+			id?: string;
+			name?: string;
+			ref?: string | null;
+			description?: string | null;
+		}[];
+	}[];
+	const flattened: {
+		action: { id?: string; name?: string; ref?: string | null; description?: string | null };
+		packName: string;
+	}[] = [];
+	for (const pack of packs) {
+		const packName = pack.name ?? pack.ref ?? pack.id ?? '(unknown pack)';
+		for (const action of pack.actions ?? []) {
+			flattened.push({ action, packName });
+		}
+	}
+	if (flattened.length === 0) {
+		return `No actions found${filter ? ` matching "${filter}"` : ''} in this organization.`;
+	}
+	const capped = flattened.slice(0, limit);
+	const lines = capped.map(
+		({ action, packName }) =>
+			`${action.ref ?? action.name ?? '(unnamed)'} (${action.id}) — ${packName}${
+				action.description ? `: ${action.description}` : ''
+			}`,
+	);
+	if (flattened.length > limit) {
+		lines.push(`…(${flattened.length - limit} more not shown; refine the filter)`);
+	}
+	return lines.join('\n');
+}
+
+async function runResolveReference(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const modelType = requireString(input, 'modelType');
+	if (!LOCAL_REFERENCE_MODELS.includes(modelType as (typeof LOCAL_REFERENCE_MODELS)[number])) {
+		throw new Error(
+			`Invalid modelType "${modelType}". Valid modelType values: ${LOCAL_REFERENCE_MODELS.join(', ')}`,
+		);
+	}
+	const search = asString(input, 'search');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_REFERENCE_LIMIT, MAX_REFERENCE_LIMIT);
+	const variables: Record<string, unknown> = { orgId, modelName: modelType, limit };
+	if (search) variables.search = search;
+	const { data, errors } = await ctx.session.rawGraphql(RESOLVE_REFERENCE_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const options = ((data as { localReferenceOptions?: unknown[] } | undefined)?.localReferenceOptions ?? []) as {
+		label?: string;
+		value?: string;
+	}[];
+	if (options.length === 0) {
+		return `No matches found for ${modelType}${search ? ` matching "${search}"` : ''} in this organization.`;
+	}
+	return options.map(option => `${option.label} (${option.value})`).join('\n');
 }
 
 async function runGetWorkflow(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
@@ -255,6 +964,16 @@ export const READ_CAPABILITIES: Capability[] = [
 	{ spec: listTemplatesSpec, access: 'read', chat: false, mcp: true, run: runListTemplates },
 	{ spec: getTemplateSpec, access: 'read', chat: false, mcp: true, run: runGetTemplate },
 	{ spec: listWorkflowsSpec, access: 'read', chat: false, mcp: true, run: runListWorkflows },
+	{ spec: listOrgVariablesSpec, access: 'read', chat: false, mcp: true, run: runListOrgVariables },
+	{ spec: listWorkflowExecutionsSpec, access: 'read', chat: false, mcp: true, run: runListWorkflowExecutions },
+	{ spec: findExecutionsByVariableSpec, access: 'read', chat: false, mcp: true, run: runFindExecutionsByVariable },
+	{ spec: listWorkflowTasksSpec, access: 'read', chat: false, mcp: true, run: runListWorkflowTasks },
+	{ spec: listWorkflowPatchesSpec, access: 'read', chat: false, mcp: true, run: runListWorkflowPatches },
+	{ spec: getWorkflowPatchSpec, access: 'read', chat: false, mcp: true, run: runGetWorkflowPatch },
+	{ spec: latestWorkflowExecutionSpec, access: 'read', chat: false, mcp: true, run: runLatestWorkflowExecution },
+	{ spec: getWorkflowExecutionStatsSpec, access: 'read', chat: false, mcp: true, run: runGetWorkflowExecutionStats },
+	{ spec: findActionSpec, access: 'read', chat: false, mcp: true, run: runFindAction },
+	{ spec: resolveReferenceSpec, access: 'read', chat: false, mcp: true, run: runResolveReference },
 	{ spec: getWorkflowSpec, access: 'read', chat: false, mcp: true, run: runGetWorkflow },
 	{
 		spec: graphqlQuerySpec,

--- a/src/capabilities/triggerFormCapabilities.test.ts
+++ b/src/capabilities/triggerFormCapabilities.test.ts
@@ -1,0 +1,100 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import type { Session } from '@sessions';
+import type { CapabilityContext } from './Capability';
+import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
+const { suite, test, setup } = Mocha;
+function fakeCtx(response: unknown) {
+	const calls: { query: string; variables: Record<string, unknown> }[] = [];
+	const session = {
+		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
+			calls.push({ query, variables });
+			return response as { data?: unknown; errors?: unknown };
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+	return { ctx, calls };
+}
+function cap(name: string) {
+	const c = TRIGGER_FORM_CAPABILITIES.find(x => x.spec.name === name);
+	if (!c) throw new Error('missing ' + name);
+	return c;
+}
+suite('Unit: triggerFormCapabilities', () => {
+	setup(() => initTestEnvironment());
+
+	test('list_triggers uses triggers query and formats trigger rows', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: {
+				triggers: [
+					{ id: 'trig-1', name: 'Alert trigger', enabled: true, triggerTypeId: 'type-1', workflowId: 'wf-1' },
+				],
+			},
+		});
+
+		const output = await cap('list_triggers').run({ orgId: 'org-1', limit: 25 }, ctx);
+
+		assert.ok(calls[0].query.includes('triggers('));
+		assert.ok(output.includes('Alert trigger (trig-1) → workflow wf-1'));
+	});
+
+	test('list_forms uses forms query and formats form rows', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: {
+				forms: [{ id: 'form-1', name: 'Client intake', updatedAt: '1710000000000' }],
+			},
+		});
+
+		const output = await cap('list_forms').run({ orgId: 'org-1', limit: 25 }, ctx);
+
+		assert.ok(calls[0].query.includes('forms('));
+		assert.ok(output.includes('Client intake (form-1)'));
+	});
+
+	test('list_tags uses tags query and formats tag rows', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: {
+				tags: [{ id: 'tag-1', name: 'Important', color: '#ff0000' }],
+			},
+		});
+
+		const output = await cap('list_tags').run({ orgId: 'org-1', limit: 25 }, ctx);
+
+		assert.ok(calls[0].query.includes('tags('));
+		assert.ok(output.includes('Important (tag-1)'));
+	});
+
+	test('list_org_trigger_instances uses orgTriggerInstances query and formats instance rows', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: {
+				orgTriggerInstances: [
+					{ id: 'instance-1', triggerId: 'trig-1', nextFireTime: '1710000000000', isManualActivation: true },
+				],
+			},
+		});
+
+		const output = await cap('list_org_trigger_instances').run({ orgId: 'org-1', limit: 25 }, ctx);
+
+		assert.ok(calls[0].query.includes('orgTriggerInstances('));
+		assert.ok(output.includes('trigger trig-1 → instance instance-1 next 1710000000000 [manual]'));
+	});
+
+	test('get_trigger_error_status uses getTriggerErrorStatus query and validates triggerIds', async () => {
+		const { ctx, calls } = fakeCtx({
+			data: {
+				getTriggerErrorStatus: { t1: true },
+			},
+		});
+
+		const output = await cap('get_trigger_error_status').run({ orgId: 'org-1', triggerIds: ['t1'] }, ctx);
+
+		assert.ok(calls[0].query.includes('getTriggerErrorStatus('));
+		assert.ok(output.includes('ERROR'));
+		await assert.rejects(() => cap('get_trigger_error_status').run({ orgId: 'org-1' }, ctx), /triggerIds/);
+		await assert.rejects(
+			() => cap('get_trigger_error_status').run({ orgId: 'org-1', triggerIds: [] }, ctx),
+			/triggerIds/,
+		);
+	});
+});

--- a/src/capabilities/triggerFormCapabilities.test.ts
+++ b/src/capabilities/triggerFormCapabilities.test.ts
@@ -1,26 +1,9 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
-import type { Session } from '@sessions';
-import type { CapabilityContext } from './Capability';
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 const { suite, test, setup } = Mocha;
-function fakeCtx(response: unknown) {
-	const calls: { query: string; variables: Record<string, unknown> }[] = [];
-	const session = {
-		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
-			calls.push({ query, variables });
-			return response as { data?: unknown; errors?: unknown };
-		},
-	} as unknown as Session;
-	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
-	return { ctx, calls };
-}
-function cap(name: string) {
-	const c = TRIGGER_FORM_CAPABILITIES.find(x => x.spec.name === name);
-	if (!c) throw new Error('missing ' + name);
-	return c;
-}
+const { fakeCtx, cap } = createCapabilityTestHarness(TRIGGER_FORM_CAPABILITIES);
 suite('Unit: triggerFormCapabilities', () => {
 	setup(() => initTestEnvironment());
 

--- a/src/capabilities/triggerFormCapabilities.ts
+++ b/src/capabilities/triggerFormCapabilities.ts
@@ -1,0 +1,229 @@
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asString, requireString, asPositiveInt, ORG_ID_PROP } from './inputHelpers';
+
+const DEFAULT_TRIGGER_LIMIT = 50;
+const MAX_TRIGGER_LIMIT = 200;
+const DEFAULT_FORM_LIMIT = 50;
+const MAX_FORM_LIMIT = 200;
+const DEFAULT_TAG_LIMIT = 100;
+const MAX_TAG_LIMIT = 500;
+const DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT = 50;
+const MAX_ORG_TRIGGER_INSTANCE_LIMIT = 200;
+
+const LIST_TRIGGERS_QUERY = `query($orgId: ID!, $limit: Int){ triggers(where:{ orgId:$orgId }, limit:$limit, order:[["name","ASC"]]){ id name enabled triggerTypeId workflowId } }`;
+const LIST_FORMS_QUERY = `query($orgId: ID!, $limit: Int){ forms(where:{ orgId:$orgId }, limit:$limit){ id name updatedAt } }`;
+const LIST_TAGS_QUERY = `query($orgId: ID!, $limit: Int){ tags(where:{ orgId:$orgId }, limit:$limit, order:[["name","asc"]]){ id name color } }`;
+const LIST_ORG_TRIGGER_INSTANCES_QUERY = `query($orgId: ID!, $limit: Int){ orgTriggerInstances(where:{ orgId:$orgId }, limit:$limit){ id triggerId nextFireTime isManualActivation } }`;
+const GET_TRIGGER_ERROR_STATUS_QUERY = `query($triggerIds: [ID!]){ getTriggerErrorStatus(triggerIds:$triggerIds) }`;
+
+const listTriggersSpec: ToolSpec = {
+	name: 'list_triggers',
+	args: '{"orgId": string, "limit"?: number}',
+	description:
+		'List the triggers in one Rewst organization (id, name, enabled, triggerTypeId, workflowId). Triggers are how workflows are invoked.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			limit: {
+				type: 'number',
+				description: `Max triggers to return (default ${DEFAULT_TRIGGER_LIMIT}, max ${MAX_TRIGGER_LIMIT}).`,
+			},
+		},
+		required: ['orgId'],
+	},
+};
+
+const listFormsSpec: ToolSpec = {
+	name: 'list_forms',
+	args: '{"orgId": string, "limit"?: number}',
+	description: 'List the forms in one Rewst organization (id, name, updatedAt).',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			limit: {
+				type: 'number',
+				description: `Max forms to return (default ${DEFAULT_FORM_LIMIT}, max ${MAX_FORM_LIMIT}).`,
+			},
+		},
+		required: ['orgId'],
+	},
+};
+
+const listTagsSpec: ToolSpec = {
+	name: 'list_tags',
+	args: '{"orgId": string, "limit"?: number}',
+	description:
+		'List the tags in one Rewst organization (id, name, color). Use the ids for tag filters on other tools.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			limit: {
+				type: 'number',
+				description: `Max tags to return (default ${DEFAULT_TAG_LIMIT}, max ${MAX_TAG_LIMIT}).`,
+			},
+		},
+		required: ['orgId'],
+	},
+};
+
+const listOrgTriggerInstancesSpec: ToolSpec = {
+	name: 'list_org_trigger_instances',
+	args: '{"orgId": string, "limit"?: number}',
+	description:
+		'List trigger activation instances for one Rewst organization (id, triggerId, nextFireTime, isManualActivation). nextFireTime is an epoch-millisecond string.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			limit: {
+				type: 'number',
+				description: `Max trigger activation instances to return (default ${DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT}, max ${MAX_ORG_TRIGGER_INSTANCE_LIMIT}).`,
+			},
+		},
+		required: ['orgId'],
+	},
+};
+
+const getTriggerErrorStatusSpec: ToolSpec = {
+	name: 'get_trigger_error_status',
+	args: '{"orgId": string, "triggerIds": string[]}',
+	description:
+		'Batch health check for triggers: given trigger ids, returns whether each currently has errors (true = has errors).',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			triggerIds: { type: 'array', items: { type: 'string' }, description: 'Trigger ids to check.' },
+		},
+		required: ['orgId', 'triggerIds'],
+	},
+};
+
+function requireStringArray(input: Record<string, unknown>, key: string): string[] {
+	const value = input[key];
+	if (!Array.isArray(value) || value.length === 0) {
+		throw new Error(`Missing required non-empty string array argument "${key}".`);
+	}
+	const strings = value.map((_, index) => asString({ value: value[index] }, 'value'));
+	if (strings.some(value => !value)) {
+		throw new Error(`Missing required non-empty string array argument "${key}".`);
+	}
+	return strings as string[];
+}
+
+async function runListTriggers(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_TRIGGER_LIMIT, MAX_TRIGGER_LIMIT);
+	const variables = { orgId, limit };
+	const { data, errors } = await ctx.session.rawGraphql(LIST_TRIGGERS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const triggers = ((data as { triggers?: unknown[] } | undefined)?.triggers ?? []) as {
+		id?: string;
+		name?: string;
+		enabled?: boolean;
+		triggerTypeId?: string;
+		workflowId?: string | null;
+	}[];
+	if (triggers.length === 0) return 'No triggers found for this organization.';
+	return triggers
+		.map(trigger => {
+			const name = trigger.name ?? '(unnamed)';
+			const id = trigger.id ?? '(unknown id)';
+			return `${name} (${id})${trigger.enabled ? '' : ' [disabled]'}${
+				trigger.workflowId ? ' → workflow ' + trigger.workflowId : ''
+			}`;
+		})
+		.join('\n');
+}
+
+async function runListForms(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_FORM_LIMIT, MAX_FORM_LIMIT);
+	const variables = { orgId, limit };
+	const { data, errors } = await ctx.session.rawGraphql(LIST_FORMS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const forms = ((data as { forms?: unknown[] } | undefined)?.forms ?? []) as {
+		id?: string;
+		name?: string;
+		updatedAt?: string | null;
+	}[];
+	if (forms.length === 0) return 'No forms found for this organization.';
+	return forms.map(form => `${form.name ?? '(unnamed)'} (${form.id ?? '(unknown id)'})`).join('\n');
+}
+
+async function runListTags(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_TAG_LIMIT, MAX_TAG_LIMIT);
+	const variables = { orgId, limit };
+	const { data, errors } = await ctx.session.rawGraphql(LIST_TAGS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const tags = ((data as { tags?: unknown[] } | undefined)?.tags ?? []) as {
+		id?: string;
+		name?: string;
+		color?: string | null;
+	}[];
+	if (tags.length === 0) return 'No tags found for this organization.';
+	return tags.map(tag => `${tag.name ?? '(unnamed)'} (${tag.id ?? '(unknown id)'})`).join('\n');
+}
+
+async function runListOrgTriggerInstances(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const limit = Math.min(
+		asPositiveInt(input, 'limit') ?? DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT,
+		MAX_ORG_TRIGGER_INSTANCE_LIMIT,
+	);
+	const variables = { orgId, limit };
+	const { data, errors } = await ctx.session.rawGraphql(LIST_ORG_TRIGGER_INSTANCES_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const instances = ((data as { orgTriggerInstances?: unknown[] } | undefined)?.orgTriggerInstances ?? []) as {
+		id?: string;
+		triggerId?: string;
+		nextFireTime?: string | null;
+		isManualActivation?: boolean;
+	}[];
+	if (instances.length === 0) return 'No trigger activation instances found for this organization.';
+	return instances
+		.map(instance => {
+			const triggerId = instance.triggerId ?? '(unknown trigger)';
+			const id = instance.id ?? '(unknown id)';
+			return `trigger ${triggerId} → instance ${id}${instance.nextFireTime ? ' next ' + instance.nextFireTime : ''}${
+				instance.isManualActivation ? ' [manual]' : ''
+			}`;
+		})
+		.join('\n');
+}
+
+async function runGetTriggerErrorStatus(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	requireString(input, 'orgId');
+	const triggerIds = requireStringArray(input, 'triggerIds');
+	const variables = { triggerIds };
+	const { data, errors } = await ctx.session.rawGraphql(GET_TRIGGER_ERROR_STATUS_QUERY, variables);
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+	const statuses = ((data as { getTriggerErrorStatus?: Record<string, boolean> } | undefined)
+		?.getTriggerErrorStatus ?? {}) as Record<string, boolean>;
+	return Object.entries(statuses)
+		.map(([id, hasError]) => `${id}: ${hasError ? 'ERROR' : 'ok'}`)
+		.join('\n');
+}
+
+export const TRIGGER_FORM_CAPABILITIES: Capability[] = [
+	{ spec: listTriggersSpec, access: 'read', chat: false, mcp: true, run: runListTriggers },
+	{ spec: listFormsSpec, access: 'read', chat: false, mcp: true, run: runListForms },
+	{ spec: listTagsSpec, access: 'read', chat: false, mcp: true, run: runListTags },
+	{ spec: listOrgTriggerInstancesSpec, access: 'read', chat: false, mcp: true, run: runListOrgTriggerInstances },
+	{ spec: getTriggerErrorStatusSpec, access: 'read', chat: false, mcp: true, run: runGetTriggerErrorStatus },
+];

--- a/src/capabilities/triggerFormCapabilities.ts
+++ b/src/capabilities/triggerFormCapabilities.ts
@@ -216,8 +216,11 @@ async function runGetTriggerErrorStatus(input: Record<string, unknown>, ctx: Cap
 	}
 	const statuses = ((data as { getTriggerErrorStatus?: Record<string, boolean> } | undefined)
 		?.getTriggerErrorStatus ?? {}) as Record<string, boolean>;
-	return Object.entries(statuses)
-		.map(([id, hasError]) => `${id}: ${hasError ? 'ERROR' : 'ok'}`)
+	return triggerIds
+		.map(id => {
+			const hasError = statuses[id];
+			return `${id}: ${hasError === true ? 'ERROR' : hasError === false ? 'ok' : 'unknown'}`;
+		})
 		.join('\n');
 }
 

--- a/src/capabilities/triggerFormCapabilities.ts
+++ b/src/capabilities/triggerFormCapabilities.ts
@@ -205,6 +205,7 @@ async function runListOrgTriggerInstances(input: Record<string, unknown>, ctx: C
 		.join('\n');
 }
 
+// orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by trigger ids alone.
 async function runGetTriggerErrorStatus(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	requireString(input, 'orgId');
 	const triggerIds = requireStringArray(input, 'triggerIds');

--- a/src/test/helpers/capabilityTestUtils.ts
+++ b/src/test/helpers/capabilityTestUtils.ts
@@ -1,0 +1,39 @@
+import type { Capability, CapabilityContext } from '@capabilities';
+import type { Session } from '@sessions';
+
+export interface RawGraphqlCall {
+	query: string;
+	variables: Record<string, unknown>;
+}
+
+export function fakeCapabilityContext(response: unknown): {
+	ctx: CapabilityContext;
+	calls: RawGraphqlCall[];
+	session: Session;
+} {
+	const calls: RawGraphqlCall[] = [];
+	const session = {
+		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
+			calls.push({ query, variables });
+			return response as { data?: unknown; errors?: unknown };
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+	return { ctx, calls, session };
+}
+
+export function findTestCapability(capabilities: readonly Capability[], name: string): Capability {
+	const capability = capabilities.find(x => x.spec.name === name);
+	if (!capability) throw new Error('missing ' + name);
+	return capability;
+}
+
+export function createCapabilityTestHarness(capabilities: readonly Capability[]): {
+	fakeCtx: typeof fakeCapabilityContext;
+	cap: (name: string) => Capability;
+} {
+	return {
+		fakeCtx: fakeCapabilityContext,
+		cap: (name: string) => findTestCapability(capabilities, name),
+	};
+}

--- a/src/test/helpers/capabilityTestUtils.ts
+++ b/src/test/helpers/capabilityTestUtils.ts
@@ -3,7 +3,7 @@ import type { Session } from '@sessions';
 
 export interface RawGraphqlCall {
 	query: string;
-	variables: Record<string, unknown>;
+	variables?: Record<string, unknown>;
 }
 
 export function fakeCapabilityContext(response: unknown): {
@@ -13,7 +13,7 @@ export function fakeCapabilityContext(response: unknown): {
 } {
 	const calls: RawGraphqlCall[] = [];
 	const session = {
-		rawGraphql: async (query: string, variables: Record<string, unknown>) => {
+		rawGraphql: async (query: string, variables?: Record<string, unknown>) => {
 			calls.push({ query, variables });
 			return response as { data?: unknown; errors?: unknown };
 		},

--- a/src/test/helpers/index.ts
+++ b/src/test/helpers/index.ts
@@ -21,3 +21,6 @@ export {
 export { Fixtures } from './fixtures';
 
 export { createMockSession, MockSessionOptions } from './mockSession';
+
+export { createCapabilityTestHarness, fakeCapabilityContext, findTestCapability } from './capabilityTestUtils';
+export type { RawGraphqlCall } from './capabilityTestUtils';


### PR DESCRIPTION
## Summary

Probes all **113 root `Query` fields** live against a sandbox org and hardens the findings into **26 new read-only MCP query capabilities** (`chat:false, mcp:true`), plus a fix for the **`list_workflows`** tool, which wrapped the server-broken `visibleWorkflows` resolver and was 100% non-functional — now uses `workflows(where:{orgId})`.

The goal: stop agents from re-discovering the same GraphQL trial-and-error (broken resolvers, `where` vs `search`, jsonb-typed columns, cross-org leaks, pagination lies). Findings live both in the tools themselves and in a developer field guide.

### New capabilities (wired through `registry.ts`)

- **`rewstReadCapabilities`** — `resolve_reference`, `list_org_variables`, `find_action`, `list_workflow_executions`, `latest_workflow_execution`, `get_workflow_execution_stats`, `list_workflow_tasks`, `list_workflow_patches`, `get_workflow_patch`, and **`find_executions_by_variable`**
- **`triggerFormCapabilities`** — `list_triggers`, `list_forms`, `list_tags`, `list_org_trigger_instances`, `get_trigger_error_status`
- **`packIntegrationCapabilities`** — `list_installed_packs`, `get_pack_auth_status`, `list_pack_configs`, `list_integrations`
- **`orgUserCapabilities`** — `search_organizations`, `list_users`, `list_roles`
- **`pageTemplateCapabilities`** — `search_templates`, `list_pages`, `list_sites`, `list_jinja_filters`
- shared **`inputHelpers`**

### `find_executions_by_variable`

Finds one workflow's executions by an **input**, **output**, or **context** variable name (and optional value). Input/output are read inline from the execution's `conductor` object; context is fetched per execution via `workflowExecutionContexts`. There is no server-side filter for execution variables, so it scans the most-recent runs and filters client-side, scoped to a single workflow (`orgId` + `workflowId` required).

## Docs

`docs/dev/graphql-field-guide.md` records every probed field (status, smallest working query, gotchas), the broken/auth-gated resolver roster, and the cross-cutting `where`/`search`/jsonb/date/cross-org rules.

## Test plan

- [x] `npm run type-check`, `npm run lint`, `prettier --check`
- [x] Full unit suite: **563 passing**
- [x] `npm run build` (webpack) clean
- [x] Every new tool smoke-tested live over MCP against the sandbox org; `find_executions_by_variable` exercised across input / context (the N+1 `workflowExecutionContexts` path) / value-filter / no-match / scan-cap
- [x] Per-tool `changelog.d/` notes included

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added new read-only MCP tools: org variable/user/role listing; workflow execution listing/latest/stats and execution search by variable; workflow task + patch history inspection.
  * Added pack integration discovery tools, page template tools (including global Jinja filter browsing), and trigger/form/tag tools (including trigger error status).
  * Added installed action search and local reference name-to-id resolution.

* **Bug Fixes**
  * Improved `list_workflows` reliability by switching away from the failing visibility query.

* **Documentation**
  * Added the GraphQL Query Field Guide.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->