### PR TITLE
Add MCP template sync tools (status + sync) for #21

### DIFF
--- a/changelog.d/21.md
+++ b/changelog.d/21.md
@@ -1,0 +1,6 @@
+---
+category: Added
+pr: 21
+---
+
+- **Template sync over MCP** - Two new MCP tools let an AI assistant work with the link-and-sync workflow that previously only existed in the VS Code UI. `buddy_template_sync_status` reports whether a file is linked to a Rewst template and how it compares to the remote (in-sync, remote-only, local-ahead, or conflict) without changing anything. `buddy_template_sync` pushes or pulls a linked file: it defaults to the safe direction and, because an MCP client cannot answer the VS Code conflict prompt, it stops and reports a conflict instead of overwriting — you resolve it by re-calling with `direction:"upload"` or `direction:"download"`. `buddy_template_sync` is a write tool, so every direction requires write tools enabled and an allowlisted org; uploading additionally needs per-call approval and changes Rewst, while downloading rewrites only the local file.

--- a/changelog.d/mcp-template-bundle-clone.md
+++ b/changelog.d/mcp-template-bundle-clone.md
@@ -1,0 +1,6 @@
+---
+category: Added
+pr: 85
+---
+
+- **Deep-clone a template bundle over MCP** - The new `buddy_template_bundle_clone` tool deep-copies a template and the templates it references (transitively, via `template('<id>')` calls) into new templates in a target org, rewriting every reference to the new ids. It walks the live remote graph (cycle-safe, depth- and count-capped), creates the clones behind a single approval, and rolls back every created template if the clone fails partway. References to other orgs or to deleted templates are reported rather than silently dropped.

--- a/changelog.d/mcp-template-link-tools.md
+++ b/changelog.d/mcp-template-link-tools.md
@@ -1,0 +1,6 @@
+---
+category: Added
+pr: 85
+---
+
+- **Template link management over MCP** - New MCP tools let an AI assistant manage the local file ↔ Rewst template links directly: `buddy_template_link` associates an existing local file with a template, `buddy_template_unlink` removes the association, and `buddy_template_sync_on_save` toggles upload-on-save for a linked file. These change only local link state (no Rewst writes) and pair with the sync tools to drive the full link-edit-sync workflow without the VS Code UI.

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -4,6 +4,35 @@
  * one consistent argument-parsing contract.
  */
 
+import type { FullTemplateFragment, Session } from '@sessions';
+
+/** Pretty-prints a value as the JSON string capabilities return to callers. */
+export function json(value: unknown): string {
+	return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Fetches a template by id from whichever active session can resolve it,
+ * returning the resolving session too. A requiresOrg:false tool has no
+ * org-targeted session and one machine can manage several orgs, so try each
+ * session rather than assuming the first. Returns undefined when no session
+ * resolves the id.
+ */
+export async function getTemplateFromAnySession(
+	sessions: readonly Session[],
+	getTemplate: (session: Session, templateId: string) => Promise<FullTemplateFragment>,
+	templateId: string,
+): Promise<{ template: FullTemplateFragment; session: Session } | undefined> {
+	for (const session of sessions) {
+		try {
+			return { template: await getTemplate(session, templateId), session };
+		} catch {
+			// Try the next session.
+		}
+	}
+	return undefined;
+}
+
 export function asString(input: Record<string, unknown>, key: string): string | undefined {
 	const value = input[key];
 	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -23,13 +23,20 @@ export async function getTemplateFromAnySession(
 	getTemplate: (session: Session, templateId: string) => Promise<FullTemplateFragment>,
 	templateId: string,
 ): Promise<{ template: FullTemplateFragment; session: Session } | undefined> {
+	// A session that does not manage the template's org throws a "not found"
+	// error — expected, so try the next session. But an auth/network/SDK failure
+	// must not be silently swallowed into a "not found" outcome; remember it and,
+	// if no session resolves the id, surface it rather than masking an outage.
+	let operationalError: unknown;
 	for (const session of sessions) {
 		try {
 			return { template: await getTemplate(session, templateId), session };
-		} catch {
-			// Try the next session.
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			if (!/not found/i.test(message)) operationalError = error;
 		}
 	}
+	if (operationalError !== undefined) throw operationalError;
 	return undefined;
 }
 

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -13,6 +13,7 @@ import { TAG_MUTATE_CAPABILITIES } from './tagMutateCapabilities';
 import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
 import { TRIGGER_MUTATE_CAPABILITIES } from './triggerMutateCapabilities';
 import { TEMPLATE_MUTATE_CAPABILITIES } from './templateMutateCapabilities';
+import { TEMPLATE_SYNC_CAPABILITIES } from './templateSyncCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -33,6 +34,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...WORKFLOW_CRUD_CAPABILITIES,
 	...TRIGGER_MUTATE_CAPABILITIES,
 	...TEMPLATE_MUTATE_CAPABILITIES,
+	...TEMPLATE_SYNC_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -14,6 +14,8 @@ import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
 import { TRIGGER_MUTATE_CAPABILITIES } from './triggerMutateCapabilities';
 import { TEMPLATE_MUTATE_CAPABILITIES } from './templateMutateCapabilities';
 import { TEMPLATE_SYNC_CAPABILITIES } from './templateSyncCapabilities';
+import { TEMPLATE_LINK_CAPABILITIES } from './templateLinkCapabilities';
+import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -35,6 +37,8 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...TRIGGER_MUTATE_CAPABILITIES,
 	...TEMPLATE_MUTATE_CAPABILITIES,
 	...TEMPLATE_SYNC_CAPABILITIES,
+	...TEMPLATE_LINK_CAPABILITIES,
+	...TEMPLATE_CLONE_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/templateCloneCapabilities.test.ts
+++ b/src/capabilities/templateCloneCapabilities.test.ts
@@ -1,0 +1,377 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { createMockSession, initTestEnvironment } from '@test';
+import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
+import type { FullTemplateFragment, Session } from '@sessions';
+import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
+import {
+	defaultTemplateCloneDeps,
+	rewriteReferences,
+	runBundleClone,
+	TEMPLATE_CLONE_CAPABILITIES,
+	type TemplateCloneDeps,
+} from './templateCloneCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+// Valid UUIDs so findAllTemplateReferences' pattern matches.
+const A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const C = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const D = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const FOREIGN = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+const MISSING = '99999999-9999-9999-9999-999999999999';
+
+function refBody(ids: string[]): string {
+	return ids.map(id => `{{ template('${id}') }}`).join('\n');
+}
+
+function tmpl(id: string, over: Partial<FullTemplateFragment> = {}): FullTemplateFragment {
+	return {
+		id,
+		name: `T-${id.slice(0, 4)}`,
+		body: '',
+		updatedAt: '1',
+		orgId: 'src-org',
+		organization: { id: 'src-org', name: 'Source' },
+		contentType: 'text',
+		language: 'jinja',
+		context: null,
+		cloneOverrides: null,
+		description: null,
+		tags: [],
+		...over,
+	} as unknown as FullTemplateFragment;
+}
+
+interface CloneDepOpts {
+	failCreateAt?: number;
+	failUpdateAt?: number;
+}
+
+type CloneUpdateArg = Parameters<TemplateCloneDeps['updateTemplate']>[1];
+
+function makeCloneDeps(remote: Record<string, FullTemplateFragment>, opts: CloneDepOpts = {}) {
+	const calls = {
+		getTemplate: [] as string[],
+		create: [] as { name: string; orgId: string }[],
+		update: [] as CloneUpdateArg[],
+		del: [] as string[],
+	};
+	let createCount = 0;
+	let updateCount = 0;
+	let idSeq = 0;
+	const deps: TemplateCloneDeps = {
+		getTemplate: async (_s, id) => {
+			calls.getTemplate.push(id);
+			const t = remote[id];
+			if (!t) throw new Error(`not found: ${id}`);
+			return t;
+		},
+		createTemplate: async (_s, name, orgId) => {
+			createCount++;
+			calls.create.push({ name, orgId });
+			if (opts.failCreateAt === createCount) throw new Error('create boom');
+			return { id: `new-${++idSeq}` };
+		},
+		updateTemplate: async (_s, update) => {
+			updateCount++;
+			calls.update.push(update);
+			if (opts.failUpdateAt === updateCount) throw new Error('update boom');
+		},
+		deleteTemplate: async (_s, id) => {
+			calls.del.push(id);
+		},
+	};
+	return { deps, calls };
+}
+
+function makeCtx(targetOrgId = 'tgt-org'): CapabilityContext {
+	const session = {
+		profile: { org: { id: targetOrgId, name: 'Target' }, allManagedOrgs: [{ id: targetOrgId, name: 'Target' }] },
+	} as unknown as Session;
+	return { session, orgId: targetOrgId, sessions: [session] };
+}
+
+suite('Unit: templateCloneCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	suite('rewriteReferences', () => {
+		test('rewrites mapped ids, leaves unmapped refs and surrounding Jinja intact', () => {
+			const map = new Map([[A, 'new-1']]);
+			const body = `{{ template('${A}') }} and {{ template('${B}') }}`;
+			const out = rewriteReferences(body, map);
+			assert.ok(out.includes("template('new-1')"), 'mapped ref rewritten');
+			assert.ok(out.includes(`template('${B}')`), 'unmapped ref left as-is');
+		});
+
+		test('matches case-insensitively against canonical (lowercase) keys', () => {
+			const map = new Map([[A, 'new-1']]);
+			const out = rewriteReferences(`{{ template('${A.toUpperCase()}') }}`, map);
+			assert.ok(out.includes("template('new-1')"), 'uppercase ref still rewritten');
+		});
+	});
+
+	suite('capability descriptor', () => {
+		test('buddy_template_bundle_clone is a write tool, mcp-only, org-scoped', () => {
+			const c = TEMPLATE_CLONE_CAPABILITIES.find(x => x.spec.name === 'buddy_template_bundle_clone');
+			assert.ok(c);
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+	});
+
+	suite('approval', () => {
+		test('creates nothing when approval is denied', async () => {
+			const { deps, calls } = makeCloneDeps({ [A]: tmpl(A) });
+			setMcpMutationApprover(async () => false);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'approval_required');
+			assert.strictEqual(calls.create.length, 0);
+		});
+
+		test('prompts once for the whole bundle, scoped to (org, root)', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B, { body: refBody([C]) }), [C]: tmpl(C) };
+			const { deps } = makeCloneDeps(remote);
+			let approverCalls = 0;
+			let scope: MutationScope | undefined;
+			setMcpMutationApprover(async s => {
+				approverCalls++;
+				scope = s;
+				return true;
+			});
+
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+
+			assert.strictEqual(approverCalls, 1, 'one approval for the whole clone');
+			assert.strictEqual(scope?.scopeId, `clone:${A}`, 'scope is per-(org, root)');
+		});
+
+		test('reuses approval for the same root but re-prompts for a different root', async () => {
+			const remote = { [A]: tmpl(A), [B]: tmpl(B) };
+			const { deps } = makeCloneDeps(remote);
+			let approverCalls = 0;
+			setMcpMutationApprover(async () => {
+				approverCalls++;
+				return true;
+			});
+
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+			assert.strictEqual(approverCalls, 1, 'same root reuses approval');
+
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: B }, makeCtx(), deps);
+			assert.strictEqual(approverCalls, 2, 'a different root re-prompts');
+		});
+	});
+
+	suite('cloning', () => {
+		setup(() => setMcpMutationApprover(async () => true));
+
+		test('clones a single template with no references', async () => {
+			const { deps, calls } = makeCloneDeps({ [A]: tmpl(A, { body: 'hello' }) });
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'cloned');
+			assert.strictEqual(out.count, 1);
+			assert.strictEqual(out.newRootTemplateId, 'new-1');
+			assert.strictEqual(calls.create.length, 1);
+			assert.strictEqual(calls.update.length, 1);
+		});
+
+		test('rewrites references to the new ids along a chain', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B, { body: refBody([C]) }), [C]: tmpl(C) };
+			const { deps, calls } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+
+			assert.strictEqual(out.count, 3);
+			const rootUpdate = calls.update.find(u => u.id === 'new-1');
+			assert.ok(rootUpdate, 'root clone updated');
+			assert.ok(rootUpdate.body.includes("template('new-2')"), 'reference rewritten to the clone id');
+			assert.ok(!rootUpdate.body.includes(B), 'old id no longer present');
+		});
+
+		test('copies source contentType / language / context onto each clone', async () => {
+			const remote = {
+				[A]: tmpl(A, { body: 'print(1)', contentType: 'powershell', language: 'python', context: { x: 1 } }),
+			};
+			const { deps, calls } = makeCloneDeps(remote);
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+			const update = calls.update[0];
+			assert.strictEqual(update.language, 'python');
+			assert.strictEqual(update.contentType, 'powershell');
+			assert.deepStrictEqual(update.context, { x: 1 });
+		});
+
+		test('handles a cycle without looping forever', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B, { body: refBody([A]) }) };
+			const { deps, calls } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 2);
+			assert.strictEqual(calls.create.length, 2);
+		});
+
+		test('clones a shared (diamond) dependency only once', async () => {
+			const remote = {
+				[A]: tmpl(A, { body: refBody([B, C]) }),
+				[B]: tmpl(B, { body: refBody([D]) }),
+				[C]: tmpl(C, { body: refBody([D]) }),
+				[D]: tmpl(D),
+			};
+			const { deps, calls } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 4, 'D cloned once');
+			assert.strictEqual(calls.create.length, 4);
+		});
+
+		test('dedupes case-variant references to one clone', async () => {
+			const remote = {
+				[A]: tmpl(A, { body: refBody([B.toUpperCase(), C]) }),
+				[B]: tmpl(B),
+				[C]: tmpl(C, { body: refBody([B]) }),
+			};
+			const { deps } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 3, 'B cloned once despite mixed-case references');
+		});
+
+		test('reports a missing referenced template and still clones the root', async () => {
+			const { deps } = makeCloneDeps({ [A]: tmpl(A, { body: refBody([MISSING]) }) });
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 1);
+			assert.deepStrictEqual(out.missingReferences, [MISSING]);
+		});
+
+		test('reports a foreign-org reference and does not clone it', async () => {
+			const remote = {
+				[A]: tmpl(A, { body: refBody([FOREIGN]) }),
+				[FOREIGN]: tmpl(FOREIGN, { orgId: 'other-org' }),
+			};
+			const { deps } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 1);
+			assert.deepStrictEqual(out.foreignReferences, [{ refId: FOREIGN, orgId: 'other-org' }]);
+		});
+
+		test('bounds the walk by maxDepth and reports the dropped child', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B, { body: refBody([C]) }), [C]: tmpl(C) };
+			const { deps } = makeCloneDeps(remote);
+			const out = JSON.parse(
+				await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A, maxDepth: 1 }, makeCtx(), deps),
+			);
+			assert.strictEqual(out.count, 2, 'A and B only');
+			assert.deepStrictEqual(out.skipped.depth, [C], 'reports the omitted child, not the cloned parent');
+		});
+
+		test('bounds the walk by maxTemplates', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B, C]) }), [B]: tmpl(B), [C]: tmpl(C) };
+			const { deps } = makeCloneDeps(remote);
+			const out = JSON.parse(
+				await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A, maxTemplates: 2 }, makeCtx(), deps),
+			);
+			assert.strictEqual(out.count, 2);
+			assert.deepStrictEqual(out.skipped.cap, [C]);
+		});
+
+		test('creates every clone in the target org', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
+			const { deps, calls } = makeCloneDeps(remote);
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+			assert.ok(calls.create.every(c => c.orgId === 'tgt-org'), 'all creates target the requested org');
+		});
+
+		test('fetches the root from a later session when the first cannot', async () => {
+			const remote = { [A]: tmpl(A) };
+			const { deps } = makeCloneDeps(remote);
+			const base = deps.getTemplate;
+			const s1 = {} as unknown as Session;
+			const s2 = {
+				profile: { org: { id: 'tgt-org', name: 'Target' }, allManagedOrgs: [{ id: 'tgt-org', name: 'Target' }] },
+			} as unknown as Session;
+			deps.getTemplate = async (s, id) => {
+				if (s === s1) throw new Error('first session cannot read it');
+				return base(s, id);
+			};
+			const ctx = { session: s2, orgId: 'tgt-org', sessions: [s1, s2] } as unknown as CapabilityContext;
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, ctx, deps));
+			assert.strictEqual(out.status, 'cloned');
+			assert.strictEqual(out.count, 1);
+		});
+
+		test('rolls back every created template when an update fails', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
+			const { deps, calls } = makeCloneDeps(remote, { failUpdateAt: 2 });
+			await assert.rejects(
+				() => runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps),
+				/Clone failed.*Rolled back all 2/,
+			);
+			assert.deepStrictEqual(calls.del, ['new-1', 'new-2'], 'both clones deleted');
+		});
+
+		test('rolls back only the templates created so far when a create fails', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
+			const { deps, calls } = makeCloneDeps(remote, { failCreateAt: 2 });
+			await assert.rejects(
+				() => runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps),
+				/Clone failed.*create boom/,
+			);
+			assert.deepStrictEqual(calls.del, ['new-1'], 'only the first clone existed to delete');
+			assert.strictEqual(calls.update.length, 0, 'no body updates ran');
+		});
+
+		test('verifies the source org against sourceOrgId', async () => {
+			const { deps } = makeCloneDeps({ [A]: tmpl(A) });
+			await assert.rejects(
+				() => runBundleClone({ orgId: 'tgt-org', rootTemplateId: A, sourceOrgId: 'wrong' }, makeCtx(), deps),
+				/is in org src-org, not wrong/,
+			);
+		});
+	});
+
+	suite('defaultTemplateCloneDeps (production SDK glue)', () => {
+		const update = { id: 'x', body: 'b', contentType: 'text', language: 'jinja', context: null, cloneOverrides: null, description: null };
+
+		test('createTemplate returns the minted id', async () => {
+			const { session, wrapper } = createMockSession({ profile: { org: { id: 'tgt', name: 'T' } } });
+			wrapper.when('createTemplateMinimal', { data: { template: { id: 'c1', name: 'X' } } });
+			const r = await defaultTemplateCloneDeps.createTemplate(session, 'X', 'tgt');
+			assert.strictEqual(r.id, 'c1');
+		});
+
+		test('createTemplate throws when the response has no template', async () => {
+			const { session, wrapper } = createMockSession();
+			wrapper.when('createTemplateMinimal', { data: { template: null } });
+			await assert.rejects(() => defaultTemplateCloneDeps.createTemplate(session, 'X', 'tgt'), /returned no template/);
+		});
+
+		test('updateTemplate succeeds and throws on a missing template', async () => {
+			const ok = createMockSession();
+			ok.wrapper.when('updateTemplate', { data: { template: { id: 'x' } } });
+			await defaultTemplateCloneDeps.updateTemplate(ok.session, update);
+
+			const bad = createMockSession();
+			bad.wrapper.when('updateTemplate', { data: { template: null } });
+			await assert.rejects(() => defaultTemplateCloneDeps.updateTemplate(bad.session, update), /returned no template/);
+		});
+
+		test('deleteTemplate succeeds and throws on a null result', async () => {
+			const ok = createMockSession();
+			ok.wrapper.when('deleteTemplate', { data: { deleteTemplate: 'x' } });
+			await defaultTemplateCloneDeps.deleteTemplate(ok.session, 'x');
+
+			const bad = createMockSession();
+			bad.wrapper.when('deleteTemplate', { data: { deleteTemplate: null } });
+			await assert.rejects(() => defaultTemplateCloneDeps.deleteTemplate(bad.session, 'x'), /rollback delete failed/);
+		});
+	});
+});

