### PR TITLE
Add MCP trigger enable/disable tool

### DIFF
--- a/changelog.d/trigger-write-tools.md
+++ b/changelog.d/trigger-write-tools.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server (experimental): trigger enable/disable tool** — when write tools are enabled, external MCP clients can now turn a Rewst workflow trigger on or off with `set_trigger_enabled`. It runs against a single organization, re-verifies the trigger belongs to that org before changing it, and requires a per-change approval inside VS Code.

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -9,6 +9,7 @@ import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
 import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 import { ORG_VARIABLE_MUTATE_CAPABILITIES } from './orgVariableMutateCapabilities';
+import { TRIGGER_MUTATE_CAPABILITIES } from './triggerMutateCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -25,6 +26,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...ORG_USER_CAPABILITIES,
 	...PAGE_TEMPLATE_CAPABILITIES,
 	...ORG_VARIABLE_MUTATE_CAPABILITIES,
+	...TRIGGER_MUTATE_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/triggerMutateCapabilities.test.ts
+++ b/src/capabilities/triggerMutateCapabilities.test.ts
@@ -1,0 +1,160 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import type { Session } from '@sessions';
+import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import { TRIGGER_MUTATE_CAPABILITIES } from './triggerMutateCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function cap(name: string): Capability {
+	const capability = TRIGGER_MUTATE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+interface GraphqlResult {
+	data?: unknown;
+	errors?: unknown;
+}
+type Op = 'byId' | 'update';
+type OpResponses = Partial<Record<Op, GraphqlResult>>;
+
+function routeOp(query: string): Op | 'unknown' {
+	if (query.includes('TriggerById')) return 'byId';
+	if (query.includes('SetTriggerEnabled')) return 'update';
+	return 'unknown';
+}
+
+function makeCtx(responses: OpResponses, orgId = 'org-sandbox', orgName = 'Sandbox') {
+	const calls: { op: string; variables: Record<string, unknown> | undefined }[] = [];
+	const session = {
+		profile: { org: { id: orgId, name: orgName }, allManagedOrgs: [{ id: orgId, name: orgName }] },
+		rawGraphql: async (query: string, variables?: Record<string, unknown>) => {
+			const op = routeOp(query);
+			calls.push({ op, variables });
+			const r = responses[op as keyof OpResponses];
+			if (!r) throw new Error(`no mock configured for op "${op}"`);
+			return r;
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId, sessions: [session] };
+	return { ctx, calls };
+}
+
+function callsFor(calls: { op: string; variables: Record<string, unknown> | undefined }[], op: string) {
+	return calls.filter(c => c.op === op);
+}
+
+suite('Unit: triggerMutateCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	suite('set_trigger_enabled', () => {
+		const inOrgDisabled = {
+			data: { triggers: [{ id: 't1', name: 'Nightly', enabled: false, orgId: 'org-sandbox' }] },
+		};
+
+		test('is a write capability gated by approval, mcp-only', () => {
+			const c = cap('set_trigger_enabled');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+
+		test('enables a trigger when in-org and approved', async () => {
+			const { ctx, calls } = makeCtx({
+				byId: inOrgDisabled,
+				update: { data: { updateTrigger: { id: 't1', name: 'Nightly', enabled: true } } },
+			});
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('set_trigger_enabled').run(
+				{ orgId: 'org-sandbox', triggerId: 't1', enabled: true },
+				ctx,
+			);
+
+			assert.deepStrictEqual(callsFor(calls, 'update')[0].variables, { trigger: { id: 't1', enabled: true } });
+			assert.strictEqual(JSON.parse(output).status, 'enabled');
+		});
+
+		test('disables a trigger and reports disabled', async () => {
+			const { ctx, calls } = makeCtx({
+				byId: { data: { triggers: [{ id: 't1', name: 'Nightly', enabled: true, orgId: 'org-sandbox' }] } },
+				update: { data: { updateTrigger: { id: 't1', name: 'Nightly', enabled: false } } },
+			});
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('set_trigger_enabled').run(
+				{ orgId: 'org-sandbox', triggerId: 't1', enabled: false },
+				ctx,
+			);
+
+			assert.strictEqual(
+				(callsFor(calls, 'update')[0].variables as { trigger: { enabled: boolean } }).trigger.enabled,
+				false,
+			);
+			assert.strictEqual(JSON.parse(output).status, 'disabled');
+		});
+
+		test('refuses to toggle a trigger in another org', async () => {
+			const { ctx, calls } = makeCtx({ byId: { data: { triggers: [] } } });
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('set_trigger_enabled').run({ orgId: 'org-sandbox', triggerId: 't1', enabled: true }, ctx),
+				/Trigger t1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(callsFor(calls, 'update').length, 0);
+		});
+
+		test('requires a boolean enabled before fetching or approving', async () => {
+			const { ctx, calls } = makeCtx({});
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('set_trigger_enabled').run({ orgId: 'org-sandbox', triggerId: 't1' }, ctx),
+				/Missing required boolean argument "enabled"/,
+			);
+			assert.strictEqual(approverCalled, false);
+			assert.strictEqual(callsFor(calls, 'byId').length, 0);
+		});
+
+		test('does not mutate when approval is denied', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgDisabled });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('set_trigger_enabled').run(
+				{ orgId: 'org-sandbox', triggerId: 't1', enabled: true },
+				ctx,
+			);
+
+			assert.strictEqual(callsFor(calls, 'update').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+	});
+});

