### PR TITLE
Add MCP workflow create/delete tools

### DIFF
--- a/changelog.d/workflow-crud-tools.md
+++ b/changelog.d/workflow-crud-tools.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): workflow create/delete tools** — when write tools are enabled, external MCP clients can now create an empty workflow (`create_workflow`, then build it out with `buddy_workflow_edit`) and permanently delete one (`delete_workflow`). Both run against a single organization, `delete_workflow` re-verifies the workflow belongs to that org before removing it (along with its triggers, tasks, and execution history), and each requires a per-change approval inside VS Code.

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -9,6 +9,7 @@ import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
 import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 import { ORG_VARIABLE_MUTATE_CAPABILITIES } from './orgVariableMutateCapabilities';
+import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -25,6 +26,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...ORG_USER_CAPABILITIES,
 	...PAGE_TEMPLATE_CAPABILITIES,
 	...ORG_VARIABLE_MUTATE_CAPABILITIES,
+	...WORKFLOW_CRUD_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/workflowCrudCapabilities.test.ts
+++ b/src/capabilities/workflowCrudCapabilities.test.ts
@@ -1,0 +1,175 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import type { Session } from '@sessions';
+import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function cap(name: string): Capability {
+	const capability = WORKFLOW_CRUD_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+interface GraphqlResult {
+	data?: unknown;
+	errors?: unknown;
+}
+type Op = 'owner' | 'create' | 'delete';
+type OpResponses = Partial<Record<Op, GraphqlResult>>;
+
+function routeOp(query: string): Op | 'unknown' {
+	if (query.includes('WorkflowOwner')) return 'owner';
+	if (query.includes('CreateWorkflow')) return 'create';
+	if (query.includes('DeleteWorkflow')) return 'delete';
+	return 'unknown';
+}
+
+function makeCtx(responses: OpResponses, orgId = 'org-sandbox', orgName = 'Sandbox') {
+	const calls: { op: string; variables: Record<string, unknown> | undefined }[] = [];
+	const session = {
+		profile: { org: { id: orgId, name: orgName }, allManagedOrgs: [{ id: orgId, name: orgName }] },
+		rawGraphql: async (query: string, variables?: Record<string, unknown>) => {
+			const op = routeOp(query);
+			calls.push({ op, variables });
+			const r = responses[op as keyof OpResponses];
+			if (!r) throw new Error(`no mock configured for op "${op}"`);
+			return r;
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId, sessions: [session] };
+	return { ctx, calls };
+}
+
+function callsFor(calls: { op: string; variables: Record<string, unknown> | undefined }[], op: string) {
+	return calls.filter(c => c.op === op);
+}
+
+suite('Unit: workflowCrudCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	suite('create_workflow', () => {
+		test('is a write capability gated by approval, mcp-only', () => {
+			const c = cap('create_workflow');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+
+		test('creates an empty workflow when approved', async () => {
+			const { ctx, calls } = makeCtx({ create: { data: { createWorkflow: { id: 'w1', name: 'Onboard' } } } });
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('create_workflow').run({ orgId: 'org-sandbox', name: 'Onboard' }, ctx);
+
+			assert.deepStrictEqual(callsFor(calls, 'create')[0].variables, {
+				workflow: { orgId: 'org-sandbox', name: 'Onboard' },
+			});
+			const parsed = JSON.parse(output);
+			assert.strictEqual(parsed.status, 'created');
+			assert.strictEqual(parsed.id, 'w1');
+		});
+
+		test('forwards a description when provided', async () => {
+			const { ctx, calls } = makeCtx({ create: { data: { createWorkflow: { id: 'w2', name: 'Wf' } } } });
+			setMcpMutationApprover(async () => true);
+
+			await cap('create_workflow').run({ orgId: 'org-sandbox', name: 'Wf', description: 'does things' }, ctx);
+
+			const wf = (callsFor(calls, 'create')[0].variables as { workflow: Record<string, unknown> }).workflow;
+			assert.strictEqual(wf.description, 'does things');
+		});
+
+		test('rejects a missing name', async () => {
+			const { ctx } = makeCtx({});
+			setMcpMutationApprover(async () => true);
+			await assert.rejects(
+				() => cap('create_workflow').run({ orgId: 'org-sandbox' }, ctx),
+				/Missing required string argument "name"/,
+			);
+		});
+
+		test('does not create when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({});
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('create_workflow').run({ orgId: 'org-sandbox', name: 'Onboard' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'create').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+	});
+
+	suite('delete_workflow', () => {
+		const inOrg = { data: { workflow: { id: 'w1', name: 'Onboard', orgId: 'org-sandbox' } } };
+
+		test('deletes when in-org and approved', async () => {
+			const { ctx, calls } = makeCtx({ owner: inOrg, delete: { data: { deleteWorkflow: 'w1' } } });
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('delete_workflow').run({ orgId: 'org-sandbox', workflowId: 'w1' }, ctx);
+
+			assert.deepStrictEqual(callsFor(calls, 'delete')[0].variables, { id: 'w1' });
+			const parsed = JSON.parse(output);
+			assert.strictEqual(parsed.status, 'deleted');
+			assert.strictEqual(parsed.id, 'w1');
+		});
+
+		test('refuses to delete a workflow in another org', async () => {
+			const { ctx, calls } = makeCtx({
+				owner: { data: { workflow: { id: 'w1', name: 'X', orgId: 'org-OTHER' } } },
+			});
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('delete_workflow').run({ orgId: 'org-sandbox', workflowId: 'w1' }, ctx),
+				/Workflow w1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+		});
+
+		test('refuses when the workflow does not exist', async () => {
+			const { ctx, calls } = makeCtx({ owner: { data: { workflow: null } } });
+			setMcpMutationApprover(async () => true);
+
+			await assert.rejects(
+				() => cap('delete_workflow').run({ orgId: 'org-sandbox', workflowId: 'w1' }, ctx),
+				/Workflow w1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+		});
+
+		test('does not delete when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({ owner: inOrg });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('delete_workflow').run({ orgId: 'org-sandbox', workflowId: 'w1' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+	});
+});

--- a/src/capabilities/workflowCrudCapabilities.ts
+++ b/src/capabilities/workflowCrudCapabilities.ts
@@ -1,0 +1,118 @@
+import type { MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { ORG_ID_PROP, asString, requireString } from './inputHelpers';
+import { orgDisplayName, throwOnGraphqlErrors, withMutationApproval } from './mutationApproval';
+
+/**
+ * Workflow create/delete capabilities. create_workflow makes an empty workflow
+ * (edit it afterwards with buddy_workflow_edit) and carries orgId in its input.
+ * delete_workflow acts by id, and one session can manage many orgs, so it first
+ * re-verifies the workflow belongs to the requested org (requireWorkflowInOrg)
+ * before deleting. Both are approval-gated and hidden unless
+ * rewst-buddy.mcp.enableWriteTools. Deleting a workflow also removes its triggers,
+ * tasks, and execution history, so the approval summary calls this out.
+ */
+
+const CREATE_WORKFLOW = `mutation RewstBuddyMcpCreateWorkflow($workflow: WorkflowInput!) {
+  createWorkflow(workflow: $workflow) { id name orgId }
+}`;
+
+const DELETE_WORKFLOW = `mutation RewstBuddyMcpDeleteWorkflow($id: ID!) {
+  deleteWorkflow(id: $id)
+}`;
+
+const WORKFLOW_OWNER = `query RewstBuddyMcpWorkflowOwner($id: ID!) {
+  workflow(where: { id: $id }) { id name orgId }
+}`;
+
+interface WorkflowRow {
+	id?: string;
+	name?: string;
+	orgId?: string;
+}
+
+/**
+ * Fetches a workflow by id and fails closed unless it belongs to the requested
+ * org. Returns the workflow name for the approval scope.
+ */
+async function requireWorkflowInOrg(ctx: CapabilityContext, workflowId: string, orgId: string): Promise<WorkflowRow> {
+	const { data, errors } = await ctx.session.rawGraphql(WORKFLOW_OWNER, { id: workflowId });
+	throwOnGraphqlErrors(errors);
+	const workflow = (data as { workflow?: WorkflowRow } | undefined)?.workflow;
+	if (!workflow || workflow.orgId !== orgId) {
+		throw new Error(`Workflow ${workflowId} is not in org ${orgId}.`);
+	}
+	return workflow;
+}
+
+const createWorkflowSpec: ToolSpec = {
+	name: 'create_workflow',
+	args: '{"orgId": string, "name": string, "description"?: string}',
+	description:
+		'Create a new, empty Rewst workflow in one organization, returning its id and name. Add tasks and transitions afterwards with buddy_workflow_edit. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			name: { type: 'string', description: 'Name for the new workflow.' },
+			description: { type: 'string', description: 'Optional workflow description.' },
+		},
+		required: ['orgId', 'name'],
+	},
+};
+
+async function runCreateWorkflow(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const name = requireString(input, 'name');
+	const description = asString(input, 'description');
+	const orgName = orgDisplayName(ctx);
+	const scope: MutationScope = { scopeId: orgId, scopeName: `new workflow "${name}"`, orgId, orgName };
+	const summary = `Create workflow "${name}" in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const workflow: Record<string, unknown> = { orgId, name };
+		if (description !== undefined) workflow.description = description;
+		const { data, errors } = await ctx.session.rawGraphql(CREATE_WORKFLOW, { workflow });
+		throwOnGraphqlErrors(errors);
+		const created = (data as { createWorkflow?: WorkflowRow } | undefined)?.createWorkflow;
+		if (!created?.id) throw new Error('createWorkflow returned no workflow; the mutation may have failed.');
+		return JSON.stringify({ status: 'created', id: created.id, name: created.name ?? name }, null, 2);
+	});
+}
+
+const deleteWorkflowSpec: ToolSpec = {
+	name: 'delete_workflow',
+	args: '{"orgId": string, "workflowId": string}',
+	description:
+		'Permanently delete one Rewst workflow, identified by org and workflow id. The workflow must belong to the given org. This also removes its triggers, tasks, and execution history and cannot be undone. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			workflowId: { type: 'string', description: 'Id of the workflow to delete.' },
+		},
+		required: ['orgId', 'workflowId'],
+	},
+};
+
+async function runDeleteWorkflow(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const workflowId = requireString(input, 'workflowId');
+	const orgName = orgDisplayName(ctx);
+	const current = await requireWorkflowInOrg(ctx, workflowId, orgId);
+	const name = current.name ?? '(unnamed)';
+	const scope: MutationScope = { scopeId: workflowId, scopeName: name, orgId, orgName };
+	const summary = `Delete workflow "${name}" (${workflowId}) and its triggers, tasks, and history in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const { data, errors } = await ctx.session.rawGraphql(DELETE_WORKFLOW, { id: workflowId });
+		throwOnGraphqlErrors(errors);
+		const deletedId = (data as { deleteWorkflow?: string | null } | undefined)?.deleteWorkflow;
+		if (!deletedId) throw new Error('deleteWorkflow returned no id; the mutation may have failed.');
+		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
+	});
+}
+
+export const WORKFLOW_CRUD_CAPABILITIES: Capability[] = [
+	{ spec: createWorkflowSpec, access: 'write', chat: false, mcp: true, run: runCreateWorkflow },
+	{ spec: deleteWorkflowSpec, access: 'write', chat: false, mcp: true, run: runDeleteWorkflow },
+];

--- a/src/test/integration/workflowCrud.test.ts
+++ b/src/test/integration/workflowCrud.test.ts
@@ -1,0 +1,114 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import { _resetApprovedMutationScopes } from '../../ui/chat/tools/graphqlTool';
+import { WORKFLOW_CRUD_CAPABILITIES } from '../../capabilities/workflowCrudCapabilities';
+
+const { suite, test, suiteSetup, suiteTeardown, setup } = Mocha;
+
+/**
+ * Live verification for create_workflow / delete_workflow, opt-in behind
+ * REWST_TEST_WRITE=1 and scoped to the token's own primary org. Creates an empty
+ * workflow and deletes it; cleans up in teardown.
+ */
+function writeTestsEnabled(): boolean {
+	return hasTestToken() && process.env.REWST_TEST_WRITE === '1';
+}
+
+function cap(name: string): Capability {
+	const capability = WORKFLOW_CRUD_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+const BY_ID = `query RbItestWorkflowById($id: ID!) { workflow(where: { id: $id }) { id name orgId } }`;
+const DELETE = `mutation RbItestDeleteWorkflow($id: ID!) { deleteWorkflow(id: $id) }`;
+
+suite('Integration: workflow CRUD tools', function () {
+	this.timeout(120_000);
+
+	let session: Session;
+	let ctx: CapabilityContext;
+	let targetOrgId: string;
+	let otherOrgId: string | undefined;
+
+	suiteSetup(async function () {
+		if (!writeTestsEnabled()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		session = await getTestSession();
+		targetOrgId = session.profile.org.id;
+		if (!targetOrgId) throw new Error('Refusing to run: the test session has no primary org id.');
+		otherOrgId = session.profile.allManagedOrgs.find(org => org.id && org.id !== targetOrgId)?.id;
+		ctx = { session, orgId: targetOrgId, sessions: [session] };
+		console.log(`\n[itest] target org: ${session.profile.org.name} (${targetOrgId})`);
+	});
+
+	setup(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		setMcpMutationApprover(async () => true);
+	});
+
+	suiteTeardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		clearCachedSession();
+	});
+
+	test('create -> delete round-trips in the target org', async () => {
+		const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+		const name = `rb-itest-${stamp}`;
+		let id: string | undefined;
+
+		const byId = async (workflowId: string) => {
+			const { data } = await session.rawGraphql(BY_ID, { id: workflowId });
+			return (data as { workflow?: { id: string; orgId?: string } | null } | undefined)?.workflow ?? null;
+		};
+
+		try {
+			const created = JSON.parse(await cap('create_workflow').run({ orgId: targetOrgId, name }, ctx));
+			assert.strictEqual(created.status, 'created');
+			id = created.id;
+			console.log('[itest] created workflow', id);
+
+			const wf = await byId(id!);
+			assert.ok(wf, 'workflow exists after create');
+			assert.strictEqual(wf!.orgId, targetOrgId, 'created workflow is in the target org');
+
+			if (otherOrgId) {
+				const guardCtx: CapabilityContext = { session, orgId: otherOrgId, sessions: [session] };
+				await assert.rejects(
+					() => cap('delete_workflow').run({ orgId: otherOrgId, workflowId: id }, guardCtx),
+					/is not in org/,
+				);
+				assert.ok(await byId(id!), 'workflow still present after refused cross-org delete');
+				console.log('[itest] org guard refused a cross-org delete to', otherOrgId);
+			}
+
+			const deleted = JSON.parse(await cap('delete_workflow').run({ orgId: targetOrgId, workflowId: id }, ctx));
+			assert.strictEqual(deleted.status, 'deleted');
+			id = undefined;
+
+			assert.strictEqual(await byId(created.id), null, 'workflow removed after delete');
+			console.log('[itest] deleted workflow; target org clean');
+		} finally {
+			if (id) {
+				try {
+					await session.rawGraphql(DELETE, { id });
+				} catch {
+					// best-effort cleanup
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds **MCP workflow create/delete tools**, completing the workflow write surface alongside the existing `buddy_workflow_edit` / `_autolayout` / `_run`. Two org-scoped, approval-gated capabilities:

- `create_workflow` — create an **empty** workflow (`{orgId, name, description?}`); build it out afterwards with `buddy_workflow_edit`
- `delete_workflow` — permanently delete a workflow (and its triggers, tasks, execution history)

Both `access:'write'` (hidden unless `rewst-buddy.mcp.enableWriteTools`), `mcp:true`, require `orgId`, via `rawGraphql`.

## Safety model

- **Per-call approval** via the shared `withMutationApproval`; denied → `approval_required`, no mutation. `delete_workflow`'s approval summary spells out that triggers/tasks/history are removed.
- **Org-ownership pre-flight** on `delete_workflow` — fetches the workflow by id and **fails closed** unless `orgId` matches (and when it doesn't exist). `create_workflow` carries `orgId` in its input.

## Tests

- **Unit (9):** shape/gating, happy path (exact GraphQL variables), description forwarding, cross-org rejection, not-found rejection, approval-denied, validation.
- **Integration (opt-in, `REWST_TEST_WRITE=1`):** live `create → delete` round-trip + cross-org guard probe; self-cleaning; verified green against a sandbox org.

Full unit suite green.

> Stacked on #75 for the shared `mutationApproval.ts` helper; GitHub will retarget to `main` once #75 merges.