--- a/src/capabilities/templateCloneCapabilities.test.ts
+++ b/src/capabilities/templateCloneCapabilities.test.ts
@@ -308,6 +308,21 @@ suite('Unit: templateCloneCapabilities', () => {
 			assert.strictEqual(out.count, 1);
 		});
 
+		test('aborts without creating anything when a reference fetch fails operationally', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }) };
+			const { deps, calls } = makeCloneDeps(remote);
+			const base = deps.getTemplate;
+			deps.getTemplate = async (s, id) => {
+				if (id === B) throw new Error('Network error: ECONNRESET');
+				return base(s, id);
+			};
+			await assert.rejects(
+				() => runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps),
+				/Network error/,
+			);
+			assert.strictEqual(calls.create.length, 0, 'no clones created on an operational failure');
+		});
+
 		test('rolls back every created template when an update fails', async () => {
 			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
 			const { deps, calls } = makeCloneDeps(remote, { failUpdateAt: 2 });

--- a/src/capabilities/templateCloneCapabilities.ts
+++ b/src/capabilities/templateCloneCapabilities.ts
@@ -1,0 +1,305 @@
+import type { FullTemplateFragment, Session } from '@sessions';
+import { findAllTemplateReferences } from '@utils';
+import { TEMPLATE_PATTERN } from '../providers/templatePatternUtils';
+import type { MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asPositiveInt, asString, getTemplateFromAnySession, json, ORG_ID_PROP, requireString } from './inputHelpers';
+import { orgDisplayName, withMutationApproval } from './mutationApproval';
+
+/**
+ * buddy_template_bundle_clone — deep-copy a template and the templates it
+ * references (transitively, via template('<id>') calls in the body) into NEW
+ * templates in a target org, rewriting every reference to the new ids.
+ *
+ * Why manual create-then-rewrite (not a native Rewst clone): the generated SDK
+ * has no clone wrapper, and a native deep clone would not rewrite the
+ * template('<id>') references to the new ids — the whole point here. So we
+ * create an empty template per node (to mint new ids), build an old→new id map,
+ * then for each node rewrite its body and write back its source metadata
+ * (contentType/language/context/cloneOverrides/description). Two phases are
+ * required because a body can reference a node not yet created (cycles / forward
+ * refs). Tags are NOT copied (they are org-scoped tag ids).
+ *
+ * orgId is the TARGET org (write destination), which the central MCP allowlist
+ * gates. The source org is taken from the root and read with whatever session
+ * manages it; writes always go to ctx.session (resolved for the target orgId).
+ */
+
+const DEFAULT_MAX_TEMPLATES = 50;
+const MAX_MAX_TEMPLATES = 200;
+const DEFAULT_MAX_DEPTH = 10;
+const MAX_MAX_DEPTH = 25;
+const DEFAULT_NAME_SUFFIX = ' (copy)';
+
+/** Source fields a clone carries beyond name+body (the create surface takes only name+body). */
+interface CloneMetadata {
+	contentType: string;
+	language: string;
+	context: unknown;
+	cloneOverrides: unknown;
+	description: string | null | undefined;
+}
+
+interface CloneUpdate extends CloneMetadata {
+	id: string;
+	body: string;
+}
+
+export interface TemplateCloneDeps {
+	getTemplate(session: Session, id: string): Promise<FullTemplateFragment>;
+	createTemplate(session: Session, name: string, orgId: string): Promise<{ id: string }>;
+	updateTemplate(session: Session, update: CloneUpdate): Promise<void>;
+	deleteTemplate(session: Session, id: string): Promise<void>;
+}
+
+export const defaultTemplateCloneDeps: TemplateCloneDeps = {
+	getTemplate: (session, id) => session.getTemplate(id),
+	async createTemplate(session, name, orgId) {
+		const response = await session.sdk?.createTemplateMinimal({ name, orgId, body: '' });
+		const template = response?.template;
+		if (!template?.id) throw new Error('createTemplateMinimal returned no template; the clone failed.');
+		return { id: template.id };
+	},
+	async updateTemplate(session, update) {
+		// updateTemplate (full TemplateUpdateInput) carries the rewritten body AND
+		// the source metadata, so a python/non-jinja or context-bearing template
+		// clones faithfully rather than as a default jinja/text template.
+		const response = await session.sdk?.updateTemplate({
+			template: {
+				id: update.id,
+				body: update.body,
+				contentType: update.contentType,
+				language: update.language,
+				context: update.context,
+				cloneOverrides: update.cloneOverrides,
+				description: update.description,
+			},
+		});
+		if (!response?.template?.id) throw new Error('updateTemplate returned no template; the clone failed.');
+	},
+	async deleteTemplate(session, id) {
+		const response = await session.sdk?.deleteTemplate({ id });
+		if (!response?.deleteTemplate) throw new Error('deleteTemplate returned no id; a rollback delete failed.');
+	},
+};
+
+/** Template ids resolve case-insensitively in Rewst; canonicalize so case-variant refs dedupe. */
+function canon(id: string): string {
+	return id.toLowerCase();
+}
+
+/**
+ * Rewrites every template('OLD') call whose id is in the map to template('NEW'),
+ * leaving the surrounding Jinja/quotes intact and leaving references not in the
+ * map (foreign-org or missing templates) untouched. Lookup is case-insensitive
+ * to match the canonicalized node keys. Uses a fresh regex so the shared global
+ * pattern's lastIndex is never a shared side effect.
+ */
+export function rewriteReferences(body: string, oldToNew: ReadonlyMap<string, string>): string {
+	const pattern = new RegExp(TEMPLATE_PATTERN.source, 'g');
+	return body.replace(pattern, (full: string, oldId: string) => {
+		const newId = oldToNew.get(canon(oldId));
+		return newId ? full.replace(oldId, newId) : full;
+	});
+}
+
+interface ClonedNode {
+	oldId: string;
+	newId: string;
+	name: string;
+}
+
+/** Best-effort delete of every already-created clone; returns ids that failed. */
+async function rollback(deps: TemplateCloneDeps, session: Session, created: readonly ClonedNode[]): Promise<string[]> {
+	const failed: string[] = [];
+	for (const { newId } of created) {
+		try {
+			await deps.deleteTemplate(session, newId);
+		} catch {
+			failed.push(newId);
+		}
+	}
+	return failed;
+}
+
+export async function runBundleClone(
+	input: Record<string, unknown>,
+	ctx: CapabilityContext,
+	deps: TemplateCloneDeps = defaultTemplateCloneDeps,
+): Promise<string> {
+	const targetOrgId = requireString(input, 'orgId');
+	const rootId = requireString(input, 'rootTemplateId');
+	const sourceOrgIdArg = asString(input, 'sourceOrgId');
+
+	let namePrefix = '';
+	if (input.namePrefix !== undefined) {
+		if (typeof input.namePrefix !== 'string') throw new Error('"namePrefix" must be a string.');
+		namePrefix = input.namePrefix;
+	}
+	let nameSuffix = DEFAULT_NAME_SUFFIX;
+	if (input.nameSuffix !== undefined) {
+		if (typeof input.nameSuffix !== 'string') throw new Error('"nameSuffix" must be a string.');
+		nameSuffix = input.nameSuffix;
+	}
+	const maxTemplates = Math.min(asPositiveInt(input, 'maxTemplates') ?? DEFAULT_MAX_TEMPLATES, MAX_MAX_TEMPLATES);
+	const maxDepth = Math.min(asPositiveInt(input, 'maxDepth') ?? DEFAULT_MAX_DEPTH, MAX_MAX_DEPTH);
+
+	// Phase 0 — fetch the root (from any session that can read it) and pin the source org.
+	const fetched = await getTemplateFromAnySession(ctx.sessions, deps.getTemplate, rootId);
+	if (!fetched) {
+		throw new Error(`Root template ${rootId} is not reachable in any active session.`);
+	}
+	const { template: root, session: sourceSession } = fetched;
+	const sourceOrgId = root.orgId;
+	if (sourceOrgIdArg && sourceOrgId !== sourceOrgIdArg) {
+		throw new Error(`Root template ${rootId} is in org ${sourceOrgId}, not ${sourceOrgIdArg}.`);
+	}
+
+	// Phase 1 — walk the transitive template() graph by RE-FETCHING each remote
+	// template (local link refs are unreliable). Cycle-safe via `visited`; keys
+	// are canonicalized so case-variant references resolve to one clone.
+	const rootKey = canon(rootId);
+	const nodes = new Map<string, { template: FullTemplateFragment; body: string }>();
+	nodes.set(rootKey, { template: root, body: root.body });
+	const visited = new Set<string>([rootKey]);
+	const queue: { id: string; depth: number }[] = [{ id: rootKey, depth: 0 }];
+	const missingReferences: string[] = [];
+	const foreignReferences: { refId: string; orgId: string }[] = [];
+	const skippedDepth: string[] = [];
+	const skippedCap: string[] = [];
+
+	while (queue.length > 0) {
+		const { id, depth } = queue.shift()!;
+		const { body } = nodes.get(id)!;
+		if (depth >= maxDepth) {
+			// Record the children actually dropped by the depth cap (not this node,
+			// which was already cloned), mirroring the other skip lists.
+			for (const rawRef of findAllTemplateReferences(body)) {
+				const refKey = canon(rawRef);
+				if (!visited.has(refKey)) {
+					visited.add(refKey);
+					skippedDepth.push(refKey);
+				}
+			}
+			continue;
+		}
+		for (const rawRef of findAllTemplateReferences(body)) {
+			const refKey = canon(rawRef);
+			if (visited.has(refKey)) continue;
+			visited.add(refKey);
+			if (nodes.size >= maxTemplates) {
+				skippedCap.push(refKey);
+				continue;
+			}
+			let referenced: FullTemplateFragment;
+			try {
+				referenced = await deps.getTemplate(sourceSession, refKey);
+			} catch {
+				missingReferences.push(refKey);
+				continue;
+			}
+			if (referenced.orgId !== sourceOrgId) {
+				foreignReferences.push({ refId: refKey, orgId: referenced.orgId });
+				continue;
+			}
+			nodes.set(refKey, { template: referenced, body: referenced.body });
+			queue.push({ id: refKey, depth: depth + 1 });
+		}
+	}
+
+	// Phase 2 — one approval scoped to (target org, root): a re-clone of the same
+	// root reuses it, but a different root (or a different write tool) re-prompts.
+	const orgName = orgDisplayName(ctx);
+	const scope: MutationScope = {
+		scopeId: `clone:${rootId}`,
+		scopeName: `clone of "${root.name}" (${nodes.size} templates)`,
+		orgId: targetOrgId,
+		orgName,
+	};
+	const summary = `Clone template "${root.name}" (${rootId}) and ${nodes.size - 1} referenced template(s) into org "${orgName}" (${targetOrgId})`;
+
+	return withMutationApproval(scope, summary, async () => {
+		const oldToNew = new Map<string, string>();
+		const created: ClonedNode[] = [];
+		try {
+			// Phase 3a — create an empty template per node to mint new ids first, so
+			// a body referencing a not-yet-created sibling never lands un-rewritten.
+			for (const [oldKey, { template }] of nodes) {
+				const name = `${namePrefix}${template.name}${nameSuffix}`;
+				const { id: newId } = await deps.createTemplate(ctx.session, name, targetOrgId);
+				oldToNew.set(oldKey, newId);
+				created.push({ oldId: oldKey, newId, name });
+			}
+			// Phase 3b — rewrite each body to the new ids and write back source metadata.
+			for (const [oldKey, { template, body }] of nodes) {
+				const newId = oldToNew.get(oldKey)!;
+				await deps.updateTemplate(ctx.session, {
+					id: newId,
+					body: rewriteReferences(body, oldToNew),
+					contentType: template.contentType,
+					language: template.language,
+					context: template.context,
+					cloneOverrides: template.cloneOverrides,
+					description: template.description,
+				});
+			}
+		} catch (error) {
+			const rollbackFailures = await rollback(deps, ctx.session, created);
+			const reason = error instanceof Error ? error.message : String(error);
+			const detail = rollbackFailures.length
+				? ` Rolled back ${created.length - rollbackFailures.length}/${created.length} created template(s); could not delete: ${rollbackFailures.join(', ')}.`
+				: ` Rolled back all ${created.length} created template(s).`;
+			throw new Error(`Clone failed: ${reason}${detail}`);
+		}
+
+		return json({
+			status: 'cloned',
+			targetOrgId,
+			targetOrgName: orgName,
+			sourceOrgId,
+			rootTemplateId: rootId,
+			newRootTemplateId: oldToNew.get(rootKey),
+			count: created.length,
+			idMap: created.map(node => ({ oldId: node.oldId, newId: node.newId, name: node.name })),
+			foreignReferences,
+			missingReferences,
+			skipped: { depth: skippedDepth, cap: skippedCap },
+			message: `Cloned ${created.length} template(s) into org "${orgName}". template() references were rewritten to the new ids, and each clone's contentType/language/context/cloneOverrides were copied (tags were not). Foreign-org and missing references were left unchanged — review foreignReferences and missingReferences.`,
+		});
+	});
+}
+
+const bundleCloneSpec: ToolSpec = {
+	name: 'buddy_template_bundle_clone',
+	args: '{"orgId": string, "rootTemplateId": string, "sourceOrgId"?: string, "namePrefix"?: string, "nameSuffix"?: string, "maxTemplates"?: number, "maxDepth"?: number}',
+	description:
+		"Deep-copy a Rewst template and the templates it references (transitively, via template('<id>') calls in the body) into NEW templates in a target org, rewriting every reference to the new template ids. Each clone copies the source name, body, contentType, language, JSON context and cloneOverrides; tags are NOT copied (they are org-scoped) and references inside context/cloneOverrides are not followed. orgId is the TARGET org the clones are created in — it must have write tools enabled, be on the write allowlist, and pass per-call approval. The source org is taken from the root template (verify it with sourceOrgId). References to templates in a different org, or that no longer exist, are left pointing at the original id and reported as foreignReferences / missingReferences. Nodes beyond maxTemplates (default 50, max 200) or maxDepth (default 10, max 25) are not cloned and are reported under skipped.cap / skipped.depth. On any failure mid-clone the templates created so far are deleted (rollback). Returns the old→new id map and the new root id; it does not create a local file link — use buddy_template_link for that.",
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			rootTemplateId: { type: 'string', description: 'Id of the root template to deep-clone.' },
+			sourceOrgId: {
+				type: 'string',
+				description:
+					'Optional id of the org the root and its references live in. Verified against the root; defaults to the root’s org.',
+			},
+			namePrefix: { type: 'string', description: 'Optional prefix for cloned template names.' },
+			nameSuffix: {
+				type: 'string',
+				description: 'Optional suffix for cloned template names. Defaults to " (copy)".',
+			},
+			maxTemplates: {
+				type: 'number',
+				description: 'Max total templates to clone (root + references). Default 50, capped at 200.',
+			},
+			maxDepth: { type: 'number', description: 'Max reference depth to walk. Default 10, capped at 25.' },
+		},
+		required: ['orgId', 'rootTemplateId'],
+	},
+};
+
+export const TEMPLATE_CLONE_CAPABILITIES: Capability[] = [
+	{ spec: bundleCloneSpec, access: 'write', chat: false, mcp: true, run: (input, ctx) => runBundleClone(input, ctx) },
+];

