### PR TITLE
Add MCP tag write tools (create, update, delete)

### DIFF
--- a/changelog.d/tag-write-tools.md
+++ b/changelog.d/tag-write-tools.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): tag write tools** — when write tools are enabled, external MCP clients can now manage Rewst tags through three org-scoped tools: `create_tag`, `update_tag`, and `delete_tag`. Each runs against a single organization, re-verifies that the target tag belongs to that org before changing anything, and requires a per-change approval inside VS Code.

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -9,6 +9,7 @@ import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
 import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 import { ORG_VARIABLE_MUTATE_CAPABILITIES } from './orgVariableMutateCapabilities';
+import { TAG_MUTATE_CAPABILITIES } from './tagMutateCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -25,6 +26,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...ORG_USER_CAPABILITIES,
 	...PAGE_TEMPLATE_CAPABILITIES,
 	...ORG_VARIABLE_MUTATE_CAPABILITIES,
+	...TAG_MUTATE_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/tagMutateCapabilities.test.ts
+++ b/src/capabilities/tagMutateCapabilities.test.ts
@@ -1,0 +1,225 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import type { Session } from '@sessions';
+import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import { TAG_MUTATE_CAPABILITIES } from './tagMutateCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function cap(name: string): Capability {
+	const capability = TAG_MUTATE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+interface GraphqlResult {
+	data?: unknown;
+	errors?: unknown;
+}
+type Op = 'byId' | 'create' | 'update' | 'delete';
+type OpResponses = Partial<Record<Op, GraphqlResult>>;
+
+function routeOp(query: string): Op | 'unknown' {
+	if (query.includes('TagById')) return 'byId';
+	if (query.includes('CreateTag')) return 'create';
+	if (query.includes('UpdateTag')) return 'update';
+	if (query.includes('DeleteTag')) return 'delete';
+	return 'unknown';
+}
+
+function makeCtx(responses: OpResponses, orgId = 'org-sandbox', orgName = 'Sandbox') {
+	const calls: { op: string; variables: Record<string, unknown> | undefined }[] = [];
+	const session = {
+		profile: { org: { id: orgId, name: orgName }, allManagedOrgs: [{ id: orgId, name: orgName }] },
+		rawGraphql: async (query: string, variables?: Record<string, unknown>) => {
+			const op = routeOp(query);
+			calls.push({ op, variables });
+			const r = responses[op as keyof OpResponses];
+			if (!r) throw new Error(`no mock configured for op "${op}"`);
+			return r;
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId, sessions: [session] };
+	return { ctx, calls };
+}
+
+function callsFor(calls: { op: string; variables: Record<string, unknown> | undefined }[], op: string) {
+	return calls.filter(c => c.op === op);
+}
+
+suite('Unit: tagMutateCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	suite('create_tag', () => {
+		test('is a write capability gated by approval, mcp-only', () => {
+			const c = cap('create_tag');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+
+		test('creates with only the required fields when approved', async () => {
+			const { ctx, calls } = makeCtx({ create: { data: { createTag: { id: 'g1', name: 'prod' } } } });
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('create_tag').run({ orgId: 'org-sandbox', name: 'prod' }, ctx);
+
+			assert.deepStrictEqual(callsFor(calls, 'create')[0].variables, {
+				tag: { orgId: 'org-sandbox', name: 'prod' },
+			});
+			const parsed = JSON.parse(output);
+			assert.strictEqual(parsed.status, 'created');
+			assert.strictEqual(parsed.id, 'g1');
+		});
+
+		test('forwards color and description when provided', async () => {
+			const { ctx, calls } = makeCtx({ create: { data: { createTag: { id: 'g2', name: 'env' } } } });
+			setMcpMutationApprover(async () => true);
+
+			await cap('create_tag').run(
+				{ orgId: 'org-sandbox', name: 'env', color: '#4287f5', description: 'environment tag' },
+				ctx,
+			);
+
+			const tag = (callsFor(calls, 'create')[0].variables as { tag: Record<string, unknown> }).tag;
+			assert.strictEqual(tag.color, '#4287f5');
+			assert.strictEqual(tag.description, 'environment tag');
+		});
+
+		test('rejects a missing name', async () => {
+			const { ctx } = makeCtx({});
+			setMcpMutationApprover(async () => true);
+			await assert.rejects(
+				() => cap('create_tag').run({ orgId: 'org-sandbox' }, ctx),
+				/Missing required string argument "name"/,
+			);
+		});
+
+		test('does not create when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({});
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('create_tag').run({ orgId: 'org-sandbox', name: 'prod' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'create').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+	});
+
+	suite('update_tag', () => {
+		const inOrgRow = {
+			data: { tags: [{ id: 'g1', name: 'old', color: '#111111', description: 'd', orgId: 'org-sandbox' }] },
+		};
+
+		test('preserves current fields not being changed', async () => {
+			const { ctx, calls } = makeCtx({
+				byId: inOrgRow,
+				update: { data: { updateTag: { id: 'g1', name: 'old' } } },
+			});
+			setMcpMutationApprover(async () => true);
+
+			await cap('update_tag').run({ orgId: 'org-sandbox', tagId: 'g1', color: '#222222' }, ctx);
+
+			assert.deepStrictEqual(callsFor(calls, 'update')[0].variables, {
+				tag: { id: 'g1', orgId: 'org-sandbox', name: 'old', color: '#222222', description: 'd' },
+			});
+		});
+
+		test('renames when a new name is supplied', async () => {
+			const { ctx, calls } = makeCtx({
+				byId: inOrgRow,
+				update: { data: { updateTag: { id: 'g1', name: 'new' } } },
+			});
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('update_tag').run({ orgId: 'org-sandbox', tagId: 'g1', name: 'new' }, ctx);
+
+			const tag = (callsFor(calls, 'update')[0].variables as { tag: Record<string, unknown> }).tag;
+			assert.strictEqual(tag.name, 'new');
+			assert.strictEqual(JSON.parse(output).status, 'updated');
+		});
+
+		test('refuses to update a tag in another org', async () => {
+			const { ctx, calls } = makeCtx({ byId: { data: { tags: [] } } });
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('update_tag').run({ orgId: 'org-sandbox', tagId: 'g1', name: 'x' }, ctx),
+				/Tag g1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(callsFor(calls, 'update').length, 0);
+		});
+
+		test('does not update when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('update_tag').run({ orgId: 'org-sandbox', tagId: 'g1', name: 'x' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'update').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+	});
+
+	suite('delete_tag', () => {
+		const inOrgRow = { data: { tags: [{ id: 'g1', name: 'old', orgId: 'org-sandbox' }] } };
+
+		test('deletes when in-org and approved', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow, delete: { data: { deleteTag: 'g1' } } });
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('delete_tag').run({ orgId: 'org-sandbox', tagId: 'g1' }, ctx);
+
+			assert.deepStrictEqual(callsFor(calls, 'delete')[0].variables, { id: 'g1' });
+			assert.strictEqual(JSON.parse(output).status, 'deleted');
+		});
+
+		test('refuses to delete a tag in another org', async () => {
+			const { ctx, calls } = makeCtx({ byId: { data: { tags: [] } } });
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('delete_tag').run({ orgId: 'org-sandbox', tagId: 'g1' }, ctx),
+				/Tag g1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+		});
+
+		test('does not delete when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('delete_tag').run({ orgId: 'org-sandbox', tagId: 'g1' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+	});
+});

--- a/src/capabilities/tagMutateCapabilities.ts
+++ b/src/capabilities/tagMutateCapabilities.ts
@@ -1,0 +1,169 @@
+import type { MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { ORG_ID_PROP, asString, requireString } from './inputHelpers';
+import { orgDisplayName, throwOnGraphqlErrors, withMutationApproval } from './mutationApproval';
+
+/**
+ * Tag write capabilities. createTag carries orgId in its input so it is natively
+ * org-scoped; update and delete act on a tag by id, and one session can manage
+ * many orgs, so each first re-verifies the tag belongs to the requested org
+ * (requireTagInOrg) before mutating. Every mutation is approval-gated and hidden
+ * unless rewst-buddy.mcp.enableWriteTools.
+ */
+
+const CREATE_TAG = `mutation RewstBuddyMcpCreateTag($tag: TagCreateInput!) {
+  createTag(tag: $tag) { id name color orgId }
+}`;
+
+const UPDATE_TAG = `mutation RewstBuddyMcpUpdateTag($tag: TagUpdateInput!) {
+  updateTag(tag: $tag) { id name color orgId }
+}`;
+
+const DELETE_TAG = `mutation RewstBuddyMcpDeleteTag($id: ID!) {
+  deleteTag(id: $id)
+}`;
+
+const TAG_BY_ID = `query RewstBuddyMcpTagById($orgId: ID!, $id: ID!) {
+  tags(where: { orgId: $orgId, id: $id }) { id name color description orgId }
+}`;
+
+interface TagRow {
+	id?: string;
+	name?: string;
+	color?: string;
+	description?: string;
+	orgId?: string;
+}
+
+/**
+ * Fetches a tag by id and fails closed unless it belongs to the requested org.
+ * Returns the current fields so an update can preserve those it is not changing.
+ */
+async function requireTagInOrg(ctx: CapabilityContext, tagId: string, orgId: string): Promise<TagRow> {
+	const { data, errors } = await ctx.session.rawGraphql(TAG_BY_ID, { orgId, id: tagId });
+	throwOnGraphqlErrors(errors);
+	const rows = ((data as { tags?: TagRow[] } | undefined)?.tags ?? []) as TagRow[];
+	const row = rows.find(r => r.id === tagId);
+	if (!row) throw new Error(`Tag ${tagId} is not in org ${orgId}.`);
+	return row;
+}
+
+const createTagSpec: ToolSpec = {
+	name: 'create_tag',
+	args: '{"orgId": string, "name": string, "color"?: string, "description"?: string}',
+	description:
+		'Create a tag in one Rewst organization. color is an optional hex string (e.g. #4287f5). Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			name: { type: 'string', description: 'Tag name.' },
+			color: { type: 'string', description: 'Optional color (hex, e.g. #4287f5).' },
+			description: { type: 'string', description: 'Optional tag description.' },
+		},
+		required: ['orgId', 'name'],
+	},
+};
+
+async function runCreateTag(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const name = requireString(input, 'name');
+	const color = asString(input, 'color');
+	const description = asString(input, 'description');
+	const orgName = orgDisplayName(ctx);
+	const scope: MutationScope = { scopeId: orgId, scopeName: `new tag "${name}"`, orgId, orgName };
+	const summary = `Create tag "${name}" in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const tag: Record<string, unknown> = { orgId, name };
+		if (color !== undefined) tag.color = color;
+		if (description !== undefined) tag.description = description;
+		const { data, errors } = await ctx.session.rawGraphql(CREATE_TAG, { tag });
+		throwOnGraphqlErrors(errors);
+		const created = (data as { createTag?: TagRow } | undefined)?.createTag;
+		if (!created?.id) throw new Error('createTag returned no tag; the mutation may have failed.');
+		return JSON.stringify({ status: 'created', id: created.id, name: created.name ?? name }, null, 2);
+	});
+}
+
+const updateTagSpec: ToolSpec = {
+	name: 'update_tag',
+	args: '{"orgId": string, "tagId": string, "name"?: string, "color"?: string, "description"?: string}',
+	description:
+		'Update one existing tag (name, color, and/or description), identified by org and tag id. The tag must belong to the given org. Fields not supplied keep their current value. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			tagId: { type: 'string', description: 'Id of the tag to update.' },
+			name: { type: 'string', description: 'Optional new name (defaults to the current name).' },
+			color: { type: 'string', description: 'Optional new color (hex).' },
+			description: { type: 'string', description: 'Optional new description.' },
+		},
+		required: ['orgId', 'tagId'],
+	},
+};
+
+async function runUpdateTag(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const tagId = requireString(input, 'tagId');
+	const nameOverride = asString(input, 'name');
+	const colorOverride = asString(input, 'color');
+	const descriptionOverride = asString(input, 'description');
+	const orgName = orgDisplayName(ctx);
+	const current = await requireTagInOrg(ctx, tagId, orgId);
+	const name = nameOverride ?? current.name ?? '';
+	if (!name) throw new Error(`Tag ${tagId} has no name; provide one to update.`);
+	const scope: MutationScope = { scopeId: tagId, scopeName: current.name ?? name, orgId, orgName };
+	const summary = `Update tag "${current.name ?? name}" (${tagId}) in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const tag: Record<string, unknown> = { id: tagId, orgId, name };
+		const color = colorOverride ?? current.color;
+		const description = descriptionOverride ?? current.description;
+		if (color !== undefined) tag.color = color;
+		if (description !== undefined) tag.description = description;
+		const { data, errors } = await ctx.session.rawGraphql(UPDATE_TAG, { tag });
+		throwOnGraphqlErrors(errors);
+		const updated = (data as { updateTag?: TagRow } | undefined)?.updateTag;
+		if (!updated?.id) throw new Error('updateTag returned no tag; the mutation may have failed.');
+		return JSON.stringify({ status: 'updated', id: updated.id, name: updated.name ?? name }, null, 2);
+	});
+}
+
+const deleteTagSpec: ToolSpec = {
+	name: 'delete_tag',
+	args: '{"orgId": string, "tagId": string}',
+	description:
+		'Permanently delete one tag, identified by org and tag id. The tag must belong to the given org. This cannot be undone. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			tagId: { type: 'string', description: 'Id of the tag to delete.' },
+		},
+		required: ['orgId', 'tagId'],
+	},
+};
+
+async function runDeleteTag(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const tagId = requireString(input, 'tagId');
+	const orgName = orgDisplayName(ctx);
+	const current = await requireTagInOrg(ctx, tagId, orgId);
+	const name = current.name ?? '(unnamed)';
+	const scope: MutationScope = { scopeId: tagId, scopeName: name, orgId, orgName };
+	const summary = `Delete tag "${name}" (${tagId}) in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const { data, errors } = await ctx.session.rawGraphql(DELETE_TAG, { id: tagId });
+		throwOnGraphqlErrors(errors);
+		const deletedId = (data as { deleteTag?: string | null } | undefined)?.deleteTag;
+		if (!deletedId) throw new Error('deleteTag returned no id; the mutation may have failed.');
+		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
+	});
+}
+
+export const TAG_MUTATE_CAPABILITIES: Capability[] = [
+	{ spec: createTagSpec, access: 'write', chat: false, mcp: true, run: runCreateTag },
+	{ spec: updateTagSpec, access: 'write', chat: false, mcp: true, run: runUpdateTag },
+	{ spec: deleteTagSpec, access: 'write', chat: false, mcp: true, run: runDeleteTag },
+];

--- a/src/test/integration/tagMutate.test.ts
+++ b/src/test/integration/tagMutate.test.ts
@@ -1,0 +1,133 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import { _resetApprovedMutationScopes } from '../../ui/chat/tools/graphqlTool';
+import { TAG_MUTATE_CAPABILITIES } from '../../capabilities/tagMutateCapabilities';
+
+const { suite, test, suiteSetup, suiteTeardown, setup } = Mocha;
+
+/**
+ * Live verification for the tag write capabilities, opt-in behind
+ * REWST_TEST_WRITE=1 and scoped to the token's own primary org. Creates, updates,
+ * and deletes a throwaway tag; cleans up in teardown.
+ */
+function writeTestsEnabled(): boolean {
+	return hasTestToken() && process.env.REWST_TEST_WRITE === '1';
+}
+
+function cap(name: string): Capability {
+	const capability = TAG_MUTATE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+const BY_ID = `query RbItestTagById($orgId: ID!, $id: ID!) {
+  tags(where: { orgId: $orgId, id: $id }) { id name color orgId }
+}`;
+
+const DELETE = `mutation RbItestDeleteTag($id: ID!) { deleteTag(id: $id) }`;
+
+suite('Integration: tag write tools', function () {
+	this.timeout(120_000);
+
+	let session: Session;
+	let ctx: CapabilityContext;
+	let targetOrgId: string;
+	let otherOrgId: string | undefined;
+
+	suiteSetup(async function () {
+		if (!writeTestsEnabled()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		session = await getTestSession();
+		targetOrgId = session.profile.org.id;
+		if (!targetOrgId) throw new Error('Refusing to run: the test session has no primary org id.');
+		otherOrgId = session.profile.allManagedOrgs.find(org => org.id && org.id !== targetOrgId)?.id;
+		ctx = { session, orgId: targetOrgId, sessions: [session] };
+		console.log(`\n[itest] target org: ${session.profile.org.name} (${targetOrgId})`);
+	});
+
+	setup(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		setMcpMutationApprover(async () => true);
+	});
+
+	suiteTeardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		clearCachedSession();
+	});
+
+	test('create -> update -> delete round-trips in the target org', async () => {
+		const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+		const name = `rb-itest-${stamp}`;
+		let id: string | undefined;
+
+		const byId = async (tagId: string) => {
+			const { data } = await session.rawGraphql(BY_ID, { orgId: targetOrgId, id: tagId });
+			return ((data as { tags?: { id: string; name?: string; color?: string }[] } | undefined)?.tags ?? []) as {
+				id: string;
+				name?: string;
+				color?: string;
+			}[];
+		};
+
+		try {
+			const created = JSON.parse(
+				await cap('create_tag').run({ orgId: targetOrgId, name, color: '#4287f5' }, ctx),
+			);
+			assert.strictEqual(created.status, 'created');
+			id = created.id;
+			console.log('[itest] created tag', id);
+
+			let rows = await byId(id!);
+			assert.strictEqual(rows.length, 1);
+			assert.strictEqual(rows[0].name, name);
+			assert.strictEqual(rows[0].color, '#4287f5');
+
+			if (otherOrgId) {
+				const guardCtx: CapabilityContext = { session, orgId: otherOrgId, sessions: [session] };
+				await assert.rejects(
+					() => cap('update_tag').run({ orgId: otherOrgId, tagId: id, name: 'NOPE' }, guardCtx),
+					/is not in org/,
+				);
+				console.log('[itest] org guard refused a cross-org update to', otherOrgId);
+			}
+
+			const updated = JSON.parse(
+				await cap('update_tag').run({ orgId: targetOrgId, tagId: id, color: '#f54242' }, ctx),
+			);
+			assert.strictEqual(updated.status, 'updated');
+
+			rows = await byId(id!);
+			assert.strictEqual(rows[0].color, '#f54242');
+			assert.strictEqual(rows[0].name, name, 'name preserved when only color changes');
+
+			const deleted = JSON.parse(await cap('delete_tag').run({ orgId: targetOrgId, tagId: id }, ctx));
+			assert.strictEqual(deleted.status, 'deleted');
+			id = undefined;
+
+			rows = await byId(created.id);
+			assert.strictEqual(rows.length, 0, 'tag removed after delete');
+			console.log('[itest] deleted tag; target org clean');
+		} finally {
+			if (id) {
+				try {
+					await session.rawGraphql(DELETE, { id });
+				} catch {
+					// best-effort cleanup
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds **MCP tag write tools**, the write counterpart to `list_tags`. Three org-scoped, approval-gated capabilities: `create_tag`, `update_tag`, `delete_tag`. All `access:'write'` (hidden unless `rewst-buddy.mcp.enableWriteTools`), `mcp:true`, require `orgId`, built on `rawGraphql`.

## Safety model

- **Per-call approval** via the shared `withMutationApproval`; denied → `approval_required`, no mutation.
- **Org-ownership pre-flight** on `update`/`delete` (by-id) — fails closed unless the tag belongs to the requested org; `create` carries `orgId` in its input.
- `update` fetches the current row and **preserves fields not supplied**, so a partial update can't blank out name/color/description.

## Tests

- **Unit (12):** shape/gating, happy path (exact GraphQL variables), field preservation, cross-org rejection, approval-denied, validation.
- **Integration (opt-in, `REWST_TEST_WRITE=1`):** live `create → update → delete` round-trip + cross-org guard probe; self-cleaning; verified green against a sandbox org.

Full unit suite green.

> Stacked on #75 for the shared `mutationApproval.ts` helper; GitHub will retarget to `main` once #75 merges.
