### PR TITLE
Add MCP org variable write tools (create, update, delete)

### DIFF
--- a/changelog.d/org-variable-write-tools.md
+++ b/changelog.d/org-variable-write-tools.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): org variable write tools** — when write tools are enabled, external MCP clients can now manage Rewst configuration variables through three org-scoped tools: `create_org_variable`, `update_org_variable`, and `delete_org_variable`. Each runs against a single organization, re-verifies that the target variable belongs to that org before changing anything, and requires a per-change approval inside VS Code.

--- a/src/capabilities/mutationApproval.ts
+++ b/src/capabilities/mutationApproval.ts
@@ -1,0 +1,54 @@
+import { approveMutationScope, isMutationScopeApproved, type MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { CapabilityContext } from './Capability';
+import { requestMcpMutationApproval } from './graphqlMutateCapability';
+
+/**
+ * Shared plumbing for the org-scoped write capabilities (templates, org
+ * variables, tags, …). Every write routes through the same per-call VS Code
+ * approval the workflow write tools use, and reports the org being changed by the
+ * requested orgId rather than the session's primary org.
+ */
+
+/** The standard "not run, awaiting approval" result write tools return on deny. */
+export function approvalRequiredResult(): string {
+	return JSON.stringify({
+		status: 'approval_required',
+		message:
+			'The mutation was not run. The user must approve it in VS Code (a modal appears in their editor); retry after they approve.',
+	});
+}
+
+/**
+ * The display name of the org being mutated, resolved against the requested orgId
+ * rather than the session's primary org — one session can manage several orgs, so
+ * profile.org is not necessarily the requested one. Used only for the approval
+ * modal text; scoping itself is by the authoritative orgId.
+ */
+export function orgDisplayName(ctx: CapabilityContext): string {
+	const { profile } = ctx.session;
+	if (profile.org.id === ctx.orgId) return profile.org.name;
+	const managed = profile.allManagedOrgs.find(org => org.id === ctx.orgId);
+	return managed?.name ?? ctx.orgId;
+}
+
+/** Runs a mutation behind the shared per-call approval flow. */
+export async function withMutationApproval(
+	scope: MutationScope,
+	operationSummary: string,
+	run: () => Promise<string>,
+): Promise<string> {
+	if (!isMutationScopeApproved(scope)) {
+		if (!(await requestMcpMutationApproval(scope, operationSummary))) {
+			return approvalRequiredResult();
+		}
+		approveMutationScope(scope);
+	}
+	return run();
+}
+
+/** Throws with the serialized GraphQL errors when a rawGraphql call failed. */
+export function throwOnGraphqlErrors(errors: unknown): void {
+	if (Array.isArray(errors) ? errors.length > 0 : errors != null) {
+		throw new Error(`GraphQL error: ${JSON.stringify(errors)}`);
+	}
+}

--- a/src/capabilities/orgVariableMutateCapabilities.test.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.test.ts
@@ -1,0 +1,306 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import type { Session } from '@sessions';
+import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import { ORG_VARIABLE_MUTATE_CAPABILITIES } from './orgVariableMutateCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function cap(name: string): Capability {
+	const capability = ORG_VARIABLE_MUTATE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+interface GraphqlResult {
+	data?: unknown;
+	errors?: unknown;
+}
+type OpResponses = Partial<Record<'byId' | 'create' | 'update' | 'delete', GraphqlResult>>;
+
+function routeOp(query: string): 'byId' | 'create' | 'update' | 'delete' | 'unknown' {
+	if (query.includes('OrgVariableById')) return 'byId';
+	if (query.includes('CreateOrgVariable')) return 'create';
+	if (query.includes('UpdateOrgVariables')) return 'update';
+	if (query.includes('DeleteOrgVariable')) return 'delete';
+	return 'unknown';
+}
+
+function makeCtx(responses: OpResponses, orgId = 'org-sandbox', orgName = 'Sandbox') {
+	const calls: { op: string; variables: Record<string, unknown> | undefined }[] = [];
+	const session = {
+		profile: { org: { id: orgId, name: orgName }, allManagedOrgs: [{ id: orgId, name: orgName }] },
+		rawGraphql: async (query: string, variables?: Record<string, unknown>) => {
+			const op = routeOp(query);
+			calls.push({ op, variables });
+			const r = responses[op as keyof OpResponses];
+			if (!r) throw new Error(`no mock configured for op "${op}"`);
+			return r;
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId, sessions: [session] };
+	return { ctx, calls };
+}
+
+function callsFor(calls: { op: string; variables: Record<string, unknown> | undefined }[], op: string) {
+	return calls.filter(c => c.op === op);
+}
+
+suite('Unit: orgVariableMutateCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	suite('create_org_variable', () => {
+		test('is a write capability gated by approval, mcp-only', () => {
+			const c = cap('create_org_variable');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+
+		test('creates with defaults (general, non-cascade) when approved', async () => {
+			const { ctx, calls } = makeCtx({ create: { data: { createOrgVariable: { id: 'v1', name: 'API_KEY' } } } });
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('create_org_variable').run(
+				{ orgId: 'org-sandbox', name: 'API_KEY', value: 'abc' },
+				ctx,
+			);
+
+			const created = callsFor(calls, 'create');
+			assert.strictEqual(created.length, 1);
+			assert.deepStrictEqual(created[0].variables, {
+				orgVariable: {
+					orgId: 'org-sandbox',
+					name: 'API_KEY',
+					value: 'abc',
+					category: 'general',
+					cascade: false,
+				},
+			});
+			const parsed = JSON.parse(output);
+			assert.strictEqual(parsed.status, 'created');
+			assert.strictEqual(parsed.id, 'v1');
+		});
+
+		test('forwards secret category and cascade flag', async () => {
+			const { ctx, calls } = makeCtx({ create: { data: { createOrgVariable: { id: 'v2', name: 'TOKEN' } } } });
+			setMcpMutationApprover(async () => true);
+
+			await cap('create_org_variable').run(
+				{ orgId: 'org-sandbox', name: 'TOKEN', value: 's3cret', category: 'secret', cascade: true },
+				ctx,
+			);
+
+			const v = callsFor(calls, 'create')[0].variables as { orgVariable: Record<string, unknown> };
+			assert.strictEqual(v.orgVariable.category, 'secret');
+			assert.strictEqual(v.orgVariable.cascade, true);
+		});
+
+		test('allows an empty value but rejects a missing one', async () => {
+			const { ctx } = makeCtx({ create: { data: { createOrgVariable: { id: 'v3', name: 'EMPTY' } } } });
+			setMcpMutationApprover(async () => true);
+
+			await cap('create_org_variable').run({ orgId: 'org-sandbox', name: 'EMPTY', value: '' }, ctx);
+
+			await assert.rejects(
+				() => cap('create_org_variable').run({ orgId: 'org-sandbox', name: 'NOVAL' }, ctx),
+				/Missing required string argument "value"/,
+			);
+		});
+
+		test('rejects an unknown or reserved category before approval', async () => {
+			const { ctx, calls } = makeCtx({});
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() =>
+					cap('create_org_variable').run(
+						{ orgId: 'org-sandbox', name: 'X', value: 'y', category: 'system' },
+						ctx,
+					),
+				/"category" must be one of/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(callsFor(calls, 'create').length, 0);
+		});
+
+		test('does not create when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({});
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('create_org_variable').run(
+				{ orgId: 'org-sandbox', name: 'API_KEY', value: 'abc' },
+				ctx,
+			);
+
+			assert.strictEqual(callsFor(calls, 'create').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+	});
+
+	suite('update_org_variable', () => {
+		const inOrgRow = {
+			data: {
+				orgVariables: [
+					{ id: 'v1', name: 'API_KEY', category: 'general', cascade: false, orgId: 'org-sandbox' },
+				],
+			},
+		};
+
+		test('preserves name and updates value when in-org and approved', async () => {
+			const { ctx, calls } = makeCtx({
+				byId: inOrgRow,
+				update: { data: { updateOrgVariables: [{ id: 'v1', name: 'API_KEY' }] } },
+			});
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('update_org_variable').run(
+				{ orgId: 'org-sandbox', variableId: 'v1', value: 'new-value' },
+				ctx,
+			);
+
+			const upd = callsFor(calls, 'update');
+			assert.strictEqual(upd.length, 1);
+			assert.deepStrictEqual(upd[0].variables, {
+				orgVariables: [
+					{
+						id: 'v1',
+						orgId: 'org-sandbox',
+						name: 'API_KEY',
+						value: 'new-value',
+						category: 'general',
+						cascade: false,
+					},
+				],
+			});
+			assert.strictEqual(JSON.parse(output).status, 'updated');
+		});
+
+		test('applies category and cascade overrides', async () => {
+			const { ctx, calls } = makeCtx({
+				byId: inOrgRow,
+				update: { data: { updateOrgVariables: [{ id: 'v1', name: 'API_KEY' }] } },
+			});
+			setMcpMutationApprover(async () => true);
+
+			await cap('update_org_variable').run(
+				{ orgId: 'org-sandbox', variableId: 'v1', value: 'x', category: 'secret', cascade: true },
+				ctx,
+			);
+
+			const payload = (callsFor(calls, 'update')[0].variables as { orgVariables: Record<string, unknown>[] })
+				.orgVariables[0];
+			assert.strictEqual(payload.category, 'secret');
+			assert.strictEqual(payload.cascade, true);
+		});
+
+		test('refuses to update a variable in another org', async () => {
+			const { ctx, calls } = makeCtx({ byId: { data: { orgVariables: [] } } });
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('update_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1', value: 'x' }, ctx),
+				/Org variable v1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(callsFor(calls, 'update').length, 0);
+		});
+
+		test('does not update when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('update_org_variable').run(
+				{ orgId: 'org-sandbox', variableId: 'v1', value: 'x' },
+				ctx,
+			);
+
+			assert.strictEqual(callsFor(calls, 'update').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+
+		test('requires a value', async () => {
+			const { ctx } = makeCtx({ byId: inOrgRow });
+			setMcpMutationApprover(async () => true);
+
+			await assert.rejects(
+				() => cap('update_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1' }, ctx),
+				/Missing required string argument "value"/,
+			);
+		});
+	});
+
+	suite('delete_org_variable', () => {
+		const inOrgRow = {
+			data: {
+				orgVariables: [
+					{ id: 'v1', name: 'API_KEY', category: 'general', cascade: false, orgId: 'org-sandbox' },
+				],
+			},
+		};
+
+		test('deletes when in-org and approved', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow, delete: { data: { deleteOrgVariable: 'v1' } } });
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('delete_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'delete').length, 1);
+			assert.deepStrictEqual(callsFor(calls, 'delete')[0].variables, { id: 'v1' });
+			const parsed = JSON.parse(output);
+			assert.strictEqual(parsed.status, 'deleted');
+			assert.strictEqual(parsed.id, 'v1');
+		});
+
+		test('refuses to delete a variable in another org', async () => {
+			const { ctx, calls } = makeCtx({ byId: { data: { orgVariables: [] } } });
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('delete_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1' }, ctx),
+				/Org variable v1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+		});
+
+		test('does not delete when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('delete_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+	});
+});