--- a/src/capabilities/templateCloneCapabilities.ts
+++ b/src/capabilities/templateCloneCapabilities.ts
@@ -195,7 +195,12 @@ export async function runBundleClone(
 			let referenced: FullTemplateFragment;
 			try {
 				referenced = await deps.getTemplate(sourceSession, refKey);
-			} catch {
+			} catch (error) {
+				// Only a genuine "not found" is a missing reference. A transient
+				// auth/network/SDK failure must abort (before any writes) rather than
+				// silently producing a partial clone with stale references.
+				const message = error instanceof Error ? error.message : String(error);
+				if (!/not found/i.test(message)) throw error;
 				missingReferences.push(refKey);
 				continue;
 			}
@@ -301,5 +306,13 @@ const bundleCloneSpec: ToolSpec = {
 };
 
 export const TEMPLATE_CLONE_CAPABILITIES: Capability[] = [
-	{ spec: bundleCloneSpec, access: 'write', chat: false, mcp: true, run: (input, ctx) => runBundleClone(input, ctx) },
+	{
+		spec: bundleCloneSpec,
+		access: 'write',
+		chat: false,
+		mcp: true,
+		// Explicit: a write tool is org-scoped (the allowlist needs a concrete orgId).
+		requiresOrg: true,
+		run: (input, ctx) => runBundleClone(input, ctx),
+	},
 ];

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -195,6 +195,19 @@ suite('Unit: templateLinkCapabilities', () => {
 			assert.strictEqual(out.status, 'linked');
 			assert.ok(LinkManager.isLinked(uri));
 		});
+
+		test('propagates an operational fetch error instead of reporting template_not_found', async () => {
+			const { deps, uri } = makeLinkDeps({
+				getTemplate: async () => {
+					throw new Error('Network error: ECONNRESET');
+				},
+			});
+			await assert.rejects(
+				() => runLink({ templateId: 't1', uri: 'greeting.j2' }, makeCtx(), deps),
+				/Network error/,
+			);
+			assert.ok(!LinkManager.isLinked(uri), 'no link created on an operational failure');
+		});
 	});
 
 	suite('resolvePathToUri', () => {

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -1,0 +1,280 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import type { CapabilityContext } from '@capabilities';
+import { LinkManager, SyncOnSaveManager, type TemplateLink } from '@models';
+import type { FullTemplateFragment, Session } from '@sessions';
+import { getHash } from '@utils';
+import vscode from 'vscode';
+import {
+	resolvePathToUri,
+	runLink,
+	runSyncOnSave,
+	runUnlink,
+	TEMPLATE_LINK_CAPABILITIES,
+	type TemplateLinkDeps,
+} from './templateLinkCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+const REF_UUID = '11111111-1111-1111-1111-111111111111';
+const BODY_WITH_REF = `{{ template('${REF_UUID}') }}`;
+
+function makeCtx(): CapabilityContext {
+	const session = {} as unknown as Session;
+	return { session, orgId: 'org-1', sessions: [session] };
+}
+
+function fakeTemplate(over: Partial<FullTemplateFragment> = {}): FullTemplateFragment {
+	return {
+		id: 't1',
+		name: 'Greeting',
+		body: 'remote body',
+		updatedAt: '2024-05-05T00:00:00Z',
+		orgId: 'org-1',
+		organization: { id: 'org-1', name: 'Org One' },
+		contentType: 'text',
+		language: 'jinja',
+		tags: [],
+		...over,
+	} as unknown as FullTemplateFragment;
+}
+
+interface LinkDepOpts {
+	resolveUndefined?: boolean;
+	exists?: boolean;
+	body?: string;
+	getTemplate?: () => Promise<FullTemplateFragment>;
+}
+
+function makeLinkDeps(opts: LinkDepOpts = {}) {
+	const uri = vscode.Uri.file('/ws/greeting.j2');
+	const resolved = opts.resolveUndefined ? undefined : uri;
+	const calls = { getTemplate: 0, readBody: 0 };
+	const deps: TemplateLinkDeps = {
+		resolvePathToUri: () => resolved,
+		fileExists: async () => opts.exists ?? true,
+		readBody: async () => {
+			calls.readBody++;
+			return opts.body ?? BODY_WITH_REF;
+		},
+		getTemplate: async () => {
+			calls.getTemplate++;
+			return opts.getTemplate ? opts.getTemplate() : fakeTemplate();
+		},
+	};
+	return { deps, calls, uri };
+}
+
+function addLink(fsPath: string, templateId = 't1', orgId = 'org-1'): vscode.Uri {
+	const uri = vscode.Uri.file(fsPath);
+	const link: TemplateLink = {
+		uriString: uri.toString(),
+		org: { id: orgId, name: 'Org' },
+		type: 'Template',
+		template: { id: templateId, name: 'Greeting', updatedAt: '1' } as unknown as TemplateLink['template'],
+		bodyHash: 'h',
+	};
+	LinkManager.addLink(link);
+	return uri;
+}
+
+suite('Unit: templateLinkCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	suite('capability descriptors', () => {
+		test('all three are read tools, mcp-only, org-agnostic', () => {
+			for (const name of ['buddy_template_link', 'buddy_template_unlink', 'buddy_template_sync_on_save']) {
+				const c = TEMPLATE_LINK_CAPABILITIES.find(candidate => candidate.spec.name === name);
+				assert.ok(c, `missing ${name}`);
+				assert.strictEqual(c.access, 'read', `${name} access`);
+				assert.strictEqual(c.mcp, true, `${name} mcp`);
+				assert.strictEqual(c.chat, false, `${name} chat`);
+				assert.strictEqual(c.requiresOrg, false, `${name} requiresOrg`);
+			}
+		});
+	});
+
+	suite('buddy_template_link', () => {
+		test('links an existing file, storing the sentinel updatedAt and local bodyHash', async () => {
+			const { deps, uri } = makeLinkDeps({ body: BODY_WITH_REF });
+			const out = JSON.parse(await runLink({ templateId: 't1', uri: 'greeting.j2' }, makeCtx(), deps));
+
+			assert.strictEqual(out.status, 'linked');
+			assert.strictEqual(out.templateId, 't1');
+			assert.strictEqual(out.orgId, 'org-1');
+			assert.deepStrictEqual(out.referencedTemplateIds, [REF_UUID]);
+			assert.ok(LinkManager.isLinked(uri), 'link persisted');
+			const link = LinkManager.getTemplateLink(uri);
+			assert.strictEqual(link.template.updatedAt, '0', 'stores sentinel, not real remote updatedAt');
+			assert.strictEqual((link.template as { body?: unknown }).body, '');
+			assert.strictEqual(link.bodyHash, getHash(BODY_WITH_REF));
+		});
+
+		test('returns invalid_path when the path cannot be resolved', async () => {
+			const { deps } = makeLinkDeps({ resolveUndefined: true });
+			const out = JSON.parse(await runLink({ templateId: 't1', uri: '???' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'invalid_path');
+		});
+
+		test('returns file_not_found when the file does not exist', async () => {
+			const { deps, uri } = makeLinkDeps({ exists: false });
+			const out = JSON.parse(await runLink({ templateId: 't1', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'file_not_found');
+			assert.ok(!LinkManager.isLinked(uri));
+		});
+
+		test('refuses to relink an already-linked file unless overwrite is set', async () => {
+			const uri = vscode.Uri.file('/ws/greeting.j2');
+			addLink('/ws/greeting.j2', 'old-template');
+			const { deps } = makeLinkDeps({});
+
+			const blocked = JSON.parse(await runLink({ templateId: 't1', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(blocked.status, 'already_linked');
+			assert.strictEqual(LinkManager.getTemplateLink(uri).template.id, 'old-template', 'unchanged');
+
+			const replaced = JSON.parse(
+				await runLink({ templateId: 't1', uri: 'greeting.j2', overwrite: true }, makeCtx(), deps),
+			);
+			assert.strictEqual(replaced.status, 'linked');
+			assert.strictEqual(LinkManager.getTemplateLink(uri).template.id, 't1', 'replaced');
+		});
+
+		test('returns template_not_found when no session resolves the template', async () => {
+			const { deps, uri } = makeLinkDeps({
+				getTemplate: async () => {
+					throw new Error('not found');
+				},
+			});
+			const out = JSON.parse(await runLink({ templateId: 'missing', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'template_not_found');
+			assert.ok(!LinkManager.isLinked(uri));
+		});
+
+		test('returns org_mismatch when the template is in a different org than requested', async () => {
+			const { deps, uri } = makeLinkDeps({ getTemplate: async () => fakeTemplate({ orgId: 'org-2' }) });
+			const out = JSON.parse(
+				await runLink({ templateId: 't1', uri: 'greeting.j2', orgId: 'org-1' }, makeCtx(), deps),
+			);
+			assert.strictEqual(out.status, 'org_mismatch');
+			assert.ok(!LinkManager.isLinked(uri));
+		});
+
+		test('rejects a missing templateId', async () => {
+			const { deps } = makeLinkDeps({});
+			await assert.rejects(
+				() => runLink({ uri: 'greeting.j2' }, makeCtx(), deps),
+				/Missing required string argument "templateId"/,
+			);
+		});
+
+		test('finds the template via a later session when the first cannot', async () => {
+			const uri = vscode.Uri.file('/ws/greeting.j2');
+			const s1 = {} as unknown as Session;
+			const s2 = {} as unknown as Session;
+			const deps: TemplateLinkDeps = {
+				resolvePathToUri: () => uri,
+				fileExists: async () => true,
+				readBody: async () => BODY_WITH_REF,
+				getTemplate: async session => {
+					if (session === s1) throw new Error('first session cannot read it');
+					return fakeTemplate();
+				},
+			};
+			const ctx: CapabilityContext = { session: s1, orgId: 'org-1', sessions: [s1, s2] };
+			const out = JSON.parse(await runLink({ templateId: 't1', uri: 'greeting.j2' }, ctx, deps));
+			assert.strictEqual(out.status, 'linked');
+			assert.ok(LinkManager.isLinked(uri));
+		});
+	});
+
+	suite('resolvePathToUri', () => {
+		test('returns undefined for empty or whitespace input', () => {
+			assert.strictEqual(resolvePathToUri(''), undefined);
+			assert.strictEqual(resolvePathToUri('   '), undefined);
+		});
+
+		test('parses a file:// URI', () => {
+			const u = resolvePathToUri('file:///ws/x.j2');
+			assert.ok(u);
+			assert.strictEqual(u.fsPath, '/ws/x.j2');
+		});
+
+		test('treats an absolute path as a file URI', () => {
+			const u = resolvePathToUri('/ws/x.j2');
+			assert.ok(u);
+			assert.strictEqual(u.scheme, 'file');
+			assert.strictEqual(u.fsPath, '/ws/x.j2');
+		});
+
+		test('resolves a relative path against a workspace folder, or undefined without one', () => {
+			const folders = vscode.workspace.workspaceFolders;
+			const u = resolvePathToUri('sub/x.j2');
+			if (!folders || folders.length === 0) {
+				assert.strictEqual(u, undefined);
+			} else {
+				assert.ok(u);
+				assert.ok(u.fsPath.endsWith('/sub/x.j2'));
+			}
+		});
+	});
+
+	suite('buddy_template_unlink', () => {
+		test('removes the link for a linked file', async () => {
+			const uri = addLink('/ws/greeting.j2', 't1');
+			const out = JSON.parse(await runUnlink({ uri: 'greeting.j2' }, makeCtx()));
+			assert.strictEqual(out.status, 'unlinked');
+			assert.strictEqual(out.templateId, 't1');
+			assert.ok(!LinkManager.isLinked(uri), 'link removed');
+		});
+
+		test('returns not_linked when the file is not linked', async () => {
+			const out = JSON.parse(await runUnlink({ uri: 'nope.j2' }, makeCtx()));
+			assert.strictEqual(out.status, 'not_linked');
+		});
+
+		test('rejects a missing uri', async () => {
+			await assert.rejects(() => runUnlink({}, makeCtx()), /Missing required string argument "uri"/);
+		});
+	});
+
+	suite('buddy_template_sync_on_save', () => {
+		test('enables sync-on-save for a linked file', async () => {
+			const uri = addLink('/ws/greeting.j2', 't1');
+			const out = JSON.parse(await runSyncOnSave({ uri: 'greeting.j2', enabled: true }, makeCtx()));
+			assert.strictEqual(out.status, 'updated');
+			assert.strictEqual(out.syncOnSave, true);
+			assert.ok(SyncOnSaveManager.isUriSynced(uri));
+		});
+
+		test('disables sync-on-save for a linked file', async () => {
+			const uri = addLink('/ws/greeting.j2', 't1');
+			SyncOnSaveManager.enableSync(uri);
+			const out = JSON.parse(await runSyncOnSave({ uri: 'greeting.j2', enabled: false }, makeCtx()));
+			assert.strictEqual(out.syncOnSave, false);
+			assert.ok(!SyncOnSaveManager.isUriSynced(uri));
+		});
+
+		test('returns not_linked when the file is not linked', async () => {
+			const out = JSON.parse(await runSyncOnSave({ uri: 'nope.j2', enabled: true }, makeCtx()));
+			assert.strictEqual(out.status, 'not_linked');
+		});
+
+		test('rejects a non-boolean enabled', async () => {
+			addLink('/ws/greeting.j2', 't1');
+			await assert.rejects(
+				() => runSyncOnSave({ uri: 'greeting.j2', enabled: 'yes' }, makeCtx()),
+				/"enabled" must be a boolean/,
+			);
+		});
+	});
+});

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -1,0 +1,314 @@
+import { LinkManager, SyncOnSaveManager, type TemplateLink } from '@models';
+import type { FullTemplateFragment, Session } from '@sessions';
+import { findAllTemplateReferences, getHash, uriExists } from '@utils';
+import vscode from 'vscode';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asString, getTemplateFromAnySession, json, requireString } from './inputHelpers';
+import { resolveLinkedUri } from './templateSyncCapabilities';
+
+/**
+ * Local link-management tools for the MCP surface: associate a local file with a
+ * Rewst template, remove that association, and toggle sync-on-save. They mutate
+ * only the extension's own link state and never call a Rewst write API, so —
+ * per the project's decision that local-only mutations are read-tier — they are
+ * exposed as access:'read' (ungated). They reach the LinkManager /
+ * SyncOnSaveManager singletons directly, like list_template_links. They derive
+ * the org from the link/template, not from ctx.orgId (requiresOrg is false).
+ *
+ * MCP arguments are not validated against inputSchema, so every input is coerced
+ * here (requireString / explicit boolean check).
+ */
+
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+// Posix (/x) or Windows (C:\x, C:/x) absolute path.
+const ABSOLUTE_RE = /^(?:[a-zA-Z]:[\\/]|[\\/])/;
+
+/**
+ * Resolves a path or file URI to a vscode.Uri WITHOUT requiring it to be linked
+ * (buddy_template_link targets a not-yet-linked file, so resolveLinkedUri does
+ * not apply). file:// URIs are parsed as-is, absolute paths become file URIs,
+ * and a bare relative path is resolved against the first workspace folder.
+ * Returns undefined when the input is empty, malformed, or relative with no
+ * workspace open.
+ */
+export function resolvePathToUri(pathOrUri: string): vscode.Uri | undefined {
+	const value = pathOrUri.trim();
+	if (value === '') return undefined;
+	try {
+		if (SCHEME_RE.test(value)) return vscode.Uri.parse(value);
+		if (ABSOLUTE_RE.test(value)) return vscode.Uri.file(value);
+		const folder = vscode.workspace.workspaceFolders?.[0];
+		if (!folder) return undefined;
+		return vscode.Uri.joinPath(folder.uri, value);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Seams for unit testing; production uses {@link defaultTemplateLinkDeps}. */
+export interface TemplateLinkDeps {
+	resolvePathToUri(pathOrUri: string): vscode.Uri | undefined;
+	fileExists(uri: vscode.Uri): Promise<boolean>;
+	readBody(uri: vscode.Uri): Promise<string>;
+	getTemplate(session: Session, templateId: string): Promise<FullTemplateFragment>;
+}
+
+export const defaultTemplateLinkDeps: TemplateLinkDeps = {
+	resolvePathToUri,
+	fileExists: uri => uriExists(uri),
+	async readBody(uri) {
+		const doc = await vscode.workspace.openTextDocument(uri);
+		return doc.getText();
+	},
+	getTemplate: (session, templateId) => session.getTemplate(templateId),
+};
+
+export async function runLink(
+	input: Record<string, unknown>,
+	ctx: CapabilityContext,
+	deps: TemplateLinkDeps = defaultTemplateLinkDeps,
+): Promise<string> {
+	const templateId = requireString(input, 'templateId');
+	const rawUri = requireString(input, 'uri');
+	const requestedOrgId = asString(input, 'orgId');
+	const overwrite = input.overwrite === true;
+
+	const uri = deps.resolvePathToUri(rawUri);
+	if (!uri) {
+		return json({
+			status: 'invalid_path',
+			uri: rawUri,
+			message:
+				'Could not resolve this to a file. Pass an absolute path, a file:// URI, or a path relative to an open workspace folder.',
+		});
+	}
+	if (!(await deps.fileExists(uri))) {
+		return json({
+			status: 'file_not_found',
+			path: uri.fsPath,
+			message: 'No file exists at this path. Create and save the file first, then link it.',
+		});
+	}
+	if (LinkManager.isLinked(uri) && !overwrite) {
+		return json({
+			status: 'already_linked',
+			path: uri.fsPath,
+			message:
+				'This file is already linked to a template. Pass overwrite:true to replace the link, or unlink it first.',
+		});
+	}
+
+	const found = await getTemplateFromAnySession(ctx.sessions, deps.getTemplate, templateId);
+	if (!found) {
+		return json({
+			status: 'template_not_found',
+			templateId,
+			message:
+				'No template with this id is reachable in the active session(s). Check the id and that you are signed into its org.',
+		});
+	}
+	const template = found.template;
+	if (requestedOrgId && template.orgId !== requestedOrgId) {
+		return json({
+			status: 'org_mismatch',
+			templateId,
+			templateOrgId: template.orgId,
+			requestedOrgId,
+			message: `Template ${templateId} is in org ${template.orgId}, not ${requestedOrgId}.`,
+		});
+	}
+
+	const body = await deps.readBody(uri);
+	const referencedTemplateIds = findAllTemplateReferences(body);
+	const bodyHash = getHash(body);
+	const orgName = template.organization?.name ?? template.orgId;
+	// Mirror LinkTemplateInteractive: store the sentinel updatedAt '0' (not the
+	// real remote timestamp) and an empty body so the first sync reconciles
+	// instead of appearing already in-sync. The bodyHash is of the LOCAL file.
+	template.updatedAt = '0';
+	template.body = '';
+	const templateLink: TemplateLink = {
+		type: 'Template',
+		uriString: uri.toString(),
+		org: { id: template.orgId, name: orgName },
+		template,
+		bodyHash,
+		referencedTemplateIds,
+	};
+	LinkManager.addLink(templateLink);
+	// addLink only schedules a debounced persist; flush so the link survives
+	// before this MCP call returns.
+	await LinkManager.flush();
+
+	return json({
+		status: 'linked',
+		path: uri.fsPath,
+		uri: uri.toString(),
+		templateId: template.id,
+		templateName: template.name,
+		orgId: template.orgId,
+		orgName,
+		referencedTemplateIds,
+		message:
+			'Linked. The link starts out-of-sync (updatedAt sentinel); call buddy_template_sync_status to compare, or buddy_template_sync with a direction to reconcile.',
+	});
+}
+
+export async function runUnlink(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
+	const rawUri = requireString(input, 'uri');
+	const resolved = resolveLinkedUri(rawUri);
+	if (!resolved) {
+		return json({
+			status: 'not_linked',
+			uri: rawUri,
+			message:
+				'No template is linked to this file (or the path matches more than one link). Check list_template_links and pass a fuller path.',
+		});
+	}
+	const { uri, link } = resolved;
+	const { id, name } = link.template;
+	const orgId = link.org.id;
+	// removeLink takes the uriString (not a Uri) and clears the secondary
+	// indexes; the fired onLinksSaved prunes any sync-on-save entry for this uri.
+	LinkManager.removeLink(link.uriString);
+	await LinkManager.flush();
+	return json({
+		status: 'unlinked',
+		path: uri.fsPath,
+		templateId: id,
+		templateName: name,
+		orgId,
+		message: 'Link removed. The local file and the remote template are untouched.',
+	});
+}
+
+export async function runSyncOnSave(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
+	const rawUri = requireString(input, 'uri');
+	const enabled = input.enabled;
+	if (typeof enabled !== 'boolean') {
+		throw new Error('"enabled" must be a boolean (true to enable sync-on-save, false to disable).');
+	}
+	const resolved = resolveLinkedUri(rawUri);
+	if (!resolved) {
+		return json({
+			status: 'not_linked',
+			uri: rawUri,
+			message:
+				'No template is linked to this file (or the path matches more than one link). Link it first with buddy_template_link.',
+		});
+	}
+	const { uri, link } = resolved;
+	if (enabled) {
+		SyncOnSaveManager.enableSync(uri);
+	} else {
+		SyncOnSaveManager.disableSync(uri);
+	}
+	// Report the effective state — it depends on the rewst-buddy.syncOnSaveByDefault
+	// mode, not just raw set membership.
+	const syncOnSave = SyncOnSaveManager.isUriSynced(uri);
+	return json({
+		status: 'updated',
+		path: uri.fsPath,
+		templateId: link.template.id,
+		templateName: link.template.name,
+		syncOnSave,
+		message: syncOnSave
+			? 'Sync-on-save is ON: saving this file uploads it to Rewst.'
+			: 'Sync-on-save is OFF: saving this file does not upload it.',
+	});
+}
+
+const linkSpec: ToolSpec = {
+	name: 'buddy_template_link',
+	args: '{"templateId": string, "uri": string, "orgId"?: string, "overwrite"?: boolean}',
+	description:
+		'Associate an existing local file with an existing Rewst template, so it can be synced. Does not create the file or the template. Identify the file by an absolute path, a workspace-relative path, or a file:// URI. The link starts out-of-sync on purpose — afterwards call buddy_template_sync_status to compare, or buddy_template_sync to reconcile. Returns already_linked unless overwrite is true, and invalid_path / file_not_found / template_not_found / org_mismatch on the obvious failures. This changes only local link state (no Rewst write).',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			templateId: {
+				type: 'string',
+				description: 'Id of the existing Rewst template to link the file to (from list_templates).',
+			},
+			uri: {
+				type: 'string',
+				description: 'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
+			},
+			orgId: {
+				type: 'string',
+				description: 'Optional org id to verify the template belongs to. Defaults to the template’s own org.',
+			},
+			overwrite: {
+				type: 'boolean',
+				description: 'If the file is already linked, replace the existing link instead of failing. Default false.',
+			},
+		},
+		required: ['templateId', 'uri'],
+	},
+};
+
+const unlinkSpec: ToolSpec = {
+	name: 'buddy_template_unlink',
+	args: '{"uri": string}',
+	description:
+		'Remove the link between a local file and its Rewst template. The local file and the remote template are left untouched; only the local association (and its sync-on-save setting) is removed. Identify the file by the path shown in list_template_links or its file URI. Returns not_linked if no template is linked to it.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Path or file URI of the linked file, as shown by list_template_links.',
+			},
+		},
+		required: ['uri'],
+	},
+};
+
+const syncOnSaveSpec: ToolSpec = {
+	name: 'buddy_template_sync_on_save',
+	args: '{"uri": string, "enabled": boolean}',
+	description:
+		'Enable or disable sync-on-save for a linked file: when on, saving the file in VS Code uploads it to its Rewst template. The file must already be linked (see buddy_template_link). Returns the effective syncOnSave state, which also depends on the rewst-buddy.syncOnSaveByDefault setting. This changes only local state (no Rewst write).',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			uri: { type: 'string', description: 'Path or file URI of the linked file.' },
+			enabled: {
+				type: 'boolean',
+				description: 'true to enable sync-on-save (upload on save), false to disable.',
+			},
+		},
+		required: ['uri', 'enabled'],
+	},
+};
+
+export const TEMPLATE_LINK_CAPABILITIES: Capability[] = [
+	{
+		spec: linkSpec,
+		group: 'workspace',
+		access: 'read',
+		chat: false,
+		mcp: true,
+		requiresOrg: false,
+		run: (input, ctx) => runLink(input, ctx),
+	},
+	{
+		spec: unlinkSpec,
+		group: 'workspace',
+		access: 'read',
+		chat: false,
+		mcp: true,
+		requiresOrg: false,
+		run: (input, ctx) => runUnlink(input, ctx),
+	},
+	{
+		spec: syncOnSaveSpec,
+		group: 'workspace',
+		access: 'read',
+		chat: false,
+		mcp: true,
+		requiresOrg: false,
+		run: (input, ctx) => runSyncOnSave(input, ctx),
+	},
+];

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -1,0 +1,484 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
+import { LinkManager, type SyncDecision, type SyncDecisionContext, type TemplateLink } from '@models';
+import type { FullTemplateFragment, Session } from '@sessions';
+import vscode from 'vscode';
+import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import {
+	matchLinkByPath,
+	resolveLinkedUri,
+	runSync,
+	runSyncStatus,
+	TEMPLATE_SYNC_CAPABILITIES,
+	type TemplateSyncDeps,
+	type TemplateSyncTarget,
+} from './templateSyncCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+interface TargetOpts {
+	action: SyncDecision['action'];
+	orgId?: string;
+	remoteOrgId?: string;
+	templateId?: string;
+	templateName?: string;
+	localBody?: string;
+	remoteBody?: string;
+	localUpdatedAt?: string;
+	remoteUpdatedAt?: string;
+	dirty?: boolean;
+}
+
+function makeTarget(opts: TargetOpts): TemplateSyncTarget {
+	const orgId = opts.orgId ?? 'org-sandbox';
+	const templateId = opts.templateId ?? 't1';
+	const templateName = opts.templateName ?? 'Greeting';
+	const link = {
+		type: 'Template',
+		uriString: 'file:///ws/greeting.j2',
+		org: { id: orgId, name: 'Sandbox' },
+		bodyHash: 'h',
+		template: { id: templateId, name: templateName, updatedAt: opts.localUpdatedAt ?? '1', orgId },
+	} as unknown as TemplateLink;
+	const remoteTemplate = {
+		id: templateId,
+		name: templateName,
+		body: opts.remoteBody ?? 'remote',
+		updatedAt: opts.remoteUpdatedAt ?? '1',
+		orgId: opts.remoteOrgId ?? orgId,
+	} as unknown as FullTemplateFragment;
+	const context: SyncDecisionContext = {
+		link,
+		session: {} as unknown as Session,
+		remoteTemplate,
+		localBody: opts.localBody ?? 'local',
+		decision: { action: opts.action },
+	};
+	const uri = { fsPath: '/ws/greeting.j2', toString: () => 'file:///ws/greeting.j2' } as unknown as vscode.Uri;
+	return { uri, doc: {} as unknown as vscode.TextDocument, context, dirty: opts.dirty ?? false };
+}
+
+interface DepCalls {
+	upload: number;
+	download: number;
+	refreshMetadata: number;
+	saveIfDirty: number;
+}
+
+function makeDeps(target: TemplateSyncTarget | null, overrides: Partial<TemplateSyncDeps> = {}) {
+	const calls: DepCalls = { upload: 0, download: 0, refreshMetadata: 0, saveIfDirty: 0 };
+	const deps: TemplateSyncDeps = {
+		prepare: async () => (target ? { kind: 'ready', target } : { kind: 'unlinked' }),
+		isSyncOnSaveEnabled: () => true,
+		saveIfDirty: async () => {
+			calls.saveIfDirty++;
+		},
+		upload: async () => {
+			calls.upload++;
+			return { templateId: target?.context.link.template.id ?? 't1', name: 'Greeting', updatedAt: '2' };
+		},
+		download: async () => {
+			calls.download++;
+		},
+		refreshMetadata: async () => {
+			calls.refreshMetadata++;
+		},
+		...overrides,
+	};
+	return { deps, calls };
+}
+
+function makeCtx(orgId = 'org-sandbox'): CapabilityContext {
+	const session = {
+		profile: { org: { id: orgId, name: 'Sandbox' }, allManagedOrgs: [{ id: orgId, name: 'Sandbox' }] },
+	} as unknown as Session;
+	return { session, orgId, sessions: [session] };
+}
+
+function addTemplateLink(fsPath: string, orgId = 'org-1', templateId = 't1'): vscode.Uri {
+	const uri = vscode.Uri.file(fsPath);
+	const link: TemplateLink = {
+		uriString: uri.toString(),
+		org: { id: orgId, name: 'Org' },
+		type: 'Template',
+		template: { id: templateId, name: 'Greeting', updatedAt: '1' } as unknown as TemplateLink['template'],
+		bodyHash: 'h',
+	};
+	LinkManager.addLink(link);
+	return uri;
+}
+
+suite('Unit: templateSyncCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	suite('buddy_template_sync_status', () => {
+		test('reports unlinked files without touching Rewst', async () => {
+			const { deps } = makeDeps(null);
+			const out = JSON.parse(await runSyncStatus({ uri: 'unknown.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.linked, false);
+			assert.strictEqual(out.uri, 'unknown.j2');
+		});
+
+		test('maps update-metadata to in-sync with no recommended direction', async () => {
+			const { deps } = makeDeps(makeTarget({ action: 'update-metadata', localBody: 'same', remoteBody: 'same' }));
+			const out = JSON.parse(await runSyncStatus({ uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.linked, true);
+			assert.strictEqual(out.status, 'in-sync');
+			assert.strictEqual(out.recommendedDirection, 'none');
+			assert.strictEqual(out.bodiesMatch, true);
+			assert.strictEqual(out.orgId, 'org-sandbox');
+			assert.strictEqual(out.templateId, 't1');
+			assert.strictEqual(out.syncOnSave, true);
+		});
+
+		test('maps upload-local to local-ahead', async () => {
+			const { deps } = makeDeps(makeTarget({ action: 'upload-local' }));
+			const out = JSON.parse(await runSyncStatus({ uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'local-ahead');
+			assert.strictEqual(out.recommendedDirection, 'upload');
+		});
+
+		test('maps download-remote to remote-only', async () => {
+			const { deps } = makeDeps(makeTarget({ action: 'download-remote', localBody: '' }));
+			const out = JSON.parse(await runSyncStatus({ uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'remote-only');
+			assert.strictEqual(out.recommendedDirection, 'download');
+			assert.strictEqual(out.localEmpty, true);
+		});
+
+		test('maps conflict and surfaces resolve as the recommended direction', async () => {
+			const { deps } = makeDeps(makeTarget({ action: 'conflict' }));
+			const out = JSON.parse(await runSyncStatus({ uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'conflict');
+			assert.strictEqual(out.recommendedDirection, 'resolve');
+		});
+
+		test('rejects a missing uri', async () => {
+			const { deps } = makeDeps(makeTarget({ action: 'update-metadata' }));
+			await assert.rejects(
+				() => runSyncStatus({}, makeCtx(), deps),
+				/Missing required string argument "uri"/,
+			);
+		});
+	});
+
+	suite('buddy_template_sync (auto direction)', () => {
+		test('refreshes metadata when bodies already match, without uploading or prompting', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'update-metadata' }));
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			const out = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+
+			assert.strictEqual(out.status, 'in-sync');
+			assert.strictEqual(calls.refreshMetadata, 1);
+			assert.strictEqual(calls.upload, 0);
+			assert.strictEqual(approverCalled, false);
+		});
+
+		test('downloads when the local file is empty, never prompting for approval', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'download-remote', localBody: '' }));
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+			const out = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'downloaded');
+			assert.strictEqual(calls.download, 1);
+			assert.strictEqual(calls.upload, 0);
+			assert.strictEqual(approverCalled, false);
+		});
+
+		test('uploads local-ahead changes after approval, saving first', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'upload-local', dirty: true }));
+			let approverCalls = 0;
+			setMcpMutationApprover(async () => {
+				approverCalls++;
+				return true;
+			});
+
+			const out = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+
+			assert.strictEqual(out.status, 'uploaded');
+			assert.strictEqual(approverCalls, 1);
+			assert.strictEqual(calls.saveIfDirty, 1);
+			assert.strictEqual(calls.upload, 1);
+		});
+
+		test('does not upload when approval is denied', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'upload-local' }));
+			setMcpMutationApprover(async () => false);
+
+			const out = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+
+			assert.strictEqual(out.status, 'approval_required');
+			assert.strictEqual(calls.upload, 0);
+			assert.strictEqual(calls.saveIfDirty, 0);
+		});
+
+		test('reuses a prior approval and does not prompt twice for the same template', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'upload-local' }));
+			let approverCalls = 0;
+			setMcpMutationApprover(async () => {
+				approverCalls++;
+				return true;
+			});
+
+			const first = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+			const second = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+
+			assert.strictEqual(first.status, 'uploaded');
+			assert.strictEqual(second.status, 'uploaded');
+			assert.strictEqual(approverCalls, 1, 'the second upload reuses the first approval');
+			assert.strictEqual(calls.upload, 2);
+		});
+
+		test('stops on a conflict and changes nothing', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'conflict' }));
+			setMcpMutationApprover(async () => true);
+
+			const out = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+
+			assert.strictEqual(out.status, 'conflict');
+			assert.strictEqual(calls.upload, 0);
+			assert.strictEqual(calls.download, 0);
+			assert.strictEqual(calls.refreshMetadata, 0);
+		});
+	});
+
+	suite('buddy_template_sync (explicit direction)', () => {
+		test('upload resolves a conflict by overwriting Rewst (with approval)', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'conflict' }));
+			setMcpMutationApprover(async () => true);
+
+			const out = JSON.parse(
+				await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2', direction: 'upload' }, makeCtx(), deps),
+			);
+
+			assert.strictEqual(out.status, 'uploaded');
+			assert.strictEqual(calls.upload, 1);
+		});
+
+		test('download resolves a conflict by overwriting the local file, no approval', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'conflict' }));
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			const out = JSON.parse(
+				await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2', direction: 'download' }, makeCtx(), deps),
+			);
+
+			assert.strictEqual(out.status, 'downloaded');
+			assert.strictEqual(calls.download, 1);
+			assert.strictEqual(approverCalled, false);
+		});
+
+		test('an explicit upload still no-ops when bodies already match', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'update-metadata' }));
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			const out = JSON.parse(
+				await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2', direction: 'upload' }, makeCtx(), deps),
+			);
+
+			assert.strictEqual(out.status, 'in-sync');
+			assert.strictEqual(calls.refreshMetadata, 1);
+			assert.strictEqual(calls.upload, 0);
+			assert.strictEqual(approverCalled, false);
+		});
+
+		test('an explicit upload of an empty local file warns that it clears the remote', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'download-remote', localBody: '' }));
+			let promptSummary = '';
+			setMcpMutationApprover(async (_scope, summary) => {
+				promptSummary = summary;
+				return true;
+			});
+
+			const out = JSON.parse(
+				await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2', direction: 'upload' }, makeCtx(), deps),
+			);
+
+			assert.strictEqual(out.status, 'uploaded');
+			assert.match(promptSummary, /CLEARS the remote template body/);
+			assert.match(out.message, /remote template body was cleared/);
+			assert.strictEqual(calls.upload, 1);
+		});
+
+		test('rejects an invalid direction', async () => {
+			const { deps } = makeDeps(makeTarget({ action: 'upload-local' }));
+			await assert.rejects(
+				() => runSync({ orgId: 'org-sandbox', uri: 'greeting.j2', direction: 'sideways' }, makeCtx(), deps),
+				/"direction" must be one of/,
+			);
+		});
+	});
+
+	suite('buddy_template_sync (guards)', () => {
+		test('reports not_linked when no template is linked', async () => {
+			const { deps } = makeDeps(null);
+			const out = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'x.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'not_linked');
+		});
+
+		test('refuses when the linked org differs from the requested org', async () => {
+			const { deps, calls } = makeDeps(makeTarget({ action: 'upload-local', orgId: 'org-OTHER' }));
+			setMcpMutationApprover(async () => true);
+			await assert.rejects(
+				() => runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps),
+				/linked to org org-OTHER, not org-sandbox/,
+			);
+			assert.strictEqual(calls.upload, 0);
+		});
+
+		test('refuses when the remote template belongs to another org', async () => {
+			const { deps, calls } = makeDeps(
+				makeTarget({ action: 'upload-local', orgId: 'org-sandbox', remoteOrgId: 'org-OTHER' }),
+			);
+			setMcpMutationApprover(async () => true);
+			await assert.rejects(
+				() => runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps),
+				/Template t1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(calls.upload, 0);
+		});
+
+		test('rejects a missing orgId', async () => {
+			const { deps } = makeDeps(makeTarget({ action: 'upload-local' }));
+			await assert.rejects(
+				() => runSync({ uri: 'greeting.j2' }, makeCtx(), deps),
+				/Missing required string argument "orgId"/,
+			);
+		});
+	});
+
+	suite('matchLinkByPath', () => {
+		const links = [
+			{ uriString: 'file:///ws/templates/greeting.j2', fsPath: '/ws/templates/greeting.j2' },
+			{ uriString: 'file:///ws/other.j2', fsPath: '/ws/other.j2' },
+		];
+
+		test('matches an exact link URI string', () => {
+			assert.strictEqual(matchLinkByPath('file:///ws/other.j2', links), 'file:///ws/other.j2');
+		});
+
+		test('matches an exact filesystem path', () => {
+			assert.strictEqual(matchLinkByPath('/ws/templates/greeting.j2', links), 'file:///ws/templates/greeting.j2');
+		});
+
+		test('matches a workspace-relative suffix', () => {
+			assert.strictEqual(matchLinkByPath('templates/greeting.j2', links), 'file:///ws/templates/greeting.j2');
+		});
+
+		test('returns undefined when nothing matches', () => {
+			assert.strictEqual(matchLinkByPath('nope.j2', links), undefined);
+		});
+
+		test('returns undefined for an empty request or empty link set', () => {
+			assert.strictEqual(matchLinkByPath('', links), undefined);
+			assert.strictEqual(matchLinkByPath('greeting.j2', []), undefined);
+		});
+
+		test('normalizes backslash separators before matching', () => {
+			assert.strictEqual(matchLinkByPath('templates\\greeting.j2', links), 'file:///ws/templates/greeting.j2');
+		});
+
+		test('strips a leading ./ before matching', () => {
+			assert.strictEqual(matchLinkByPath('./templates/greeting.j2', links), 'file:///ws/templates/greeting.j2');
+		});
+
+		test('matching is case-sensitive', () => {
+			assert.strictEqual(matchLinkByPath('/WS/templates/greeting.j2', links), undefined);
+		});
+
+		test('refuses an ambiguous suffix that matches more than one link', () => {
+			const dupLinks = [
+				{ uriString: 'file:///ws/a/dup.j2', fsPath: '/ws/a/dup.j2' },
+				{ uriString: 'file:///ws/b/dup.j2', fsPath: '/ws/b/dup.j2' },
+			];
+			assert.strictEqual(matchLinkByPath('dup.j2', dupLinks), undefined);
+			// An unambiguous exact path still resolves.
+			assert.strictEqual(matchLinkByPath('/ws/a/dup.j2', dupLinks), 'file:///ws/a/dup.j2');
+		});
+	});
+
+	suite('resolveLinkedUri (against the live LinkManager)', () => {
+		test('resolves an exact file URI to its template link', () => {
+			const uri = addTemplateLink('/ws/templates/greeting.j2', 'org-1', 't1');
+			const resolved = resolveLinkedUri(uri.toString());
+			assert.ok(resolved);
+			assert.strictEqual(resolved.link.template.id, 't1');
+			assert.strictEqual(resolved.uri.toString(), uri.toString());
+		});
+
+		test('resolves an absolute filesystem path', () => {
+			addTemplateLink('/ws/templates/greeting.j2', 'org-1', 't1');
+			assert.strictEqual(resolveLinkedUri('/ws/templates/greeting.j2')?.link.template.id, 't1');
+		});
+
+		test('resolves a workspace-relative suffix', () => {
+			addTemplateLink('/ws/templates/greeting.j2', 'org-1', 't1');
+			assert.strictEqual(resolveLinkedUri('templates/greeting.j2')?.link.template.id, 't1');
+		});
+
+		test('returns undefined for an unlinked path', () => {
+			addTemplateLink('/ws/templates/greeting.j2');
+			assert.strictEqual(resolveLinkedUri('not/linked.j2'), undefined);
+		});
+
+		test('refuses an ambiguous bare filename matching two linked files', () => {
+			addTemplateLink('/ws/a/dup.j2', 'org-1', 't-a');
+			addTemplateLink('/ws/b/dup.j2', 'org-1', 't-b');
+			assert.strictEqual(resolveLinkedUri('dup.j2'), undefined);
+			assert.strictEqual(resolveLinkedUri('/ws/a/dup.j2')?.link.template.id, 't-a');
+		});
+	});
+
+	suite('capability descriptors', () => {
+		function cap(name: string) {
+			const capability = TEMPLATE_SYNC_CAPABILITIES.find(candidate => candidate.spec.name === name);
+			assert.ok(capability, `missing capability ${name}`);
+			return capability;
+		}
+
+		test('buddy_template_sync_status is a read tool, mcp-only, no org required', () => {
+			const c = cap('buddy_template_sync_status');
+			assert.strictEqual(c.access, 'read');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.strictEqual(c.requiresOrg, false);
+		});
+
+		test('buddy_template_sync is a write tool, mcp-only, and stays org-scoped', () => {
+			const c = cap('buddy_template_sync');
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+	});
+});

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -192,6 +192,15 @@ suite('Unit: templateSyncCapabilities', () => {
 			assert.strictEqual(approverCalled, false);
 		});
 
