### PR TITLE
Add MCP template write tools (create, update body, rename, delete)

### DIFF
--- a/changelog.d/template-write-tools.md
+++ b/changelog.d/template-write-tools.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): template write tools** — when write tools are enabled, external MCP clients can now create and modify Rewst templates through four org-scoped tools: `create_template`, `update_template_body`, `rename_template`, and `delete_template`. Each runs against a single organization, re-verifies that the target template belongs to that org before changing anything, and requires a per-change approval inside VS Code before it runs.

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -8,6 +8,7 @@ import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
 import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
+import { TEMPLATE_MUTATE_CAPABILITIES } from './templateMutateCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -23,6 +24,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...PACK_INTEGRATION_CAPABILITIES,
 	...ORG_USER_CAPABILITIES,
 	...PAGE_TEMPLATE_CAPABILITIES,
+	...TEMPLATE_MUTATE_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/templateMutateCapabilities.test.ts
+++ b/src/capabilities/templateMutateCapabilities.test.ts
@@ -1,0 +1,402 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
+import { TEMPLATE_MUTATE_CAPABILITIES } from './templateMutateCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function cap(name: string): Capability {
+	const capability = TEMPLATE_MUTATE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+/** A mock session whose primary org is the given id, plus a ctx scoped to it. */
+function sandboxCtx(orgId = 'org-sandbox', name = 'Sandbox') {
+	const { session, wrapper } = createMockSession({ profile: { org: { id: orgId, name } } });
+	const ctx: CapabilityContext = { session, orgId, sessions: [session] };
+	return { ctx, wrapper };
+}
+
+suite('Unit: templateMutateCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	suite('create_template', () => {
+		test('is a write capability gated by approval, mcp-only', () => {
+			const c = cap('create_template');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+
+		test('creates the template and returns its id when approved', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('createTemplateMinimal', {
+				data: Fixtures.createTemplateMinimalMutation({ id: 't-new', name: 'My Template' }),
+			});
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('create_template').run(
+				{ orgId: 'org-sandbox', name: 'My Template', body: 'hello' },
+				ctx,
+			);
+
+			const calls = wrapper.getCallsFor('createTemplateMinimal');
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0].variables, { name: 'My Template', orgId: 'org-sandbox', body: 'hello' });
+			const parsed = JSON.parse(output);
+			assert.strictEqual(parsed.status, 'created');
+			assert.strictEqual(parsed.id, 't-new');
+		});
+
+		test('passes the requested org to the approval scope and summary', async () => {
+			const { ctx, wrapper } = sandboxCtx('org-sandbox', 'Sandbox');
+			wrapper.when('createTemplateMinimal', { data: Fixtures.createTemplateMinimalMutation({ id: 't-1' }) });
+			let seenScope: MutationScope | undefined;
+			let seenSummary = '';
+			setMcpMutationApprover(async (scope, summary) => {
+				seenScope = scope;
+				seenSummary = summary;
+				return true;
+			});
+
+			await cap('create_template').run({ orgId: 'org-sandbox', name: 'Greeting', body: '' }, ctx);
+
+			assert.strictEqual(seenScope?.orgId, 'org-sandbox');
+			assert.strictEqual(seenScope?.orgName, 'Sandbox');
+			assert.ok(seenSummary.includes('Greeting'));
+			assert.ok(seenSummary.includes('org-sandbox'));
+		});
+
+		test('does not mutate when approval is denied', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('create_template').run(
+				{ orgId: 'org-sandbox', name: 'My Template', body: 'hello' },
+				ctx,
+			);
+
+			assert.strictEqual(wrapper.getCallsFor('createTemplateMinimal').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+
+		test('allows an empty body but rejects a missing one', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('createTemplateMinimal', { data: Fixtures.createTemplateMinimalMutation({ id: 't-blank' }) });
+			setMcpMutationApprover(async () => true);
+
+			await cap('create_template').run({ orgId: 'org-sandbox', name: 'Blank', body: '' }, ctx);
+			assert.strictEqual(wrapper.getCallsFor('createTemplateMinimal')[0].variables!.body, '');
+
+			await assert.rejects(
+				() => cap('create_template').run({ orgId: 'org-sandbox', name: 'No Body' }, ctx),
+				/Missing required string argument "body"/,
+			);
+		});
+
+		test('rejects a blank name before requesting approval', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('create_template').run({ orgId: 'org-sandbox', name: '   ', body: 'x' }, ctx),
+				/Missing required string argument "name"/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(wrapper.getCallsFor('createTemplateMinimal').length, 0);
+		});
+	});
+
+	suite('update_template_body', () => {
+		test('is a write capability gated by approval, mcp-only', () => {
+			const c = cap('update_template_body');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+
+		test('updates the body when the template is in-org and approved', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper
+				.when('getTemplate', {
+					data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'My T' }),
+				})
+				.when('updateTemplateBody', {
+					data: Fixtures.updateTemplateBodyMutation({ id: 't-1', orgId: 'org-sandbox', name: 'My T' }),
+				});
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('update_template_body').run(
+				{ orgId: 'org-sandbox', templateId: 't-1', body: 'new body' },
+				ctx,
+			);
+
+			const calls = wrapper.getCallsFor('updateTemplateBody');
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0].variables, { id: 't-1', body: 'new body' });
+			assert.strictEqual(JSON.parse(output).status, 'updated');
+		});
+
+		test('refuses to mutate a template that belongs to another org', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('getTemplate', {
+				data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-OTHER', name: 'Foreign' }),
+			});
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('update_template_body').run({ orgId: 'org-sandbox', templateId: 't-1', body: 'x' }, ctx),
+				/Template t-1 is not in org org-sandbox/,
+			);
+			// The org check runs before any prompt or mutation: fail closed.
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 0);
+		});
+
+		test('does not mutate when approval is denied', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('getTemplate', {
+				data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'My T' }),
+			});
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('update_template_body').run(
+				{ orgId: 'org-sandbox', templateId: 't-1', body: 'x' },
+				ctx,
+			);
+
+			assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+
+		test('allows an empty body but rejects a missing one', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper
+				.when('getTemplate', {
+					data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'My T' }),
+				})
+				.when('updateTemplateBody', {
+					data: Fixtures.updateTemplateBodyMutation({ id: 't-1', orgId: 'org-sandbox' }),
+				});
+			setMcpMutationApprover(async () => true);
+
+			await cap('update_template_body').run({ orgId: 'org-sandbox', templateId: 't-1', body: '' }, ctx);
+			assert.strictEqual(wrapper.getCallsFor('updateTemplateBody')[0].variables!.body, '');
+
+			await assert.rejects(
+				() => cap('update_template_body').run({ orgId: 'org-sandbox', templateId: 't-1' }, ctx),
+				/Missing required string argument "body"/,
+			);
+		});
+
+		test('rejects a blank templateId before fetching or approving', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('update_template_body').run({ orgId: 'org-sandbox', templateId: '  ', body: 'x' }, ctx),
+				/Missing required string argument "templateId"/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 0);
+			assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 0);
+		});
+	});
+
+	suite('rename_template', () => {
+		test('is a write capability gated by approval, mcp-only', () => {
+			const c = cap('rename_template');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+
+		test('renames the template when in-org and approved', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper
+				.when('getTemplate', {
+					data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'Old Name' }),
+				})
+				.when('updateTemplateName', {
+					data: {
+						__typename: 'Mutation',
+						template: Fixtures.fullTemplate({ id: 't-1', orgId: 'org-sandbox', name: 'New Name' }),
+					},
+				});
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('rename_template').run(
+				{ orgId: 'org-sandbox', templateId: 't-1', name: 'New Name' },
+				ctx,
+			);
+
+			const calls = wrapper.getCallsFor('updateTemplateName');
+			assert.strictEqual(calls.length, 1);
+			assert.deepStrictEqual(calls[0].variables, { id: 't-1', name: 'New Name' });
+			const parsed = JSON.parse(output);
+			assert.strictEqual(parsed.status, 'renamed');
+			assert.strictEqual(parsed.name, 'New Name');
+		});
+
+		test('refuses to rename a template that belongs to another org', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('getTemplate', {
+				data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-OTHER', name: 'Foreign' }),
+			});
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('rename_template').run({ orgId: 'org-sandbox', templateId: 't-1', name: 'X' }, ctx),
+				/Template t-1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(wrapper.getCallsFor('updateTemplateName').length, 0);
+		});
+
+		test('does not mutate when approval is denied', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('getTemplate', {
+				data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'Old Name' }),
+			});
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('rename_template').run(
+				{ orgId: 'org-sandbox', templateId: 't-1', name: 'New Name' },
+				ctx,
+			);
+
+			assert.strictEqual(wrapper.getCallsFor('updateTemplateName').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+
+		test('rejects a blank name before fetching or approving', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('rename_template').run({ orgId: 'org-sandbox', templateId: 't-1', name: '  ' }, ctx),
+				/Missing required string argument "name"/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 0);
+			assert.strictEqual(wrapper.getCallsFor('updateTemplateName').length, 0);
+		});
+	});
+
+	suite('delete_template', () => {
+		test('is a write capability gated by approval, mcp-only', () => {
+			const c = cap('delete_template');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+
+		test('deletes the template when in-org and approved', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper
+				.when('getTemplate', {
+					data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'Doomed' }),
+				})
+				.when('deleteTemplate', { data: { __typename: 'Mutation', deleteTemplate: 't-1' } });
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('delete_template').run({ orgId: 'org-sandbox', templateId: 't-1' }, ctx);
+
+			assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 1);
+			assert.deepStrictEqual(wrapper.getCallsFor('deleteTemplate')[0].variables, { id: 't-1' });
+			const parsed = JSON.parse(output);
+			assert.strictEqual(parsed.status, 'deleted');
+			assert.strictEqual(parsed.id, 't-1');
+		});
+
+		test('refuses to delete a template that belongs to another org', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('getTemplate', {
+				data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-OTHER', name: 'Foreign' }),
+			});
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('delete_template').run({ orgId: 'org-sandbox', templateId: 't-1' }, ctx),
+				/Template t-1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 0);
+		});
+
+		test('does not delete when approval is denied', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('getTemplate', {
+				data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'Doomed' }),
+			});
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('delete_template').run({ orgId: 'org-sandbox', templateId: 't-1' }, ctx);
+
+			assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+
+		test('rejects a blank templateId before fetching or approving', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('delete_template').run({ orgId: 'org-sandbox', templateId: '  ' }, ctx),
+				/Missing required string argument "templateId"/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 0);
+			assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 0);
+		});
+	});
+});