--- a/src/capabilities/triggerMutateCapabilities.ts
+++ b/src/capabilities/triggerMutateCapabilities.ts
@@ -1,0 +1,93 @@
+import type { MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { ORG_ID_PROP, requireString } from './inputHelpers';
+import { orgDisplayName, throwOnGraphqlErrors, withMutationApproval } from './mutationApproval';
+
+/**
+ * Trigger write capabilities. set_trigger_enabled toggles a workflow trigger on
+ * or off via updateTrigger. It acts on a trigger by id, and one session can
+ * manage many orgs, so it first re-verifies the trigger belongs to the requested
+ * org (requireTriggerInOrg) before mutating. Approval-gated and hidden unless
+ * rewst-buddy.mcp.enableWriteTools.
+ */
+
+const SET_TRIGGER_ENABLED = `mutation RewstBuddyMcpSetTriggerEnabled($trigger: TriggerUpdateInput!) {
+  updateTrigger(trigger: $trigger) { id name enabled orgId }
+}`;
+
+const TRIGGER_BY_ID = `query RewstBuddyMcpTriggerById($orgId: ID!, $id: ID!) {
+  triggers(where: { orgId: $orgId, id: $id }) { id name enabled orgId }
+}`;
+
+interface TriggerRow {
+	id?: string;
+	name?: string;
+	enabled?: boolean;
+	orgId?: string;
+}
+
+/** Reads a required boolean argument; non-booleans are an error, not coerced. */
+function requireBoolean(input: Record<string, unknown>, key: string): boolean {
+	const value = input[key];
+	if (typeof value !== 'boolean') throw new Error(`Missing required boolean argument "${key}".`);
+	return value;
+}
+
+/**
+ * Fetches a trigger by id and fails closed unless it belongs to the requested
+ * org. Returns the current name for the approval scope.
+ */
+async function requireTriggerInOrg(ctx: CapabilityContext, triggerId: string, orgId: string): Promise<TriggerRow> {
+	const { data, errors } = await ctx.session.rawGraphql(TRIGGER_BY_ID, { orgId, id: triggerId });
+	throwOnGraphqlErrors(errors);
+	const rows = ((data as { triggers?: TriggerRow[] } | undefined)?.triggers ?? []) as TriggerRow[];
+	const row = rows.find(r => r.id === triggerId);
+	if (!row) throw new Error(`Trigger ${triggerId} is not in org ${orgId}.`);
+	return row;
+}
+
+const setTriggerEnabledSpec: ToolSpec = {
+	name: 'set_trigger_enabled',
+	args: '{"orgId": string, "triggerId": string, "enabled": boolean}',
+	description:
+		'Enable or disable one Rewst workflow trigger, identified by org and trigger id. The trigger must belong to the given org. Pass enabled=true to turn it on, false to turn it off. Requires write tools to be enabled and per-call approval in VS Code.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			triggerId: { type: 'string', description: 'Id of the trigger to enable or disable.' },
+			enabled: { type: 'boolean', description: 'true to enable the trigger, false to disable it.' },
+		},
+		required: ['orgId', 'triggerId', 'enabled'],
+	},
+};
+
+async function runSetTriggerEnabled(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const triggerId = requireString(input, 'triggerId');
+	const enabled = requireBoolean(input, 'enabled');
+	const orgName = orgDisplayName(ctx);
+	const current = await requireTriggerInOrg(ctx, triggerId, orgId);
+	const name = current.name ?? '(unnamed)';
+	const verb = enabled ? 'Enable' : 'Disable';
+	const scope: MutationScope = { scopeId: triggerId, scopeName: name, orgId, orgName };
+	const summary = `${verb} trigger "${name}" (${triggerId}) in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		const { data, errors } = await ctx.session.rawGraphql(SET_TRIGGER_ENABLED, {
+			trigger: { id: triggerId, enabled },
+		});
+		throwOnGraphqlErrors(errors);
+		const updated = (data as { updateTrigger?: TriggerRow } | undefined)?.updateTrigger;
+		if (!updated?.id) throw new Error('updateTrigger returned no trigger; the mutation may have failed.');
+		return JSON.stringify(
+			{ status: updated.enabled ? 'enabled' : 'disabled', id: updated.id, name: updated.name ?? name },
+			null,
+			2,
+		);
+	});
+}
+
+export const TRIGGER_MUTATE_CAPABILITIES: Capability[] = [
+	{ spec: setTriggerEnabledSpec, access: 'write', chat: false, mcp: true, run: runSetTriggerEnabled },
+];

--- a/src/test/integration/triggerMutate.test.ts
+++ b/src/test/integration/triggerMutate.test.ts
@@ -1,0 +1,118 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import { _resetApprovedMutationScopes } from '../../ui/chat/tools/graphqlTool';
+import { TRIGGER_MUTATE_CAPABILITIES } from '../../capabilities/triggerMutateCapabilities';
+
+const { suite, test, suiteSetup, suiteTeardown, setup } = Mocha;
+
+/**
+ * Live verification for set_trigger_enabled, opt-in behind REWST_TEST_WRITE=1 and
+ * scoped to the token's own primary org. Toggles an existing sandbox trigger to
+ * the opposite state and restores it (net-zero); skips if the org has no trigger.
+ */
+function writeTestsEnabled(): boolean {
+	return hasTestToken() && process.env.REWST_TEST_WRITE === '1';
+}
+
+function cap(name: string): Capability {
+	const capability = TRIGGER_MUTATE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+const FIRST_TRIGGER = `query RbItestFirstTrigger($orgId: ID!) {
+  triggers(where: { orgId: $orgId }, limit: 1) { id name enabled orgId }
+}`;
+const RESTORE = `mutation RbItestRestoreTrigger($trigger: TriggerUpdateInput!) {
+  updateTrigger(trigger: $trigger) { id enabled }
+}`;
+
+suite('Integration: trigger write tools', function () {
+	this.timeout(120_000);
+
+	let session: Session;
+	let ctx: CapabilityContext;
+	let targetOrgId: string;
+	let otherOrgId: string | undefined;
+
+	suiteSetup(async function () {
+		if (!writeTestsEnabled()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		session = await getTestSession();
+		targetOrgId = session.profile.org.id;
+		if (!targetOrgId) throw new Error('Refusing to run: the test session has no primary org id.');
+		otherOrgId = session.profile.allManagedOrgs.find(org => org.id && org.id !== targetOrgId)?.id;
+		ctx = { session, orgId: targetOrgId, sessions: [session] };
+		console.log(`\n[itest] target org: ${session.profile.org.name} (${targetOrgId})`);
+	});
+
+	setup(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		setMcpMutationApprover(async () => true);
+	});
+
+	suiteTeardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		clearCachedSession();
+	});
+
+	test('toggles an existing trigger and restores it', async function () {
+		const { data } = await session.rawGraphql(FIRST_TRIGGER, { orgId: targetOrgId });
+		const trigger = (data as { triggers?: { id: string; enabled?: boolean }[] } | undefined)?.triggers?.[0];
+		if (!trigger) {
+			console.log('[itest] no trigger in sandbox; skipping toggle');
+			this.skip();
+			return;
+		}
+		const original = trigger.enabled ?? false;
+		const triggerId = trigger.id;
+		let changed = false;
+
+		try {
+			if (otherOrgId) {
+				const guardCtx: CapabilityContext = { session, orgId: otherOrgId, sessions: [session] };
+				await assert.rejects(
+					() =>
+						cap('set_trigger_enabled').run({ orgId: otherOrgId, triggerId, enabled: !original }, guardCtx),
+					/is not in org/,
+				);
+				console.log('[itest] org guard refused a cross-org toggle to', otherOrgId);
+			}
+
+			const toggled = JSON.parse(
+				await cap('set_trigger_enabled').run({ orgId: targetOrgId, triggerId, enabled: !original }, ctx),
+			);
+			changed = true;
+			assert.strictEqual(toggled.status, !original ? 'enabled' : 'disabled');
+			console.log('[itest] toggled trigger', triggerId, '->', toggled.status);
+
+			const restored = JSON.parse(
+				await cap('set_trigger_enabled').run({ orgId: targetOrgId, triggerId, enabled: original }, ctx),
+			);
+			changed = false;
+			assert.strictEqual(restored.status, original ? 'enabled' : 'disabled');
+			console.log('[itest] restored trigger to original state');
+		} finally {
+			if (changed) {
+				try {
+					await session.rawGraphql(RESTORE, { trigger: { id: triggerId, enabled: original } });
+				} catch {
+					// best-effort restore
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
## Summary

Adds **`set_trigger_enabled`**, the write counterpart to `list_triggers` — enable or disable one Rewst workflow trigger (`{orgId, triggerId, enabled}`). `access:'write'` (hidden unless `rewst-buddy.mcp.enableWriteTools`), `mcp:true`, requires `orgId`, via `rawGraphql` (`updateTrigger`).

## Safety model

- **Per-call approval** via the shared `withMutationApproval`; denied → `approval_required`, no mutation. The approval summary reads "Enable/Disable trigger …".
- **Org-ownership pre-flight** — fetches the trigger scoped to the requested org and **fails closed** unless it belongs there.
- `enabled` must be a boolean (no coercion); validated before any fetch or prompt.

## Tests

- **Unit (6):** shape/gating, enable, disable, cross-org rejection, boolean validation before side effects, approval-denied.
- **Integration (opt-in, `REWST_TEST_WRITE=1`):** toggles an existing sandbox trigger to the opposite state and **restores it** (net-zero), plus a cross-org guard probe; skips if the org has no trigger. Verified green against a sandbox org.

Full unit suite green.

> Stacked on #75 for the shared `mutationApproval.ts` helper; GitHub will retarget to `main` once #75 merges.