+		test('metadata-sync returns the refreshed remote template name, not the stale link name', async () => {
+			const target = makeTarget({ action: 'update-metadata', templateName: 'Old Name' });
+			target.context.remoteTemplate.name = 'New Remote Name';
+			const { deps } = makeDeps(target);
+			const out = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'in-sync');
+			assert.strictEqual(out.name, 'New Remote Name');
+		});
+
 		test('downloads when the local file is empty, never prompting for approval', async () => {
 			const { deps, calls } = makeDeps(makeTarget({ action: 'download-remote', localBody: '' }));
 			let approverCalled = false;
@@ -359,6 +368,18 @@ suite('Unit: templateSyncCapabilities', () => {
 			const { deps, calls } = makeDeps(
 				makeTarget({ action: 'upload-local', orgId: 'org-sandbox', remoteOrgId: 'org-OTHER' }),
 			);
+			setMcpMutationApprover(async () => true);
+			await assert.rejects(
+				() => runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps),
+				/Template t1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(calls.upload, 0);
+		});
+
+		test('fails closed when the remote template has no orgId', async () => {
+			const target = makeTarget({ action: 'upload-local', orgId: 'org-sandbox' });
+			delete (target.context.remoteTemplate as { orgId?: unknown }).orgId;
+			const { deps, calls } = makeDeps(target);
 			setMcpMutationApprover(async () => true);
 			await assert.rejects(
 				() => runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps),

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -1,0 +1,406 @@
+import {
+	LinkManager,
+	SyncManager,
+	SyncOnSaveManager,
+	type SyncDecision,
+	type SyncDecisionContext,
+	type TemplateLink,
+} from '@models';
+import vscode from 'vscode';
+import type { MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { ORG_ID_PROP, requireString } from './inputHelpers';
+import { orgDisplayName, withMutationApproval } from './mutationApproval';
+
+/**
+ * Template sync capabilities for the MCP surface. The extension already syncs a
+ * linked file to its Rewst template on save, but that flow resolves conflicts
+ * with an interactive VS Code modal that an external MCP client can never see.
+ * These tools expose the same non-interactive primitives (SyncManager) and
+ * replace the modal with an explicit `direction` argument, so a conflict is
+ * surfaced as data the model resolves by choosing a direction — never a silent
+ * overwrite.
+ *
+ * buddy_template_sync_status is read-only and ungated; it derives the org from
+ * the link. buddy_template_sync is a single org-scoped write capability, so the
+ * MCP boundary requires write tools to be enabled and the org to be allowlisted
+ * for the whole tool — every direction, including download — before run() is
+ * reached. Only the per-call VS Code approval prompt is upload-specific:
+ * downloading and metadata refreshes rewrite local state and never prompt.
+ */
+
+/** Identifies one linked file by path/URI and carries the sync state for it. */
+export interface TemplateSyncTarget {
+	uri: vscode.Uri;
+	doc: vscode.TextDocument;
+	context: SyncDecisionContext;
+	dirty: boolean;
+}
+
+export type PreparedTarget = { kind: 'unlinked' } | { kind: 'ready'; target: TemplateSyncTarget };
+
+interface UploadResult {
+	templateId: string;
+	name: string;
+	updatedAt: string;
+}
+
+/**
+ * Seams for unit testing; production uses {@link defaultTemplateSyncDeps}. The
+ * capability logic (direction handling, org verification, approval, JSON
+ * shaping) is tested against a fake deps object so it needs no live workspace.
+ */
+export interface TemplateSyncDeps {
+	prepare(pathOrUri: string): Promise<PreparedTarget>;
+	isSyncOnSaveEnabled(target: TemplateSyncTarget): boolean;
+	saveIfDirty(target: TemplateSyncTarget): Promise<void>;
+	upload(target: TemplateSyncTarget): Promise<UploadResult>;
+	download(target: TemplateSyncTarget): Promise<void>;
+	refreshMetadata(target: TemplateSyncTarget): Promise<void>;
+}
+
+function safeFsPath(uriString: string): string {
+	try {
+		return vscode.Uri.parse(uriString).fsPath;
+	} catch {
+		return '';
+	}
+}
+
+/**
+ * Matches a requested path/URI against the known template links and returns the
+ * link's canonical uriString, or undefined if nothing matches. Pure so it can be
+ * unit-tested: callers pass the link's uriString and its resolved fsPath. The
+ * order matters — an exact link URI or filesystem path wins before the
+ * relative-suffix match used for the workspace-relative paths list_template_links
+ * prints.
+ */
+export function matchLinkByPath(
+	pathOrUri: string,
+	links: readonly { uriString: string; fsPath: string }[],
+): string | undefined {
+	const norm = (value: string): string => value.replace(/\\/g, '/').trim();
+	const wanted = norm(pathOrUri);
+	if (wanted === '') return undefined;
+
+	const exactUri = links.find(link => link.uriString === pathOrUri || norm(link.uriString) === wanted);
+	if (exactUri) return exactUri.uriString;
+
+	const exactPath = links.find(link => link.fsPath !== '' && norm(link.fsPath) === wanted);
+	if (exactPath) return exactPath.uriString;
+
+	const relative = wanted.replace(/^\.?\//, '');
+	if (relative === '') return undefined;
+	const suffixMatches = links.filter(link => {
+		const path = norm(link.fsPath);
+		return path !== '' && (path === relative || path.endsWith(`/${relative}`));
+	});
+	// A bare/relative path that matches more than one linked file is ambiguous;
+	// refuse rather than silently pick an arbitrary one — this resolves a write
+	// target. The caller should pass the full URI or absolute path to disambiguate.
+	if (suffixMatches.length !== 1) return undefined;
+	return suffixMatches[0].uriString;
+}
+
+export function resolveLinkedUri(pathOrUri: string): { uri: vscode.Uri; link: TemplateLink } | undefined {
+	const links = LinkManager.getAllTemplateLinks();
+	const matched = matchLinkByPath(
+		pathOrUri,
+		links.map(link => ({ uriString: link.uriString, fsPath: safeFsPath(link.uriString) })),
+	);
+	if (!matched) return undefined;
+	const link = links.find(candidate => candidate.uriString === matched);
+	if (!link) return undefined;
+	return { uri: vscode.Uri.parse(matched), link };
+}
+
+export const defaultTemplateSyncDeps: TemplateSyncDeps = {
+	async prepare(pathOrUri) {
+		const resolved = resolveLinkedUri(pathOrUri);
+		if (!resolved) return { kind: 'unlinked' };
+		const doc = await vscode.workspace.openTextDocument(resolved.uri);
+		const context = await SyncManager.computeSyncDecision(doc);
+		return { kind: 'ready', target: { uri: resolved.uri, doc, context, dirty: doc.isDirty } };
+	},
+	isSyncOnSaveEnabled: target => SyncOnSaveManager.isUriSynced(target.uri),
+	async saveIfDirty(target) {
+		if (target.doc.isDirty && !(await target.doc.save())) {
+			throw new Error('Failed to save the document before uploading.');
+		}
+	},
+	async upload(target) {
+		await SyncManager.updateTemplateBody(target.doc);
+		const link = LinkManager.getTemplateLink(target.uri);
+		return { templateId: link.template.id, name: link.template.name, updatedAt: link.template.updatedAt };
+	},
+	download: target =>
+		SyncManager.applyTemplateToDocument(target.doc, target.context.session, target.context.remoteTemplate),
+	async refreshMetadata(target) {
+		SyncManager.refreshLinkMetadata(
+			target.doc,
+			target.context.session,
+			target.context.remoteTemplate,
+			target.context.localBody,
+		);
+	},
+};
+
+type SyncStatusLabel = 'in-sync' | 'remote-only' | 'local-ahead' | 'conflict';
+type RecommendedDirection = 'none' | 'upload' | 'download' | 'resolve';
+
+function statusLabel(action: SyncDecision['action']): SyncStatusLabel {
+	switch (action) {
+		case 'update-metadata':
+			return 'in-sync';
+		case 'download-remote':
+			return 'remote-only';
+		case 'upload-local':
+			return 'local-ahead';
+		case 'conflict':
+			return 'conflict';
+	}
+}
+
+function recommendedDirection(action: SyncDecision['action']): RecommendedDirection {
+	switch (action) {
+		case 'update-metadata':
+			return 'none';
+		case 'download-remote':
+			return 'download';
+		case 'upload-local':
+			return 'upload';
+		case 'conflict':
+			return 'resolve';
+	}
+}
+
+type SyncDirection = 'auto' | 'upload' | 'download';
+
+function parseDirection(value: unknown): SyncDirection {
+	if (value === undefined || value === null) return 'auto';
+	if (value === 'auto' || value === 'upload' || value === 'download') return value;
+	throw new Error('"direction" must be one of "auto", "upload", or "download".');
+}
+
+type EffectiveAction = 'metadata' | 'download' | 'upload' | 'conflict';
+
+function resolveEffectiveAction(direction: SyncDirection, action: SyncDecision['action']): EffectiveAction {
+	// Bodies already match: there is nothing to push or pull regardless of the
+	// requested direction, so just refresh metadata.
+	if (action === 'update-metadata') return 'metadata';
+	if (direction === 'upload') return 'upload';
+	if (direction === 'download') return 'download';
+	// direction === 'auto'; action is download-remote | upload-local | conflict.
+	if (action === 'download-remote') return 'download';
+	if (action === 'upload-local') return 'upload';
+	return 'conflict';
+}
+
+export async function runSyncStatus(
+	input: Record<string, unknown>,
+	_ctx: CapabilityContext,
+	deps: TemplateSyncDeps = defaultTemplateSyncDeps,
+): Promise<string> {
+	const uri = requireString(input, 'uri');
+	const prepared = await deps.prepare(uri);
+	if (prepared.kind === 'unlinked') {
+		return JSON.stringify(
+			{
+				linked: false,
+				uri,
+				message:
+					'No Rewst template is linked to this file. Use list_template_links to see which files are linked.',
+			},
+			null,
+			2,
+		);
+	}
+	const { target } = prepared;
+	const { link, remoteTemplate, localBody, decision } = target.context;
+	return JSON.stringify(
+		{
+			linked: true,
+			path: target.uri.fsPath,
+			orgId: link.org.id,
+			orgName: link.org.name,
+			templateId: link.template.id,
+			templateName: link.template.name,
+			syncOnSave: deps.isSyncOnSaveEnabled(target),
+			status: statusLabel(decision.action),
+			recommendedDirection: recommendedDirection(decision.action),
+			localUpdatedAt: link.template.updatedAt,
+			remoteUpdatedAt: remoteTemplate.updatedAt,
+			bodiesMatch: localBody === remoteTemplate.body,
+			localEmpty: localBody === '',
+			unsavedEdits: target.dirty,
+		},
+		null,
+		2,
+	);
+}
+
+export async function runSync(
+	input: Record<string, unknown>,
+	ctx: CapabilityContext,
+	deps: TemplateSyncDeps = defaultTemplateSyncDeps,
+): Promise<string> {
+	const orgId = requireString(input, 'orgId');
+	const uri = requireString(input, 'uri');
+	const direction = parseDirection(input.direction);
+
+	const prepared = await deps.prepare(uri);
+	if (prepared.kind === 'unlinked') {
+		return JSON.stringify(
+			{
+				status: 'not_linked',
+				message: `No Rewst template is linked to "${uri}". Link it in VS Code first, or check list_template_links.`,
+			},
+			null,
+			2,
+		);
+	}
+	const { target } = prepared;
+	const { link, remoteTemplate, decision } = target.context;
+
+	// A session can manage several orgs, so confirm the linked file AND the remote
+	// template belong to the requested org before any upload — otherwise a file
+	// linked to a sibling org could be reached by path.
+	if (link.org.id !== orgId) {
+		throw new Error(`"${uri}" is linked to org ${link.org.id}, not ${orgId}.`);
+	}
+	const remoteOrgId = (remoteTemplate as { orgId?: unknown }).orgId;
+	if (typeof remoteOrgId === 'string' && remoteOrgId !== orgId) {
+		throw new Error(`Template ${link.template.id} is not in org ${orgId}.`);
+	}
+
+	const effective = resolveEffectiveAction(direction, decision.action);
+
+	if (effective === 'conflict') {
+		return JSON.stringify(
+			{
+				status: 'conflict',
+				templateId: link.template.id,
+				templateName: link.template.name,
+				localUpdatedAt: link.template.updatedAt,
+				remoteUpdatedAt: remoteTemplate.updatedAt,
+				message:
+					'Local and remote both changed since the last sync. Re-call with direction:"upload" to overwrite Rewst with the local file, or direction:"download" to overwrite the local file with Rewst.',
+			},
+			null,
+			2,
+		);
+	}
+
+	if (effective === 'metadata') {
+		await deps.refreshMetadata(target);
+		return JSON.stringify(
+			{
+				status: 'in-sync',
+				templateId: link.template.id,
+				name: link.template.name,
+				message: 'Bodies already match; refreshed the local link metadata. Nothing was uploaded or downloaded.',
+			},
+			null,
+			2,
+		);
+	}
+
+	if (effective === 'download') {
+		await deps.download(target);
+		return JSON.stringify(
+			{
+				status: 'downloaded',
+				templateId: link.template.id,
+				name: remoteTemplate.name,
+				remoteUpdatedAt: remoteTemplate.updatedAt,
+				message: 'Local file overwritten with the latest Rewst template body.',
+			},
+			null,
+			2,
+		);
+	}
+
+	// effective === 'upload' — this changes Rewst, so gate it behind the shared
+	// per-call approval flow (the same one the other write tools use).
+	const orgName = orgDisplayName(ctx);
+	const scope: MutationScope = { scopeId: link.template.id, scopeName: link.template.name, orgId, orgName };
+	// 'download-remote' is only produced when the local file is empty, so an
+	// explicit upload then CLEARS the remote template body. Surface that in the
+	// approval prompt rather than the generic "upload local edits" wording.
+	const clearsRemote = decision.action === 'download-remote';
+	const summary = clearsRemote
+		? `Upload an EMPTY local file to template "${link.template.name}" (${link.template.id}) in org "${orgName}" (${orgId}) — this CLEARS the remote template body`
+		: `Upload local edits to template "${link.template.name}" (${link.template.id}) in org "${orgName}" (${orgId})`;
+	return withMutationApproval(scope, summary, async () => {
+		await deps.saveIfDirty(target);
+		const result = await deps.upload(target);
+		return JSON.stringify(
+			{
+				status: 'uploaded',
+				templateId: result.templateId,
+				name: result.name,
+				updatedAt: result.updatedAt,
+				message: clearsRemote
+					? 'Empty local file uploaded; the remote template body was cleared.'
+					: 'Local file body uploaded to Rewst.',
+			},
+			null,
+			2,
+		);
+	});
+}
+
+const syncStatusSpec: ToolSpec = {
+	name: 'buddy_template_sync_status',
+	args: '{"uri": string}',
+	description:
+		'Report whether a local file is linked to a Rewst template and how it compares to the remote template, without changing anything. Identify the file by the path shown in list_template_links (workspace-relative or absolute) or its file URI. Returns linked:false when no template is linked. When linked, returns the org id and template id to pass to buddy_template_sync, whether sync-on-save is on, and a status of "in-sync", "remote-only" (the local file is empty), "local-ahead" (safe to upload), or "conflict" (both changed since the last sync), plus a recommended direction.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Path or file URI of the local file, as shown by list_template_links.',
+			},
+		},
+		required: ['uri'],
+	},
+};
+
+const syncSpec: ToolSpec = {
+	name: 'buddy_template_sync',
+	args: '{"orgId": string, "uri": string, "direction"?: "auto" | "upload" | "download"}',
+	description:
+		'Synchronize one linked local file with its Rewst template. Identify the file by the path from list_template_links or its file URI; orgId must be the org the file is linked to (buddy_template_sync_status returns it). direction defaults to "auto": it uploads when only the local file changed, downloads when the local file is empty, refreshes metadata when the bodies already match, and on a conflict (both changed since the last sync) it changes nothing and asks you to choose. Pass direction:"upload" to overwrite the Rewst template with the local file, or direction:"download" to overwrite the local file with the Rewst template. This is a write tool: every direction (including download) requires write tools to be enabled in VS Code and the org to be on the write allowlist. Only uploading additionally needs per-call approval and changes Rewst; downloading and metadata refreshes rewrite local state only.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			uri: {
+				type: 'string',
+				description: 'Path or file URI of the linked local file, as shown by list_template_links.',
+			},
+			direction: {
+				type: 'string',
+				enum: ['auto', 'upload', 'download'],
+				description:
+					'auto (default) resolves the safe direction and stops on a conflict; upload overwrites Rewst with the local file; download overwrites the local file with Rewst.',
+			},
+		},
+		required: ['orgId', 'uri'],
+	},
+};
+
+export const TEMPLATE_SYNC_CAPABILITIES: Capability[] = [
+	{
+		spec: syncStatusSpec,
+		group: 'workspace',
+		access: 'read',
+		chat: false,
+		mcp: true,
+		requiresOrg: false,
+		run: (input, ctx) => runSyncStatus(input, ctx),
+	},
+	{ spec: syncSpec, access: 'write', chat: false, mcp: true, run: (input, ctx) => runSync(input, ctx) },
+];

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -269,8 +269,10 @@ export async function runSync(
 	if (link.org.id !== orgId) {
 		throw new Error(`"${uri}" is linked to org ${link.org.id}, not ${orgId}.`);
 	}
+	// Fail closed: a write tool must re-verify the resource's org, so reject an
+	// absent/non-string remote orgId as well as a mismatch.
 	const remoteOrgId = (remoteTemplate as { orgId?: unknown }).orgId;
-	if (typeof remoteOrgId === 'string' && remoteOrgId !== orgId) {
+	if (typeof remoteOrgId !== 'string' || remoteOrgId !== orgId) {
 		throw new Error(`Template ${link.template.id} is not in org ${orgId}.`);
 	}
 
@@ -298,7 +300,7 @@ export async function runSync(
 			{
 				status: 'in-sync',
 				templateId: link.template.id,
-				name: link.template.name,
+				name: remoteTemplate.name,
 				message: 'Bodies already match; refreshed the local link metadata. Nothing was uploaded or downloaded.',
 			},
 			null,

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -5,7 +5,21 @@ import { findAllTemplateReferences, getHash, log, makeUniqueUri, writeTextFile }
 import vscode, { Uri } from 'vscode';
 import { LinkManager } from './LinkManager';
 import { SyncOnSaveManager } from './SyncOnSaveManager';
-import { determineSyncAction } from './syncDecision';
+import { determineSyncAction, type SyncDecision } from './syncDecision';
+
+/**
+ * Everything needed to act on a sync without re-fetching: the link, the session
+ * resolved for its org, the remote template (body intact), the current local
+ * body, and the computed action. Shared by the save-driven sync and the
+ * non-interactive MCP sync tools so they decide identically.
+ */
+export interface SyncDecisionContext {
+	link: TemplateLink;
+	session: Session;
+	remoteTemplate: FullTemplateFragment;
+	localBody: string;
+	decision: SyncDecision;
+}
 
 export const SyncManager = new (class _ implements vscode.Disposable {
 	private syncingUris = new Set<string>();
@@ -173,8 +187,8 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 			this.addLink(link, doc.uri);
 
 			log.info('Saved updated info to template');
-		} catch {
-			throw log.error('Failure in response from ticket update, unknown if successful');
+		} catch (e) {
+			throw log.error('Failure in response from ticket update, unknown if successful', e);
 		}
 	}
 
@@ -213,56 +227,18 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 			}
 		}
 
-		const link = LinkManager.getTemplateLink(doc.uri);
+		const { link, session, remoteTemplate, localBody, decision } = await this.computeSyncDecision(doc);
 		log.debug('syncTemplateInternal: syncing template', {
 			templateId: link.template.id,
 			templateName: link.template.name,
+			action: decision.action,
 		});
-
-		const session = SessionManager.getSessionForOrg(link.org.id);
-
-		let remoteTemplate;
-		try {
-			log.trace('syncTemplateInternal: fetching remote template');
-			remoteTemplate = await session.getTemplate(link.template.id);
-		} catch {
-			throw log.error('syncTemplateInternal: failed to fetch remote template');
-		}
-
-		const localBody = doc.getText();
-		const currentBodyHash = getHash(localBody);
-
-		log.debug('syncTemplateInternal: comparing states', {
-			localUpdatedAt: link.template.updatedAt,
-			remoteUpdatedAt: remoteTemplate.updatedAt,
-			storedBodyHash: link.bodyHash,
-			currentBodyHash,
-		});
-
-		const decision = determineSyncAction({
-			localUpdatedAt: link.template.updatedAt,
-			remoteUpdatedAt: remoteTemplate.updatedAt,
-			localBody,
-			remoteBody: remoteTemplate.body,
-		});
-
-		log.debug('syncTemplateInternal: decision', decision.action);
 
 		switch (decision.action) {
-			case 'update-metadata': {
-				// Bodies match - just update link metadata with latest remote info
-				remoteTemplate.body = '';
-				const templateLink: TemplateLink = {
-					type: 'Template',
-					bodyHash: currentBodyHash,
-					referencedTemplateIds: findAllTemplateReferences(localBody),
-					template: remoteTemplate,
-					uriString: doc.uri.toString(),
-					org: session.profile.org,
-				};
-				this.addLink(templateLink, doc.uri);
+			case 'update-metadata':
+				// Bodies match - just refresh link metadata with the latest remote info.
+				this.refreshLinkMetadata(doc, session, remoteTemplate, localBody);
 				break;
-			}
 
 			case 'download-remote':
 				log.debug('syncTemplateInternal: downloading remote (local empty)');
@@ -279,6 +255,67 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 				await this.handleConflict(doc, session, remoteTemplate);
 				break;
 		}
+	}
+
+	/**
+	 * Gathers the remote template and computes the sync action for a linked
+	 * document without mutating local or remote state. The interactive
+	 * save-driven sync and the non-interactive MCP sync tools both build on this
+	 * so they decide identically. Throws if the document is not a template link
+	 * or the remote template cannot be fetched.
+	 */
+	async computeSyncDecision(doc: vscode.TextDocument): Promise<SyncDecisionContext> {
+		const link = LinkManager.getTemplateLink(doc.uri);
+		const session = SessionManager.getSessionForOrg(link.org.id);
+
+		let remoteTemplate: FullTemplateFragment;
+		try {
+			log.trace('computeSyncDecision: fetching remote template', link.template.id);
+			remoteTemplate = await session.getTemplate(link.template.id);
+		} catch (e) {
+			throw log.error('computeSyncDecision: failed to fetch remote template', e);
+		}
+
+		const localBody = doc.getText();
+		const decision = determineSyncAction({
+			localUpdatedAt: link.template.updatedAt,
+			remoteUpdatedAt: remoteTemplate.updatedAt,
+			localBody,
+			remoteBody: remoteTemplate.body,
+		});
+
+		log.debug('computeSyncDecision: states', {
+			localUpdatedAt: link.template.updatedAt,
+			remoteUpdatedAt: remoteTemplate.updatedAt,
+			storedBodyHash: link.bodyHash,
+			currentBodyHash: getHash(localBody),
+			action: decision.action,
+		});
+
+		return { link, session, remoteTemplate, localBody, decision };
+	}
+
+	/**
+	 * Refreshes a template link's metadata from the latest remote state when the
+	 * local and remote bodies already match (the 'update-metadata' action). The
+	 * link stores an empty body, matching how links are persisted elsewhere.
+	 */
+	refreshLinkMetadata(
+		doc: vscode.TextDocument,
+		session: Session,
+		remoteTemplate: FullTemplateFragment,
+		localBody: string,
+	): void {
+		remoteTemplate.body = '';
+		const templateLink: TemplateLink = {
+			type: 'Template',
+			bodyHash: getHash(localBody),
+			referencedTemplateIds: findAllTemplateReferences(localBody),
+			template: remoteTemplate,
+			uriString: doc.uri.toString(),
+			org: session.profile.org,
+		};
+		this.addLink(templateLink, doc.uri);
 	}
 
 	private async handleConflict(doc: vscode.TextDocument, session: Session, remoteTemplate: FullTemplateFragment) {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,5 +1,5 @@
 export { LinkManager } from './LinkManager';
-export { SyncManager } from './SyncManager';
+export { SyncManager, type SyncDecisionContext } from './SyncManager';
 export { SyncOnSaveManager } from './SyncOnSaveManager';
 export { TemplateBundleManager } from './TemplateBundleManager';
 export { TemplateMetadataStore, type TemplateMetadata } from './TemplateMetadataStore';

--- a/src/test/integration/templateClone.test.ts
+++ b/src/test/integration/templateClone.test.ts
@@ -1,0 +1,117 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+import {
+	_resetMcpMutationApproverForTesting,
+	setMcpMutationApprover,
+	type Capability,
+	type CapabilityContext,
+} from '@capabilities';
+import { _resetApprovedMutationScopes } from '../../ui/chat/tools/graphqlTool';
+import { TEMPLATE_CLONE_CAPABILITIES } from '../../capabilities/templateCloneCapabilities';
+
+const { suite, test, suiteSetup, suiteTeardown, setup } = Mocha;
+
+/**
+ * Live verification for buddy_template_bundle_clone. It creates a small real
+ * template bundle (a root that references a child), clones it, and asserts the
+ * cloned root's body was rewritten to point at the cloned child — exercising the
+ * end-to-end approval + create + updateTemplate flow against a real session.
+ * Opt-in (token + REWST_TEST_WRITE=1) and always targets the token's own primary
+ * org (use a sandbox token). Every created template — sources and clones — is
+ * deleted in the finally block even if an assertion fails.
+ */
+function writeTestsEnabled(): boolean {
+	return hasTestToken() && process.env.REWST_TEST_WRITE === '1';
+}
+
+function cap(name: string): Capability {
+	const capability = TEMPLATE_CLONE_CAPABILITIES.find(c => c.spec.name === name);
+	if (!capability) throw new Error(`missing capability ${name}`);
+	return capability;
+}
+
+suite('Integration: template bundle clone', function () {
+	this.timeout(120_000);
+
+	let session: Session;
+	let ctx: CapabilityContext;
+	let targetOrgId: string;
+
+	suiteSetup(async function () {
+		if (!writeTestsEnabled()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		session = await getTestSession();
+		targetOrgId = session.profile.org.id;
+		if (!targetOrgId) {
+			throw new Error('Refusing to run: the test session has no primary org id.');
+		}
+		ctx = { session, orgId: targetOrgId, sessions: [session] };
+		console.log(`\n[itest] target org: ${session.profile.org.name} (${targetOrgId})`);
+	});
+
+	setup(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		setMcpMutationApprover(async () => true);
+	});
+
+	suiteTeardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		clearCachedSession();
+	});
+
+	test('clones a root + referenced child and rewrites the reference to the new child id', async () => {
+		const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+		const createdIds = new Set<string>();
+
+		const create = async (name: string, body: string): Promise<string> => {
+			const response = await session.sdk?.createTemplateMinimal({ name, orgId: targetOrgId, body });
+			const id = response?.template?.id;
+			if (!id) throw new Error(`failed to create template "${name}"`);
+			createdIds.add(id);
+			return id;
+		};
+
+		try {
+			const childId = await create(`rb-itest-clone-child-${stamp}`, '{{ "child" }}');
+			const rootId = await create(`rb-itest-clone-root-${stamp}`, `{{ template('${childId}') }}`);
+			console.log('[itest] created source bundle', { rootId, childId });
+
+			const result = JSON.parse(
+				await cap('buddy_template_bundle_clone').run({ orgId: targetOrgId, rootTemplateId: rootId }, ctx),
+			);
+			assert.strictEqual(result.status, 'cloned');
+			assert.strictEqual(result.count, 2, 'root + child cloned');
+			assert.ok(Array.isArray(result.idMap) && result.idMap.length === 2);
+			for (const node of result.idMap as { newId: string }[]) {
+				createdIds.add(node.newId);
+			}
+
+			const newRootId: string = result.newRootTemplateId;
+			const clonedChild = (result.idMap as { oldId: string; newId: string }[]).find(n => n.oldId === childId);
+			assert.ok(newRootId, 'new root id returned');
+			assert.ok(clonedChild, 'child was cloned');
+
+			// The cloned root must reference the cloned child, not the original.
+			const newRoot = await session.getTemplate(newRootId);
+			assert.ok(newRoot.body.includes(clonedChild!.newId), 'reference rewritten to the cloned child id');
+			assert.ok(!newRoot.body.includes(childId), 'original child id no longer present in the cloned root');
+
+			console.log('[itest] clone rewrote the reference; target org will be cleaned up');
+		} finally {
+			for (const id of createdIds) {
+				try {
+					await session.sdk?.deleteTemplate({ id });
+				} catch {
+					// best-effort cleanup
+				}
+			}
+		}
+	});
+});


