### PR TITLE
Add a write-org allowlist gate to the MCP boundary

### DIFF
--- a/changelog.d/write-org-allowlist.md
+++ b/changelog.d/write-org-allowlist.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **MCP server: write-org allowlist** — a new `rewst-buddy.mcp.writeOrgAllowlist` setting limits which organizations MCP write tools (including `rewst_graphql_mutate`) may change. Leave it empty to allow any org your sessions manage; list one or more org ids and a write against any other org is rejected at the MCP boundary before it runs. This is a hard, declarative blast-radius cap that does not depend on the in-VS-Code approval prompt — which an external MCP client's user may never see. Read tools are never restricted.

--- a/package.json
+++ b/package.json
@@ -150,6 +150,14 @@
 					"type": "boolean",
 					"default": false,
 					"description": "Allow the raw rewst_graphql_mutate MCP tool to run arbitrary GraphQL mutations against the live Rewst organization. This is separate from write tools because it can change anything your Rewst session can change; each mutation still requires per-resource approval inside VS Code."
+				},
+				"rewst-buddy.mcp.writeOrgAllowlist": {
+					"type": "array",
+					"items": {
+						"type": "string"
+					},
+					"default": [],
+					"description": "Organization ids that MCP write tools (including rewst_graphql_mutate) may target. Leave empty to allow any org your sessions manage. When you list one or more org ids, a write against any other org is rejected at the MCP boundary before it runs — a hard limit that does not depend on the approval prompt. Find org ids with the list_orgs tool. Read tools are never restricted."
 				}
 			}
 		},

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -17,7 +17,13 @@ import type { McpSettings } from './settings';
 const { suite, test, setup, teardown } = Mocha;
 
 function settings(over: Partial<McpSettings> = {}): McpSettings {
-	return { enable: true, enableWriteTools: false, enableDangerousGraphqlMutation: false, ...over };
+	return {
+		enable: true,
+		enableWriteTools: false,
+		enableDangerousGraphqlMutation: false,
+		writeOrgAllowlist: [],
+		...over,
+	};
 }
 
 /** A mock session managing one org, registered with the SessionManager. */
@@ -324,6 +330,83 @@ suite('Unit: McpActions', () => {
 				),
 				(error: unknown) => error instanceof McpError && error.code === 'write_disabled',
 			);