--- a/src/capabilities/orgVariableMutateCapabilities.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.ts
@@ -1,0 +1,213 @@
+import type { MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { ORG_ID_PROP, requireString } from './inputHelpers';
+import { orgDisplayName, throwOnGraphqlErrors, withMutationApproval } from './mutationApproval';
+
+/**
+ * Org-variable write capabilities. createOrgVariable carries orgId in its input
+ * so it is natively org-scoped; update and delete act on a variable by id, and
+ * one session can manage many orgs, so each first re-verifies the variable
+ * belongs to the requested org (requireOrgVariableInOrg) before mutating. Every
+ * mutation is approval-gated and hidden unless rewst-buddy.mcp.enableWriteTools.
+ */
+
+// Categories a caller may set. 'system' is reserved for Rewst-managed variables
+// and is rejected rather than offered.
+const SETTABLE_CATEGORIES = new Set(['general', 'contact', 'secret']);
+
+const CREATE_ORG_VARIABLE = `mutation RewstBuddyMcpCreateOrgVariable($orgVariable: OrgVariableCreateInput!) {
+  createOrgVariable(orgVariable: $orgVariable) { id name category cascade orgId }
+}`;
+
+const UPDATE_ORG_VARIABLES = `mutation RewstBuddyMcpUpdateOrgVariables($orgVariables: [OrgVariableUpdateInput!]!) {
+  updateOrgVariables(orgVariables: $orgVariables) { id name category cascade orgId }
+}`;
+
+const DELETE_ORG_VARIABLE = `mutation RewstBuddyMcpDeleteOrgVariable($id: ID!) {
+  deleteOrgVariable(id: $id)
+}`;
+
+const ORG_VARIABLE_BY_ID = `query RewstBuddyMcpOrgVariableById($orgId: ID!, $id: ID!) {
+  orgVariables(where: { orgId: $orgId, id: $id }, maskSecrets: true) { id name category cascade orgId }
+}`;
+
+interface OrgVariableRow {
+	id?: string;
+	name?: string;
+	category?: string;
+	cascade?: boolean;
+	orgId?: string;
+}
+
+/** Reads an optional category argument, rejecting unknown or reserved values. */
+function optionalCategory(input: Record<string, unknown>): string | undefined {
+	const value = input.category;
+	if (value === undefined || value === null) return undefined;
+	if (typeof value !== 'string' || !SETTABLE_CATEGORIES.has(value)) {
+		throw new Error(`"category" must be one of ${[...SETTABLE_CATEGORIES].join(', ')}.`);
+	}
+	return value;
+}
+
+/** Reads an optional boolean argument; non-booleans are an error, not coerced. */
+function optionalBoolean(input: Record<string, unknown>, key: string): boolean | undefined {
+	const value = input[key];
+	if (value === undefined) return undefined;
+	if (typeof value !== 'boolean') throw new Error(`"${key}" must be a boolean.`);
+	return value;
+}
+
+/** Requires a string argument that may be empty (a variable value can be blank). */
+function requireStringAllowEmpty(input: Record<string, unknown>, key: string): string {
+	const value = input[key];
+	if (typeof value !== 'string') throw new Error(`Missing required string argument "${key}".`);
+	return value;
+}
+
+/**
+ * Fetches a variable by id and fails closed unless it belongs to the requested
+ * org. Returns the fields needed to build a safe update payload. The value is
+ * never read here, so a secret value is not surfaced.
+ */
+async function requireOrgVariableInOrg(
+	ctx: CapabilityContext,
+	variableId: string,
+	orgId: string,
+): Promise<OrgVariableRow> {
+	const { data, errors } = await ctx.session.rawGraphql(ORG_VARIABLE_BY_ID, { orgId, id: variableId });
+	throwOnGraphqlErrors(errors);
+	const rows = ((data as { orgVariables?: OrgVariableRow[] } | undefined)?.orgVariables ?? []) as OrgVariableRow[];
+	const row = rows.find(r => r.id === variableId);
+	if (!row) throw new Error(`Org variable ${variableId} is not in org ${orgId}.`);
+	return row;
+}
+
+const createOrgVariableSpec: ToolSpec = {
+	name: 'create_org_variable',
+	args: '{"orgId": string, "name": string, "value": string, "category"?: "general"|"contact"|"secret", "cascade"?: boolean}',
+	description:
+		'Create a configuration variable in one Rewst organization. category defaults to general (use secret for sensitive values); cascade (default false) makes the variable visible to descendant orgs. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			name: { type: 'string', description: 'Variable name.' },
+			value: { type: 'string', description: 'Variable value; may be an empty string.' },
+			category: {
+				type: 'string',
+				enum: ['general', 'contact', 'secret'],
+				description: 'Variable category (default general). secret masks the value in reads.',
+			},
+			cascade: { type: 'boolean', description: 'Whether descendant orgs inherit the variable (default false).' },
+		},
+		required: ['orgId', 'name', 'value'],
+	},
+};
+
+async function runCreateOrgVariable(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const name = requireString(input, 'name');
+	const value = requireStringAllowEmpty(input, 'value');
+	const category = optionalCategory(input) ?? 'general';
+	const cascade = optionalBoolean(input, 'cascade') ?? false;
+	const orgName = orgDisplayName(ctx);
+	const scope: MutationScope = { scopeId: orgId, scopeName: `new variable "${name}"`, orgId, orgName };
+	const summary = `Create ${category} variable "${name}" in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const { data, errors } = await ctx.session.rawGraphql(CREATE_ORG_VARIABLE, {
+			orgVariable: { orgId, name, value, category, cascade },
+		});
+		throwOnGraphqlErrors(errors);
+		const created = (data as { createOrgVariable?: OrgVariableRow } | undefined)?.createOrgVariable;
+		if (!created?.id) throw new Error('createOrgVariable returned no variable; the mutation may have failed.');
+		return JSON.stringify({ status: 'created', id: created.id, name: created.name ?? name }, null, 2);
+	});
+}
+
+const updateOrgVariableSpec: ToolSpec = {
+	name: 'update_org_variable',
+	args: '{"orgId": string, "variableId": string, "value": string, "category"?: "general"|"contact"|"secret", "cascade"?: boolean}',
+	description:
+		'Replace the value of one existing org variable, identified by org and variable id. The variable must belong to the given org. Optionally also change its category or cascade; the name is preserved. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			variableId: { type: 'string', description: 'Id of the variable to update.' },
+			value: { type: 'string', description: 'New value; may be an empty string.' },
+			category: {
+				type: 'string',
+				enum: ['general', 'contact', 'secret'],
+				description: 'Optional new category; defaults to the variable’s current category.',
+			},
+			cascade: { type: 'boolean', description: 'Optional new cascade flag; defaults to the current value.' },
+		},
+		required: ['orgId', 'variableId', 'value'],
+	},
+};
+
+async function runUpdateOrgVariable(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const variableId = requireString(input, 'variableId');
+	const value = requireStringAllowEmpty(input, 'value');
+	const categoryOverride = optionalCategory(input);
+	const cascadeOverride = optionalBoolean(input, 'cascade');
+	const orgName = orgDisplayName(ctx);
+	const current = await requireOrgVariableInOrg(ctx, variableId, orgId);
+	const name = current.name ?? '';
+	if (!name) throw new Error(`Org variable ${variableId} has no name; refusing to update.`);
+	const category = categoryOverride ?? current.category ?? 'general';
+	const cascade = cascadeOverride ?? current.cascade ?? false;
+	const scope: MutationScope = { scopeId: variableId, scopeName: name, orgId, orgName };
+	const summary = `Update variable "${name}" (${variableId}) in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const { data, errors } = await ctx.session.rawGraphql(UPDATE_ORG_VARIABLES, {
+			orgVariables: [{ id: variableId, orgId, name, value, category, cascade }],
+		});
+		throwOnGraphqlErrors(errors);
+		const rows = ((data as { updateOrgVariables?: OrgVariableRow[] } | undefined)?.updateOrgVariables ??
+			[]) as OrgVariableRow[];
+		const updated = rows.find(r => r.id === variableId) ?? rows[0];
+		if (!updated?.id) throw new Error('updateOrgVariables returned no variable; the mutation may have failed.');
+		return JSON.stringify({ status: 'updated', id: updated.id, name: updated.name ?? name }, null, 2);
+	});
+}
+
+const deleteOrgVariableSpec: ToolSpec = {
+	name: 'delete_org_variable',
+	args: '{"orgId": string, "variableId": string}',
+	description:
+		'Permanently delete one org variable, identified by org and variable id. The variable must belong to the given org. This cannot be undone. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			variableId: { type: 'string', description: 'Id of the variable to delete.' },
+		},
+		required: ['orgId', 'variableId'],
+	},
+};
+
+async function runDeleteOrgVariable(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const variableId = requireString(input, 'variableId');
+	const orgName = orgDisplayName(ctx);
+	const current = await requireOrgVariableInOrg(ctx, variableId, orgId);
+	const name = current.name ?? '(unnamed)';
+	const scope: MutationScope = { scopeId: variableId, scopeName: name, orgId, orgName };
+	const summary = `Delete variable "${name}" (${variableId}) in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const { data, errors } = await ctx.session.rawGraphql(DELETE_ORG_VARIABLE, { id: variableId });
+		throwOnGraphqlErrors(errors);
+		const deletedId = (data as { deleteOrgVariable?: string | null } | undefined)?.deleteOrgVariable;
+		if (!deletedId) throw new Error('deleteOrgVariable returned no id; the mutation may have failed.');
+		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
+	});
+}
+
+export const ORG_VARIABLE_MUTATE_CAPABILITIES: Capability[] = [
+	{ spec: createOrgVariableSpec, access: 'write', chat: false, mcp: true, run: runCreateOrgVariable },
+	{ spec: updateOrgVariableSpec, access: 'write', chat: false, mcp: true, run: runUpdateOrgVariable },
+	{ spec: deleteOrgVariableSpec, access: 'write', chat: false, mcp: true, run: runDeleteOrgVariable },
+];

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -8,6 +8,7 @@ import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
 import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
+import { ORG_VARIABLE_MUTATE_CAPABILITIES } from './orgVariableMutateCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -23,6 +24,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...PACK_INTEGRATION_CAPABILITIES,
 	...ORG_USER_CAPABILITIES,
 	...PAGE_TEMPLATE_CAPABILITIES,
+	...ORG_VARIABLE_MUTATE_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/test/helpers/testSession.ts
+++ b/src/test/helpers/testSession.ts
@@ -1,4 +1,5 @@
 import { Session, SessionProfile, Sdk } from '@sessions';
+import { context } from '@global';
 
 let cachedSession: Session | undefined;
 
@@ -55,6 +56,10 @@ export async function getTestSession(): Promise<Session> {
 		label: 'Test Session',
 		user: response.user,
 	};
+
+	// Store the validated cookie so session.rawGraphql (which reads the cookie from
+	// secrets via getCookies) works in integration tests, not just the typed SDK.
+	await context.secrets.store(profile.org.id, cookieString.value);
 
 	cachedSession = new Session(sdk, profile);
 	return cachedSession;

--- a/src/test/integration/orgVariableMutate.test.ts
+++ b/src/test/integration/orgVariableMutate.test.ts
@@ -1,0 +1,143 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import { _resetApprovedMutationScopes } from '../../ui/chat/tools/graphqlTool';
+import { ORG_VARIABLE_MUTATE_CAPABILITIES } from '../../capabilities/orgVariableMutateCapabilities';
+
+const { suite, test, suiteSetup, suiteTeardown, setup } = Mocha;
+
+/**
+ * Live verification for the org-variable write capabilities, opt-in behind
+ * REWST_TEST_WRITE=1 and always scoped to the token's own primary org. Creates,
+ * updates, and deletes a throwaway variable, asserting the update mutates in
+ * place (no duplicate) and the delete removes it. Cleans up in teardown.
+ */
+function writeTestsEnabled(): boolean {
+	return hasTestToken() && process.env.REWST_TEST_WRITE === '1';
+}
+
+function cap(name: string): Capability {
+	const capability = ORG_VARIABLE_MUTATE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+const BY_NAME = `query RbItestOrgVarByName($orgId: ID!, $name: String!) {
+  orgVariables(where: { orgId: $orgId, name: $name }, maskSecrets: false) { id name value category cascade orgId }
+}`;
+
+const DELETE = `mutation RbItestDeleteOrgVar($id: ID!) { deleteOrgVariable(id: $id) }`;
+
+suite('Integration: org variable write tools', function () {
+	this.timeout(120_000);
+
+	let session: Session;
+	let ctx: CapabilityContext;
+	let targetOrgId: string;
+	let otherOrgId: string | undefined;
+
+	suiteSetup(async function () {
+		if (!writeTestsEnabled()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		// getTestSession stores the validated cookie in secrets, so session.rawGraphql works.
+		session = await getTestSession();
+		targetOrgId = session.profile.org.id;
+		if (!targetOrgId) throw new Error('Refusing to run: the test session has no primary org id.');
+		otherOrgId = session.profile.allManagedOrgs.find(org => org.id && org.id !== targetOrgId)?.id;
+		ctx = { session, orgId: targetOrgId, sessions: [session] };
+		console.log(`\n[itest] target org: ${session.profile.org.name} (${targetOrgId})`);
+	});
+
+	setup(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		setMcpMutationApprover(async () => true);
+	});
+
+	suiteTeardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		clearCachedSession();
+	});
+
+	test('create -> update -> delete round-trips and updates in place', async () => {
+		const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+		const name = `RB_ITEST_${stamp}`.replace(/-/g, '_');
+		let id: string | undefined;
+
+		const byName = async () => {
+			const { data } = await session.rawGraphql(BY_NAME, { orgId: targetOrgId, name });
+			return ((data as { orgVariables?: { id: string; value?: string }[] } | undefined)?.orgVariables ?? []) as {
+				id: string;
+				value?: string;
+			}[];
+		};
+
+		try {
+			const created = JSON.parse(
+				await cap('create_org_variable').run({ orgId: targetOrgId, name, value: 'created-value' }, ctx),
+			);
+			assert.strictEqual(created.status, 'created');
+			id = created.id;
+			console.log('[itest] created org variable', id);
+
+			let rows = await byName();
+			assert.strictEqual(rows.length, 1, 'exactly one variable after create');
+			assert.strictEqual(rows[0].id, id);
+			assert.strictEqual(rows[0].value, 'created-value');
+
+			// Org guard (live): updating with a non-target managed orgId must be refused
+			// before mutating. This only reads the variable; the other org is untouched.
+			if (otherOrgId) {
+				const guardCtx: CapabilityContext = { session, orgId: otherOrgId, sessions: [session] };
+				await assert.rejects(
+					() =>
+						cap('update_org_variable').run({ orgId: otherOrgId, variableId: id, value: 'NOPE' }, guardCtx),
+					/is not in org/,
+				);
+				console.log('[itest] org guard refused a cross-org update to', otherOrgId);
+			}
+
+			const updated = JSON.parse(
+				await cap('update_org_variable').run(
+					{ orgId: targetOrgId, variableId: id, value: 'updated-value' },
+					ctx,
+				),
+			);
+			assert.strictEqual(updated.status, 'updated');
+
+			rows = await byName();
+			assert.strictEqual(rows.length, 1, 'update must mutate in place, not create a duplicate');
+			assert.strictEqual(rows[0].id, id);
+			assert.strictEqual(rows[0].value, 'updated-value');
+
+			const deleted = JSON.parse(
+				await cap('delete_org_variable').run({ orgId: targetOrgId, variableId: id }, ctx),
+			);
+			assert.strictEqual(deleted.status, 'deleted');
+			id = undefined;
+
+			rows = await byName();
+			assert.strictEqual(rows.length, 0, 'variable removed after delete');
+			console.log('[itest] deleted org variable; target org clean');
+		} finally {
+			if (id) {
+				try {
+					await session.rawGraphql(DELETE, { id });
+				} catch {
+					// best-effort cleanup
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds **MCP org-variable write tools**, the write counterpart to `list_org_variables`. Three org-scoped, approval-gated capabilities:

- `create_org_variable` — create a variable from `{orgId, name, value, category?, cascade?}`
- `update_org_variable` — replace a variable's value (and optionally category/cascade), preserving its name
- `delete_org_variable` — permanently delete a variable

All are `access:'write'` (hidden unless `rewst-buddy.mcp.enableWriteTools`), `mcp:true`, and require an `orgId`. Built on `rawGraphql` since these mutations aren't in the typed SDK.

## Safety model

- **Per-call approval** via the shared `withMutationApproval` flow; denied → `approval_required`, no mutation.
- **Org-ownership pre-flight.** `update`/`delete` act on a variable by id, and one session can manage many orgs, so each first queries the variable scoped to the requested org and **fails closed** unless it belongs there. `create` carries `orgId` in its input (natively scoped).
- `category` is validated against `general|contact|secret` (the reserved `system` category is rejected); `cascade` must be a boolean.
- `update` never reads or re-sends the existing value, so a `secret` value is never surfaced; the caller supplies the new value.

## Shared helper + test-infra change

- New `mutationApproval.ts` extracts the approval flow, org-name resolution, and GraphQL-error check shared by org-scoped write tools.
- `getTestSession` now stores the validated session cookie in secrets, so `rawGraphql`-backed capabilities (not just the typed SDK) can be exercised by integration tests.

## Tests

- **Unit (14):** each tool — shape/gating, happy path (asserting exact GraphQL variables), cross-org rejection, approval-denied, and input validation.
- **Integration (opt-in, `REWST_TEST_WRITE=1`):** a live `create → update → delete` round-trip that asserts the update **mutates in place (no duplicate)** and the delete removes the variable, plus a live cross-org guard probe. Skips by default; verified green against a sandbox org.

Full unit suite green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental MCP server write tools for managing organization configuration variables. External MCP clients can now create, update, and delete organization-scoped variables via three new tools. Each mutation requires explicit approval in VS Code and includes re-verification of ownership.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->