### PR DESCRIPTION
## What

Closes #21 (first slice). Exposes the extension's local **file ↔ Rewst-template sync** over MCP so an AI assistant can see a file's link/sync state and push or pull a linked template — without driving the VS Code UI. Two new MCP-only tools:

| Tool | Access | Gating | Purpose |
|---|---|---|---|
| `buddy_template_sync_status` | read | ungated (derives org from the link) | Is this file linked? How does it compare to remote — `in-sync` / `remote-only` / `local-ahead` / `conflict` — plus orgId, templateId, sync-on-save, recommended direction. Changes nothing. |
| `buddy_template_sync` | write | write gate + `writeOrgAllowlist` (whole tool); per-call approval **on upload only** | Push/pull a linked file. `direction` defaults to `auto`. |

### Why the new tools (not the existing sync command)

The existing save-driven sync resolves conflicts with an **interactive VS Code modal**, which an external MCP client can never answer. So `buddy_template_sync` replaces the modal with an explicit `direction`:

- **`auto`** (default): uploads when only local changed, downloads when local is empty, refreshes metadata when bodies match, and on a **conflict changes nothing** — it returns a `conflict` status and asks the caller to choose. Never a surprise overwrite.
- **`upload`** overwrites Rewst with the local file; **`download`** overwrites the local file with Rewst.