+		});
+
+		test('a write to a non-allowlisted org is rejected before it runs', async () => {
+			useSession('org-1');
+
+			await assert.rejects(
+				callTool(
+					{
+						name: WORKFLOW_EDIT_TOOL_NAME,
+						arguments: {
+							orgId: 'org-1',
+							workflowId: 'wf-1',
+							workflowName: 'Workflow',
+							orgName: 'Acme',
+							operations: [],
+						},
+					},
+					settings({ enableWriteTools: true, writeOrgAllowlist: ['org-other'] }),
+				),
+				(error: unknown) => error instanceof McpError && error.code === 'org_not_allowlisted',
+			);
+		});
+
+		test('a write to an allowlisted org passes the boundary guard', async () => {
+			const { session, wrapper } = useSession('org-1', 'Acme');
+			useRawGraphqlWrapper(session, wrapper);
+			setMcpMutationApprover(async () => false);
+
+			const result = await callTool(
+				{
+					name: WORKFLOW_EDIT_TOOL_NAME,
+					arguments: {
+						orgId: 'org-1',
+						workflowId: 'wf-1',
+						workflowName: 'MCP Sample Workflow',
+						orgName: 'Acme',
+						operations: [{ op: 'reposition', task: 'start', x: 1, y: 2 }],
+					},
+				},
+				settings({ enableWriteTools: true, writeOrgAllowlist: ['org-1'] }),
+			);
+
+			// Past the allowlist guard; stopped only at approval (declined here).
+			assert.strictEqual(JSON.parse(result.text).status, 'approval_required');
+		});
+
+		test('an empty allowlist permits writes to any managed org', async () => {
+			const { session, wrapper } = useSession('org-1', 'Acme');
+			useRawGraphqlWrapper(session, wrapper);
+			setMcpMutationApprover(async () => false);
+
+			const result = await callTool(
+				{
+					name: WORKFLOW_EDIT_TOOL_NAME,
+					arguments: {
+						orgId: 'org-1',
+						workflowId: 'wf-1',
+						workflowName: 'MCP Sample Workflow',
+						orgName: 'Acme',
+						operations: [{ op: 'reposition', task: 'start', x: 1, y: 2 }],
+					},
+				},
+				settings({ enableWriteTools: true, writeOrgAllowlist: [] }),
+			);
+
+			assert.strictEqual(JSON.parse(result.text).status, 'approval_required');
+		});
+
+		test('the allowlist does not restrict read tools', async () => {
+			useSession('org-1');
+
+			const result = await callTool(
+				{ name: 'list_templates', arguments: { orgId: 'org-1' } },
+				settings({ writeOrgAllowlist: ['org-other'] }),
+			);
+
+			assert.ok(!result.isError);
 		});
 
 		test('buddy_workflow_edit returns approval_required without executing when the user declines', async () => {

--- a/src/mcp/McpActions.ts
+++ b/src/mcp/McpActions.ts
@@ -50,6 +50,28 @@ export class McpError extends Error {
 	}
 }
 
+/**
+ * Enforces the write-org allowlist: a write capability may only run against an
+ * org on rewst-buddy.mcp.writeOrgAllowlist. An empty allowlist means "any managed
+ * org" (logged as a warning, since nothing then caps the blast radius). Reads are
+ * never restricted. This is the reliable, boundary-level gate for the MCP model,
+ * where the per-call approval modal — hosted in VS Code, not the external client —
+ * may never surface to the operator.
+ */
+function assertOrgWriteAllowed(capability: Capability, orgId: string, settings: McpSettings): void {
+	if (capability.access !== 'write') return;
+	if (settings.writeOrgAllowlist.length === 0) {
+		log.info(`[MCP] write allowlist empty; "${capability.spec.name}" may target any managed org (${orgId}).`);
+		return;
+	}
+	if (!settings.writeOrgAllowlist.includes(orgId)) {
+		throw new McpError(
+			'org_not_allowlisted',
+			`Writes to org "${orgId}" are not allowed. Add it to rewst-buddy.mcp.writeOrgAllowlist in VS Code to permit write tools against this org.`,
+		);
+	}
+}
+
 /** Whether a capability is exposed to MCP under the current settings. */
 function isExposed(capability: Capability, settings: McpSettings): boolean {
 	if (!capability.mcp) return false;
@@ -201,6 +223,9 @@ export async function callTool(
 		const args = params.arguments ?? {};
 		const ctx = await resolveContext(capability, args, params.orgId);
 		auditOrgId = capability.requiresOrg === false ? '—' : ctx.orgId || '—';
+		// Reject a disallowed write before the capability runs (and before its
+		// approval modal, which may never surface to an external MCP client).
+		assertOrgWriteAllowed(capability, ctx.orgId, settings);
 		try {
 			const text = await capability.run(args, ctx);
 			auditOutcome = auditOutcomeForText(text);

--- a/src/mcp/protocol.ts
+++ b/src/mcp/protocol.ts
@@ -37,6 +37,7 @@ export type McpErrorCode =
 	| 'no_session'
 	| 'refresh_failed'
 	| 'write_disabled'
+	| 'org_not_allowlisted'
 	| 'approval_required'
 	| 'rate_limited'
 	| 'graphql_error'

--- a/src/mcp/settings.ts
+++ b/src/mcp/settings.ts
@@ -9,6 +9,20 @@ export interface McpSettings {
 	enableWriteTools: boolean;
 	/** Allows the raw GraphQL mutation capability through the MCP boundary. */
 	enableDangerousGraphqlMutation: boolean;
+	/**
+	 * Org ids that write tools may target. Empty means "any managed org" (the
+	 * default). When non-empty, a write whose orgId is not listed is rejected at
+	 * the MCP boundary before it runs — a hard, declarative blast-radius cap that
+	 * does not depend on the approval modal (which an external MCP client's user
+	 * may never see).
+	 */
+	writeOrgAllowlist: string[];
+}
+
+/** Coerces the user-supplied allowlist setting into trimmed, non-empty string ids. */
+function normalizeAllowlist(value: unknown): string[] {
+	if (!Array.isArray(value)) return [];
+	return value.map(entry => (typeof entry === 'string' ? entry.trim() : '')).filter(entry => entry.length > 0);
 }
 
 export function readMcpSettings(): McpSettings {
@@ -17,5 +31,6 @@ export function readMcpSettings(): McpSettings {
 		enable: config.get<boolean>('enable', false),
 		enableWriteTools: config.get<boolean>('enableWriteTools', false),
 		enableDangerousGraphqlMutation: config.get<boolean>('enableDangerousGraphqlMutation', false),
+		writeOrgAllowlist: normalizeAllowlist(config.get<unknown>('writeOrgAllowlist', [])),
 	};
 }


### PR DESCRIPTION
## Summary

Adds **`rewst-buddy.mcp.writeOrgAllowlist`** — a setting that caps which organizations MCP write tools may change, enforced as a hard gate at the MCP boundary.

- Empty (default) → any org your sessions manage may be written (a one-line audit warning notes nothing is capping the blast radius).
- Non-empty → a write whose `orgId` isn't listed is rejected with `org_not_allowlisted` **before the capability runs** — and before its approval prompt.

Applies to **every** `access:'write'` capability, including the dangerous `rewst_graphql_mutate`, and any future write tool, via a single check in `McpActions.callTool`. **Reads are never restricted** (so `list_orgs` discovery still works).

## Why a setting, and why at the boundary

The per-call approval modal lives in **VS Code**, but MCP write tools are called by **external clients** (Claude Desktop/Code/Cursor) in another process — often another app or window, sometimes headless. In those conditions the modal may never surface to the operator (and it blocks a synchronous HTTP request while it waits). So the durable gate for the MCP model is a **standing, declarative policy enforced at the boundary**, not an interactive prompt.

It's a **setting, not a tool**, on purpose: if the allowlist were itself an MCP tool, the model could add orgs to its own allowlist. It lives in VS Code config, the same trust boundary as `enableWriteTools`.

## Implementation

- `settings.ts`: `writeOrgAllowlist: string[]` (defensively normalized — trims, drops non-strings/empties).
- `McpActions.ts`: `assertOrgWriteAllowed(capability, orgId, settings)` called after the org resolves, before `capability.run`. New `org_not_allowlisted` error code.
- `package.json`: the `rewst-buddy.mcp.writeOrgAllowlist` config contribution.

## Tests

- Non-allowlisted org → rejected before running; allowlisted org → passes the guard (stops only at approval); empty allowlist → permitted; read tools unaffected by the allowlist.

Full unit suite green (incl. the package-manifest sync test).

Independent of the write-tool PRs (#74–#78); this gate also hardens the existing `rewst_graphql_mutate`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `rewst-buddy.mcp.writeOrgAllowlist` configuration setting to restrict which organizations MCP write tools can modify. Leave empty to permit writes to any managed organization, or specify organization IDs to limit write access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->