--- a/src/capabilities/templateMutateCapabilities.ts
+++ b/src/capabilities/templateMutateCapabilities.ts
@@ -1,0 +1,228 @@
+import { approveMutationScope, isMutationScopeApproved, type MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { requestMcpMutationApproval } from './graphqlMutateCapability';
+import { ORG_ID_PROP, requireString } from './inputHelpers';
+
+/**
+ * Template write capabilities. Every mutation here is org-scoped: the MCP
+ * boundary resolves a session for the requested orgId, but one session can manage
+ * many orgs, so a bare template-id mutation could otherwise reach a template in a
+ * sibling org. Each by-id write therefore re-verifies the template's orgId before
+ * mutating (requireTemplateInOrg), mirroring the read path in runGetTemplate, and
+ * every mutation is gated by the same per-call VS Code approval the other write
+ * tools use. Exposure is additionally gated by rewst-buddy.mcp.enableWriteTools.
+ */
+
+function approvalRequiredResult(): string {
+	return JSON.stringify({
+		status: 'approval_required',
+		message:
+			'The mutation was not run. The user must approve it in VS Code (a modal appears in their editor); retry after they approve.',
+	});
+}
+
+/**
+ * The name of the org being mutated, resolved against the requested orgId rather
+ * than the session's primary org (a session can manage several orgs, so
+ * profile.org is not necessarily the requested one). Used only for the approval
+ * modal text; org scoping itself is by the authoritative orgId.
+ */
+function orgDisplayName(ctx: CapabilityContext): string {
+	const { profile } = ctx.session;
+	if (profile.org.id === ctx.orgId) return profile.org.name;
+	const managed = profile.allManagedOrgs.find(org => org.id === ctx.orgId);
+	return managed?.name ?? ctx.orgId;
+}
+
+/** Requires a string argument that may be empty (e.g. a blank template body). */
+function requireStringAllowEmpty(input: Record<string, unknown>, key: string): string {
+	const value = input[key];
+	if (typeof value !== 'string') {
+		throw new Error(`Missing required string argument "${key}".`);
+	}
+	return value;
+}
+
+/**
+ * Fetches a template by id and fails closed unless it belongs to the requested
+ * org. A session can manage several orgs and the SDK mutations target a template
+ * by id alone, so this re-verification is what actually confines a by-id write to
+ * the requested org (mirrors the read path in runGetTemplate). Returns the
+ * template's name for the approval scope. getTemplate throws if the id is unknown.
+ */
+async function requireTemplateInOrg(
+	ctx: CapabilityContext,
+	templateId: string,
+	orgId: string,
+): Promise<{ name: string }> {
+	const template = await ctx.session.getTemplate(templateId);
+	const templateOrgId = (template as { orgId?: unknown }).orgId;
+	if (typeof templateOrgId !== 'string' || templateOrgId !== orgId) {
+		throw new Error(`Template ${templateId} is not in org ${orgId}.`);
+	}
+	const name = (template as { name?: unknown }).name;
+	return { name: typeof name === 'string' && name.length > 0 ? name : '(unnamed)' };
+}
+
+/** Runs a mutation behind the shared per-call approval flow. */
+async function withTemplateApproval(
+	scope: MutationScope,
+	operationSummary: string,
+	run: () => Promise<string>,
+): Promise<string> {
+	if (!isMutationScopeApproved(scope)) {
+		if (!(await requestMcpMutationApproval(scope, operationSummary))) {
+			return approvalRequiredResult();
+		}
+		approveMutationScope(scope);
+	}
+	return run();
+}
+
+const createTemplateSpec: ToolSpec = {
+	name: 'create_template',
+	args: '{"orgId": string, "name": string, "body": string}',
+	description:
+		'Create a new Rewst template in one organization from a name and body, returning the new template id and name. Requires write tools to be enabled and per-call approval in VS Code. Pass an empty string for body to start a blank template.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			name: { type: 'string', description: 'Name for the new template.' },
+			body: {
+				type: 'string',
+				description: 'Template body (Jinja/text); pass an empty string for a blank template.',
+			},
+		},
+		required: ['orgId', 'name', 'body'],
+	},
+};
+
+async function runCreateTemplate(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const name = requireString(input, 'name');
+	const body = requireStringAllowEmpty(input, 'body');
+	const orgName = orgDisplayName(ctx);
+	// No resource id exists before creation, so the approval scope is the org; the
+	// first create in an org prompts and later creates reuse that session approval.
+	const scope: MutationScope = { scopeId: orgId, scopeName: `new template "${name}"`, orgId, orgName };
+	const summary = `Create template "${name}" in org "${orgName}" (${orgId})`;
+	return withTemplateApproval(scope, summary, async () => {
+		const response = await ctx.session.sdk?.createTemplateMinimal({ name, orgId, body });
+		const template = response?.template;
+		if (!template?.id) {
+			throw new Error('createTemplate returned no template; the mutation may have failed.');
+		}
+		return JSON.stringify({ status: 'created', id: template.id, name: template.name ?? name }, null, 2);
+	});
+}
+
+const updateTemplateBodySpec: ToolSpec = {
+	name: 'update_template_body',
+	args: '{"orgId": string, "templateId": string, "body": string}',
+	description:
+		'Replace the body of one existing Rewst template, identified by org and template id. The template must belong to the given org. Requires write tools to be enabled and per-call approval in VS Code. Pass an empty string to clear the body.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			templateId: { type: 'string', description: 'Id of the template whose body to replace.' },
+			body: { type: 'string', description: 'New template body; pass an empty string to clear it.' },
+		},
+		required: ['orgId', 'templateId', 'body'],
+	},
+};
+
+async function runUpdateTemplateBody(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const templateId = requireString(input, 'templateId');
+	const body = requireStringAllowEmpty(input, 'body');
+	const orgName = orgDisplayName(ctx);
+	// Verify org ownership before prompting or mutating, so a template in a sibling
+	// org the session also manages can never be reached by id.
+	const { name } = await requireTemplateInOrg(ctx, templateId, orgId);
+	const scope: MutationScope = { scopeId: templateId, scopeName: name, orgId, orgName };
+	const summary = `Replace body of template "${name}" (${templateId}) in org "${orgName}" (${orgId})`;
+	return withTemplateApproval(scope, summary, async () => {
+		const response = await ctx.session.sdk?.updateTemplateBody({ id: templateId, body });
+		const template = response?.template;
+		if (!template?.id) {
+			throw new Error('updateTemplateBody returned no template; the mutation may have failed.');
+		}
+		return JSON.stringify({ status: 'updated', id: template.id, name: template.name ?? name }, null, 2);
+	});
+}
+
+const renameTemplateSpec: ToolSpec = {
+	name: 'rename_template',
+	args: '{"orgId": string, "templateId": string, "name": string}',
+	description:
+		'Rename one existing Rewst template, identified by org and template id. The template must belong to the given org. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			templateId: { type: 'string', description: 'Id of the template to rename.' },
+			name: { type: 'string', description: 'New name for the template.' },
+		},
+		required: ['orgId', 'templateId', 'name'],
+	},
+};
+
+async function runRenameTemplate(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const templateId = requireString(input, 'templateId');
+	const name = requireString(input, 'name');
+	const orgName = orgDisplayName(ctx);
+	const { name: currentName } = await requireTemplateInOrg(ctx, templateId, orgId);
+	const scope: MutationScope = { scopeId: templateId, scopeName: currentName, orgId, orgName };
+	const summary = `Rename template "${currentName}" (${templateId}) to "${name}" in org "${orgName}" (${orgId})`;
+	return withTemplateApproval(scope, summary, async () => {
+		const response = await ctx.session.sdk?.updateTemplateName({ id: templateId, name });
+		const template = response?.template;
+		if (!template?.id) {
+			throw new Error('updateTemplateName returned no template; the mutation may have failed.');
+		}
+		return JSON.stringify({ status: 'renamed', id: template.id, name: template.name ?? name }, null, 2);
+	});
+}
+
+const deleteTemplateSpec: ToolSpec = {
+	name: 'delete_template',
+	args: '{"orgId": string, "templateId": string}',
+	description:
+		'Permanently delete one Rewst template, identified by org and template id. The template must belong to the given org. This cannot be undone. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			templateId: { type: 'string', description: 'Id of the template to delete.' },
+		},
+		required: ['orgId', 'templateId'],
+	},
+};
+
+async function runDeleteTemplate(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const templateId = requireString(input, 'templateId');
+	const orgName = orgDisplayName(ctx);
+	const { name } = await requireTemplateInOrg(ctx, templateId, orgId);
+	const scope: MutationScope = { scopeId: templateId, scopeName: name, orgId, orgName };
+	const summary = `Delete template "${name}" (${templateId}) in org "${orgName}" (${orgId})`;
+	return withTemplateApproval(scope, summary, async () => {
+		const response = await ctx.session.sdk?.deleteTemplate({ id: templateId });
+		const deletedId = response?.deleteTemplate;
+		if (!deletedId) {
+			throw new Error('deleteTemplate returned no id; the mutation may have failed.');
+		}
+		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
+	});
+}
+
+export const TEMPLATE_MUTATE_CAPABILITIES: Capability[] = [
+	{ spec: createTemplateSpec, access: 'write', chat: false, mcp: true, run: runCreateTemplate },
+	{ spec: updateTemplateBodySpec, access: 'write', chat: false, mcp: true, run: runUpdateTemplateBody },
+	{ spec: renameTemplateSpec, access: 'write', chat: false, mcp: true, run: runRenameTemplate },
+	{ spec: deleteTemplateSpec, access: 'write', chat: false, mcp: true, run: runDeleteTemplate },
+];