### Safety

- `buddy_template_sync` is a single `access:'write'` capability, so the central `McpActions` gate requires write tools enabled + an allowlisted org for **every** direction (fails closed); only **upload** additionally prompts for approval and changes Rewst.
- Cross-org by-path reach is blocked: the handler verifies `link.org.id === orgId` **and** `remoteTemplate.orgId === orgId` before any upload.
- An ambiguous bare filename that matches two linked files resolves to nothing (refused) rather than picking one.
- An explicit `upload` of an empty local file (which clears the remote body) gets an explicit warning in the approval prompt and the result.

### Implementation

- `SyncManager` refactored to share the non-interactive decision (`computeSyncDecision`) and metadata refresh (`refreshLinkMetadata`) with the existing on-save path — both decide identically; the modal stays confined to the on-save conflict branch. Behavior-preserving for save-on-sync.
- New `templateSyncCapabilities.ts`; reuses the shared `mutationApproval.ts` helpers (no copied approval plumbing).

## Tests

37 unit tests in `templateSyncCapabilities.test.ts` (every direction × action, approval grant/deny/reuse, conflict no-op, org guards, descriptor flags, `matchLinkByPath` + live-`LinkManager` `resolveLinkedUri` resolution incl. ambiguity/normalization). Full unit suite green (689 passing); typecheck, eslint, markdownlint, and `changelog:check` all clean.

## Review

Authored and ran an adversarial multi-agent review (5 dimensions → independent per-finding verification). All 10 confirmed findings are addressed in this PR (gating-text parity, shared-helper reuse, empty-upload warning, ambiguous-path refusal, error-context forwarding, and the added descriptor/`resolveLinkedUri`/edge-case tests).

## Deferred to follow-ups (issue #21 remainder)

- `buddy_template_link` / `buddy_template_unlink` (link a template id ↔ a file URI) and a sync-on-save toggle.
- Deep-copy of a nested/bundle into new templates.
- Optional: split status/download into a read-tier path so download works with write tools off (kept as one write tool here for ergonomics); a token-gated integration test that drives the real `defaultTemplateSyncDeps` end-to-end.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added MCP-based template sync capabilities to check sync status and synchronize linked template files (auto/upload/download), including metadata refresh and conflict handling.
  * Added MCP tools to link/unlink templates and toggle sync-on-save for linked files.
  * Added MCP capability to deep-clone a template bundle across linked templates with approval and rollback safeguards.
* **Tests**
  * Added/expanded unit test coverage for sync, linking, sync-on-save, and bundle cloning behavior, metadata, validation, and capability descriptors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->