--- a/src/test/integration/templateMutate.test.ts
+++ b/src/test/integration/templateMutate.test.ts
@@ -1,0 +1,142 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import { _resetApprovedMutationScopes } from '../../ui/chat/tools/graphqlTool';
+import { TEMPLATE_MUTATE_CAPABILITIES } from '../../capabilities/templateMutateCapabilities';
+
+const { suite, test, suiteSetup, suiteTeardown, setup } = Mocha;
+
+/**
+ * Live verification for the template write capabilities. These create and delete
+ * a real, throwaway template, so the suite is opt-in: it runs only when a token
+ * is present AND REWST_TEST_WRITE=1, and it always targets the token's own
+ * primary org (use a sandbox token). The template is removed in teardown even if
+ * an assertion fails. When the session also manages a second org, the run doubles
+ * as a live proof that a write carrying a non-target orgId is refused before it
+ * mutates.
+ */
+function writeTestsEnabled(): boolean {
+	return hasTestToken() && process.env.REWST_TEST_WRITE === '1';
+}
+
+function cap(name: string): Capability {
+	const capability = TEMPLATE_MUTATE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+suite('Integration: template write tools', function () {
+	this.timeout(120_000);
+
+	let session: Session;
+	let ctx: CapabilityContext;
+	let targetOrgId: string;
+	/** A second org the same session manages, used for the org-guard probe. */
+	let otherOrgId: string | undefined;
+
+	suiteSetup(async function () {
+		if (!writeTestsEnabled()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		session = await getTestSession();
+
+		targetOrgId = session.profile.org.id;
+		if (!targetOrgId) {
+			throw new Error('Refusing to run: the test session has no primary org id.');
+		}
+		otherOrgId = session.profile.allManagedOrgs.find(org => org.id && org.id !== targetOrgId)?.id;
+		ctx = { session, orgId: targetOrgId, sessions: [session] };
+
+		console.log(`\n[itest] target org: ${session.profile.org.name} (${targetOrgId})`);
+	});
+
+	setup(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		setMcpMutationApprover(async () => true);
+	});
+
+	suiteTeardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		clearCachedSession();
+	});
+
+	test('create -> update body -> rename -> delete round-trips in the target org', async () => {
+		const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+		const initialName = `rb-itest-${stamp}`;
+		let templateId: string | undefined;
+
+		try {
+			const created = JSON.parse(
+				await cap('create_template').run({ orgId: targetOrgId, name: initialName, body: '{{ 1 + 1 }}' }, ctx),
+			);
+			assert.strictEqual(created.status, 'created');
+			assert.ok(created.id, 'create returned an id');
+			templateId = created.id;
+
+			console.log('[itest] created template', templateId);
+
+			const fetched = await session.getTemplate(templateId!);
+			assert.strictEqual(fetched.orgId, targetOrgId, 'created template is in the target org');
+			assert.strictEqual(fetched.body, '{{ 1 + 1 }}');
+
+			const updated = JSON.parse(
+				await cap('update_template_body').run({ orgId: targetOrgId, templateId, body: '{{ 2 + 2 }}' }, ctx),
+			);
+			assert.strictEqual(updated.status, 'updated');
+			assert.strictEqual((await session.getTemplate(templateId!)).body, '{{ 2 + 2 }}');
+
+			// Org guard (live): the same write with a different managed orgId must be
+			// refused before mutating. This only reads the target template; the other
+			// org is never written.
+			if (otherOrgId) {
+				const guardCtx: CapabilityContext = { session, orgId: otherOrgId, sessions: [session] };
+				await assert.rejects(
+					() =>
+						cap('update_template_body').run(
+							{ orgId: otherOrgId, templateId, body: 'SHOULD NOT APPLY' },
+							guardCtx,
+						),
+					/is not in org/,
+				);
+				assert.strictEqual((await session.getTemplate(templateId!)).body, '{{ 2 + 2 }}');
+
+				console.log('[itest] org guard refused a cross-org write to', otherOrgId);
+			}
+
+			const renamed = JSON.parse(
+				await cap('rename_template').run(
+					{ orgId: targetOrgId, templateId, name: `${initialName}-renamed` },
+					ctx,
+				),
+			);
+			assert.strictEqual(renamed.status, 'renamed');
+			assert.strictEqual((await session.getTemplate(templateId!)).name, `${initialName}-renamed`);
+
+			const deleted = JSON.parse(await cap('delete_template').run({ orgId: targetOrgId, templateId }, ctx));
+			assert.strictEqual(deleted.status, 'deleted');
+			assert.strictEqual(deleted.id, templateId);
+			templateId = undefined;
+
+			console.log('[itest] deleted template; target org clean');
+		} finally {
+			if (templateId) {
+				try {
+					await session.sdk?.deleteTemplate({ id: templateId });
+				} catch {
+					// best-effort cleanup
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds the first set of **MCP template write tools**, the write counterpart to the read tools shipped in #73. Four org-scoped, approval-gated capabilities:

- `create_template` — create a template from `{orgId, name, body}`
- `update_template_body` — replace a template's body
- `rename_template` — rename a template
- `delete_template` — permanently delete a template

All are `access:'write'` (hidden unless `rewst-buddy.mcp.enableWriteTools` is on), `chat:false`, `mcp:true`, and require an `orgId`.

## Safety model

- **Per-call approval.** Each mutation routes through the same `requestMcpMutationApproval` / `MutationScope` flow the workflow write tools use. Denied → returns `approval_required` and performs **no** mutation.
- **Org-ownership pre-flight.** The SDK template mutations act by id alone, and one session can manage many orgs, so by-id writes (`update_template_body`, `rename_template`, `delete_template`) first fetch the template and **fail closed** unless `template.orgId === requestedOrgId` (mirrors the read path in `runGetTemplate`). `create_template` passes `orgId` straight into the mutation, so it is natively scoped.
- **Approval-modal org name** is resolved from the *requested* orgId via `allManagedOrgs`, not the session's primary org.

> [!NOTE]
> Like `rewst_graphql_mutate` and the workflow write tools, these act on **whichever org the caller passes** — they are not pinned to a single org. With multiple signed-in sessions, every managed org is reachable. Operators should keep only the intended session(s) signed in when write tools are enabled, and rely on the approval modal (which names the org) as the last gate.

## Tests

- **Unit (22):** each tool — capability shape/gating, happy path (asserting exact SDK variables), cross-org rejection (throws, approver never called, zero mutations), approval-denied, and input validation before side effects.
- **Integration (opt-in):** a live `create → update body → rename → delete` round-trip plus a live cross-org guard probe, gated behind `REWST_TEST_WRITE=1`, targeting the token's own primary org, self-cleaning. Skips by default. Verified green against a sandbox org.

Full unit suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template write tools now available for MCP clients to create, modify, rename, and delete templates with organization-scoped protection and per-operation VS Code approval.
  * Template ownership verified before any modifications to ensure data integrity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->