### PR TITLE
Complete #21: template link/unlink/sync-on-save + bundle deep-clone over MCP

### DIFF
--- a/changelog.d/mcp-template-bundle-clone.md
+++ b/changelog.d/mcp-template-bundle-clone.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Deep-clone a template bundle over MCP** - The new `buddy_template_bundle_clone` tool deep-copies a template and the templates it references (transitively, via `template('<id>')` calls) into new templates in a target org, rewriting every reference to the new ids. It walks the live remote graph (cycle-safe, depth- and count-capped), creates the clones behind a single approval, and rolls back every created template if the clone fails partway. References to other orgs or to deleted templates are reported rather than silently dropped.

--- a/changelog.d/mcp-template-bundle-clone.md
+++ b/changelog.d/mcp-template-bundle-clone.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 85
 ---
 
 - **Deep-clone a template bundle over MCP** - The new `buddy_template_bundle_clone` tool deep-copies a template and the templates it references (transitively, via `template('<id>')` calls) into new templates in a target org, rewriting every reference to the new ids. It walks the live remote graph (cycle-safe, depth- and count-capped), creates the clones behind a single approval, and rolls back every created template if the clone fails partway. References to other orgs or to deleted templates are reported rather than silently dropped.

--- a/changelog.d/mcp-template-link-tools.md
+++ b/changelog.d/mcp-template-link-tools.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Template link management over MCP** - New MCP tools let an AI assistant manage the local file ↔ Rewst template links directly: `buddy_template_link` associates an existing local file with a template, `buddy_template_unlink` removes the association, and `buddy_template_sync_on_save` toggles upload-on-save for a linked file. These change only local link state (no Rewst writes) and pair with the sync tools to drive the full link-edit-sync workflow without the VS Code UI.

--- a/changelog.d/mcp-template-link-tools.md
+++ b/changelog.d/mcp-template-link-tools.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 85
 ---
 
 - **Template link management over MCP** - New MCP tools let an AI assistant manage the local file ↔ Rewst template links directly: `buddy_template_link` associates an existing local file with a template, `buddy_template_unlink` removes the association, and `buddy_template_sync_on_save` toggles upload-on-save for a linked file. These change only local link state (no Rewst writes) and pair with the sync tools to drive the full link-edit-sync workflow without the VS Code UI.

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -4,6 +4,35 @@
  * one consistent argument-parsing contract.
  */
 
+import type { FullTemplateFragment, Session } from '@sessions';
+
+/** Pretty-prints a value as the JSON string capabilities return to callers. */
+export function json(value: unknown): string {
+	return JSON.stringify(value, null, 2);
+}
+
+/**
+ * Fetches a template by id from whichever active session can resolve it,
+ * returning the resolving session too. A requiresOrg:false tool has no
+ * org-targeted session and one machine can manage several orgs, so try each
+ * session rather than assuming the first. Returns undefined when no session
+ * resolves the id.
+ */
+export async function getTemplateFromAnySession(
+	sessions: readonly Session[],
+	getTemplate: (session: Session, templateId: string) => Promise<FullTemplateFragment>,
+	templateId: string,
+): Promise<{ template: FullTemplateFragment; session: Session } | undefined> {
+	for (const session of sessions) {
+		try {
+			return { template: await getTemplate(session, templateId), session };
+		} catch {
+			// Try the next session.
+		}
+	}
+	return undefined;
+}
+
 export function asString(input: Record<string, unknown>, key: string): string | undefined {
 	const value = input[key];
 	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -14,6 +14,8 @@ import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
 import { TRIGGER_MUTATE_CAPABILITIES } from './triggerMutateCapabilities';
 import { TEMPLATE_MUTATE_CAPABILITIES } from './templateMutateCapabilities';
 import { TEMPLATE_SYNC_CAPABILITIES } from './templateSyncCapabilities';
+import { TEMPLATE_LINK_CAPABILITIES } from './templateLinkCapabilities';
+import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -35,6 +37,8 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...TRIGGER_MUTATE_CAPABILITIES,
 	...TEMPLATE_MUTATE_CAPABILITIES,
 	...TEMPLATE_SYNC_CAPABILITIES,
+	...TEMPLATE_LINK_CAPABILITIES,
+	...TEMPLATE_CLONE_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/templateCloneCapabilities.test.ts
+++ b/src/capabilities/templateCloneCapabilities.test.ts
@@ -1,0 +1,377 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { createMockSession, initTestEnvironment } from '@test';
+import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
+import type { FullTemplateFragment, Session } from '@sessions';
+import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
+import {
+	defaultTemplateCloneDeps,
+	rewriteReferences,
+	runBundleClone,
+	TEMPLATE_CLONE_CAPABILITIES,
+	type TemplateCloneDeps,
+} from './templateCloneCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+// Valid UUIDs so findAllTemplateReferences' pattern matches.
+const A = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+const B = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+const C = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+const D = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+const FOREIGN = 'ffffffff-ffff-ffff-ffff-ffffffffffff';
+const MISSING = '99999999-9999-9999-9999-999999999999';
+
+function refBody(ids: string[]): string {
+	return ids.map(id => `{{ template('${id}') }}`).join('\n');
+}
+
+function tmpl(id: string, over: Partial<FullTemplateFragment> = {}): FullTemplateFragment {
+	return {
+		id,
+		name: `T-${id.slice(0, 4)}`,
+		body: '',
+		updatedAt: '1',
+		orgId: 'src-org',
+		organization: { id: 'src-org', name: 'Source' },
+		contentType: 'text',
+		language: 'jinja',
+		context: null,
+		cloneOverrides: null,
+		description: null,
+		tags: [],
+		...over,
+	} as unknown as FullTemplateFragment;
+}
+
+interface CloneDepOpts {
+	failCreateAt?: number;
+	failUpdateAt?: number;
+}
+
+type CloneUpdateArg = Parameters<TemplateCloneDeps['updateTemplate']>[1];
+
+function makeCloneDeps(remote: Record<string, FullTemplateFragment>, opts: CloneDepOpts = {}) {
+	const calls = {
+		getTemplate: [] as string[],
+		create: [] as { name: string; orgId: string }[],
+		update: [] as CloneUpdateArg[],
+		del: [] as string[],
+	};
+	let createCount = 0;
+	let updateCount = 0;
+	let idSeq = 0;
+	const deps: TemplateCloneDeps = {
+		getTemplate: async (_s, id) => {
+			calls.getTemplate.push(id);
+			const t = remote[id];
+			if (!t) throw new Error(`not found: ${id}`);
+			return t;
+		},
+		createTemplate: async (_s, name, orgId) => {
+			createCount++;
+			calls.create.push({ name, orgId });
+			if (opts.failCreateAt === createCount) throw new Error('create boom');
+			return { id: `new-${++idSeq}` };
+		},
+		updateTemplate: async (_s, update) => {
+			updateCount++;
+			calls.update.push(update);
+			if (opts.failUpdateAt === updateCount) throw new Error('update boom');
+		},
+		deleteTemplate: async (_s, id) => {
+			calls.del.push(id);
+		},
+	};
+	return { deps, calls };
+}
+
+function makeCtx(targetOrgId = 'tgt-org'): CapabilityContext {
+	const session = {
+		profile: { org: { id: targetOrgId, name: 'Target' }, allManagedOrgs: [{ id: targetOrgId, name: 'Target' }] },
+	} as unknown as Session;
+	return { session, orgId: targetOrgId, sessions: [session] };
+}
+
+suite('Unit: templateCloneCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	suite('rewriteReferences', () => {
+		test('rewrites mapped ids, leaves unmapped refs and surrounding Jinja intact', () => {
+			const map = new Map([[A, 'new-1']]);
+			const body = `{{ template('${A}') }} and {{ template('${B}') }}`;
+			const out = rewriteReferences(body, map);
+			assert.ok(out.includes("template('new-1')"), 'mapped ref rewritten');
+			assert.ok(out.includes(`template('${B}')`), 'unmapped ref left as-is');
+		});
+
+		test('matches case-insensitively against canonical (lowercase) keys', () => {
+			const map = new Map([[A, 'new-1']]);
+			const out = rewriteReferences(`{{ template('${A.toUpperCase()}') }}`, map);
+			assert.ok(out.includes("template('new-1')"), 'uppercase ref still rewritten');
+		});
+	});
+
+	suite('capability descriptor', () => {
+		test('buddy_template_bundle_clone is a write tool, mcp-only, org-scoped', () => {
+			const c = TEMPLATE_CLONE_CAPABILITIES.find(x => x.spec.name === 'buddy_template_bundle_clone');
+			assert.ok(c);
+			assert.strictEqual(c.access, 'write');
+			assert.strictEqual(c.mcp, true);
+			assert.strictEqual(c.chat, false);
+			assert.notStrictEqual(c.requiresOrg, false);
+		});
+	});
+
+	suite('approval', () => {
+		test('creates nothing when approval is denied', async () => {
+			const { deps, calls } = makeCloneDeps({ [A]: tmpl(A) });
+			setMcpMutationApprover(async () => false);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'approval_required');
+			assert.strictEqual(calls.create.length, 0);
+		});
+
+		test('prompts once for the whole bundle, scoped to (org, root)', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B, { body: refBody([C]) }), [C]: tmpl(C) };
+			const { deps } = makeCloneDeps(remote);
+			let approverCalls = 0;
+			let scope: MutationScope | undefined;
+			setMcpMutationApprover(async s => {
+				approverCalls++;
+				scope = s;
+				return true;
+			});
+
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+
+			assert.strictEqual(approverCalls, 1, 'one approval for the whole clone');
+			assert.strictEqual(scope?.scopeId, `clone:${A}`, 'scope is per-(org, root)');
+		});
+
+		test('reuses approval for the same root but re-prompts for a different root', async () => {
+			const remote = { [A]: tmpl(A), [B]: tmpl(B) };
+			const { deps } = makeCloneDeps(remote);
+			let approverCalls = 0;
+			setMcpMutationApprover(async () => {
+				approverCalls++;
+				return true;
+			});
+
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+			assert.strictEqual(approverCalls, 1, 'same root reuses approval');
+
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: B }, makeCtx(), deps);
+			assert.strictEqual(approverCalls, 2, 'a different root re-prompts');
+		});
+	});
+
+	suite('cloning', () => {
+		setup(() => setMcpMutationApprover(async () => true));
+
+		test('clones a single template with no references', async () => {
+			const { deps, calls } = makeCloneDeps({ [A]: tmpl(A, { body: 'hello' }) });
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'cloned');
+			assert.strictEqual(out.count, 1);
+			assert.strictEqual(out.newRootTemplateId, 'new-1');
+			assert.strictEqual(calls.create.length, 1);
+			assert.strictEqual(calls.update.length, 1);
+		});
+
+		test('rewrites references to the new ids along a chain', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B, { body: refBody([C]) }), [C]: tmpl(C) };
+			const { deps, calls } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+
+			assert.strictEqual(out.count, 3);
+			const rootUpdate = calls.update.find(u => u.id === 'new-1');
+			assert.ok(rootUpdate, 'root clone updated');
+			assert.ok(rootUpdate.body.includes("template('new-2')"), 'reference rewritten to the clone id');
+			assert.ok(!rootUpdate.body.includes(B), 'old id no longer present');
+		});
+
+		test('copies source contentType / language / context onto each clone', async () => {
+			const remote = {
+				[A]: tmpl(A, { body: 'print(1)', contentType: 'powershell', language: 'python', context: { x: 1 } }),
+			};
+			const { deps, calls } = makeCloneDeps(remote);
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+			const update = calls.update[0];
+			assert.strictEqual(update.language, 'python');
+			assert.strictEqual(update.contentType, 'powershell');
+			assert.deepStrictEqual(update.context, { x: 1 });
+		});
+
+		test('handles a cycle without looping forever', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B, { body: refBody([A]) }) };
+			const { deps, calls } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 2);
+			assert.strictEqual(calls.create.length, 2);
+		});
+
+		test('clones a shared (diamond) dependency only once', async () => {
+			const remote = {
+				[A]: tmpl(A, { body: refBody([B, C]) }),
+				[B]: tmpl(B, { body: refBody([D]) }),
+				[C]: tmpl(C, { body: refBody([D]) }),
+				[D]: tmpl(D),
+			};
+			const { deps, calls } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 4, 'D cloned once');
+			assert.strictEqual(calls.create.length, 4);
+		});
+
+		test('dedupes case-variant references to one clone', async () => {
+			const remote = {
+				[A]: tmpl(A, { body: refBody([B.toUpperCase(), C]) }),
+				[B]: tmpl(B),
+				[C]: tmpl(C, { body: refBody([B]) }),
+			};
+			const { deps } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 3, 'B cloned once despite mixed-case references');
+		});
+
+		test('reports a missing referenced template and still clones the root', async () => {
+			const { deps } = makeCloneDeps({ [A]: tmpl(A, { body: refBody([MISSING]) }) });
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 1);
+			assert.deepStrictEqual(out.missingReferences, [MISSING]);
+		});
+
+		test('reports a foreign-org reference and does not clone it', async () => {
+			const remote = {
+				[A]: tmpl(A, { body: refBody([FOREIGN]) }),
+				[FOREIGN]: tmpl(FOREIGN, { orgId: 'other-org' }),
+			};
+			const { deps } = makeCloneDeps(remote);
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps));
+			assert.strictEqual(out.count, 1);
+			assert.deepStrictEqual(out.foreignReferences, [{ refId: FOREIGN, orgId: 'other-org' }]);
+		});
+
+		test('bounds the walk by maxDepth and reports the dropped child', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B, { body: refBody([C]) }), [C]: tmpl(C) };
+			const { deps } = makeCloneDeps(remote);
+			const out = JSON.parse(
+				await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A, maxDepth: 1 }, makeCtx(), deps),
+			);
+			assert.strictEqual(out.count, 2, 'A and B only');
+			assert.deepStrictEqual(out.skipped.depth, [C], 'reports the omitted child, not the cloned parent');
+		});
+
+		test('bounds the walk by maxTemplates', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B, C]) }), [B]: tmpl(B), [C]: tmpl(C) };
+			const { deps } = makeCloneDeps(remote);
+			const out = JSON.parse(
+				await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A, maxTemplates: 2 }, makeCtx(), deps),
+			);
+			assert.strictEqual(out.count, 2);
+			assert.deepStrictEqual(out.skipped.cap, [C]);
+		});
+
+		test('creates every clone in the target org', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
+			const { deps, calls } = makeCloneDeps(remote);
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+			assert.ok(calls.create.every(c => c.orgId === 'tgt-org'), 'all creates target the requested org');
+		});
+
+		test('fetches the root from a later session when the first cannot', async () => {
+			const remote = { [A]: tmpl(A) };
+			const { deps } = makeCloneDeps(remote);
+			const base = deps.getTemplate;
+			const s1 = {} as unknown as Session;
+			const s2 = {
+				profile: { org: { id: 'tgt-org', name: 'Target' }, allManagedOrgs: [{ id: 'tgt-org', name: 'Target' }] },
+			} as unknown as Session;
+			deps.getTemplate = async (s, id) => {
+				if (s === s1) throw new Error('first session cannot read it');
+				return base(s, id);
+			};
+			const ctx = { session: s2, orgId: 'tgt-org', sessions: [s1, s2] } as unknown as CapabilityContext;
+			const out = JSON.parse(await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, ctx, deps));
+			assert.strictEqual(out.status, 'cloned');
+			assert.strictEqual(out.count, 1);
+		});
+
+		test('rolls back every created template when an update fails', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
+			const { deps, calls } = makeCloneDeps(remote, { failUpdateAt: 2 });
+			await assert.rejects(
+				() => runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps),
+				/Clone failed.*Rolled back all 2/,
+			);
+			assert.deepStrictEqual(calls.del, ['new-1', 'new-2'], 'both clones deleted');
+		});
+
+		test('rolls back only the templates created so far when a create fails', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
+			const { deps, calls } = makeCloneDeps(remote, { failCreateAt: 2 });
+			await assert.rejects(
+				() => runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps),
+				/Clone failed.*create boom/,
+			);
+			assert.deepStrictEqual(calls.del, ['new-1'], 'only the first clone existed to delete');
+			assert.strictEqual(calls.update.length, 0, 'no body updates ran');
+		});
+
+		test('verifies the source org against sourceOrgId', async () => {
+			const { deps } = makeCloneDeps({ [A]: tmpl(A) });
+			await assert.rejects(
+				() => runBundleClone({ orgId: 'tgt-org', rootTemplateId: A, sourceOrgId: 'wrong' }, makeCtx(), deps),
+				/is in org src-org, not wrong/,
+			);
+		});
+	});
+
+	suite('defaultTemplateCloneDeps (production SDK glue)', () => {
+		const update = { id: 'x', body: 'b', contentType: 'text', language: 'jinja', context: null, cloneOverrides: null, description: null };
+
+		test('createTemplate returns the minted id', async () => {
+			const { session, wrapper } = createMockSession({ profile: { org: { id: 'tgt', name: 'T' } } });
+			wrapper.when('createTemplateMinimal', { data: { template: { id: 'c1', name: 'X' } } });
+			const r = await defaultTemplateCloneDeps.createTemplate(session, 'X', 'tgt');
+			assert.strictEqual(r.id, 'c1');
+		});
+
+		test('createTemplate throws when the response has no template', async () => {
+			const { session, wrapper } = createMockSession();
+			wrapper.when('createTemplateMinimal', { data: { template: null } });
+			await assert.rejects(() => defaultTemplateCloneDeps.createTemplate(session, 'X', 'tgt'), /returned no template/);
+		});
+
+		test('updateTemplate succeeds and throws on a missing template', async () => {
+			const ok = createMockSession();
+			ok.wrapper.when('updateTemplate', { data: { template: { id: 'x' } } });
+			await defaultTemplateCloneDeps.updateTemplate(ok.session, update);
+
+			const bad = createMockSession();
+			bad.wrapper.when('updateTemplate', { data: { template: null } });
+			await assert.rejects(() => defaultTemplateCloneDeps.updateTemplate(bad.session, update), /returned no template/);
+		});
+
+		test('deleteTemplate succeeds and throws on a null result', async () => {
+			const ok = createMockSession();
+			ok.wrapper.when('deleteTemplate', { data: { deleteTemplate: 'x' } });
+			await defaultTemplateCloneDeps.deleteTemplate(ok.session, 'x');
+
+			const bad = createMockSession();
+			bad.wrapper.when('deleteTemplate', { data: { deleteTemplate: null } });
+			await assert.rejects(() => defaultTemplateCloneDeps.deleteTemplate(bad.session, 'x'), /rollback delete failed/);
+		});
+	});
+});

--- a/src/capabilities/templateCloneCapabilities.ts
+++ b/src/capabilities/templateCloneCapabilities.ts
@@ -1,0 +1,305 @@
+import type { FullTemplateFragment, Session } from '@sessions';
+import { findAllTemplateReferences } from '@utils';
+import { TEMPLATE_PATTERN } from '../providers/templatePatternUtils';
+import type { MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asPositiveInt, asString, getTemplateFromAnySession, json, ORG_ID_PROP, requireString } from './inputHelpers';
+import { orgDisplayName, withMutationApproval } from './mutationApproval';
+
+/**
+ * buddy_template_bundle_clone — deep-copy a template and the templates it
+ * references (transitively, via template('<id>') calls in the body) into NEW
+ * templates in a target org, rewriting every reference to the new ids.
+ *
+ * Why manual create-then-rewrite (not a native Rewst clone): the generated SDK
+ * has no clone wrapper, and a native deep clone would not rewrite the
+ * template('<id>') references to the new ids — the whole point here. So we
+ * create an empty template per node (to mint new ids), build an old→new id map,
+ * then for each node rewrite its body and write back its source metadata
+ * (contentType/language/context/cloneOverrides/description). Two phases are
+ * required because a body can reference a node not yet created (cycles / forward
+ * refs). Tags are NOT copied (they are org-scoped tag ids).
+ *
+ * orgId is the TARGET org (write destination), which the central MCP allowlist
+ * gates. The source org is taken from the root and read with whatever session
+ * manages it; writes always go to ctx.session (resolved for the target orgId).
+ */
+
+const DEFAULT_MAX_TEMPLATES = 50;
+const MAX_MAX_TEMPLATES = 200;
+const DEFAULT_MAX_DEPTH = 10;
+const MAX_MAX_DEPTH = 25;
+const DEFAULT_NAME_SUFFIX = ' (copy)';
+
+/** Source fields a clone carries beyond name+body (the create surface takes only name+body). */
+interface CloneMetadata {
+	contentType: string;
+	language: string;
+	context: unknown;
+	cloneOverrides: unknown;
+	description: string | null | undefined;
+}
+
+interface CloneUpdate extends CloneMetadata {
+	id: string;
+	body: string;
+}
+
+export interface TemplateCloneDeps {
+	getTemplate(session: Session, id: string): Promise<FullTemplateFragment>;
+	createTemplate(session: Session, name: string, orgId: string): Promise<{ id: string }>;
+	updateTemplate(session: Session, update: CloneUpdate): Promise<void>;
+	deleteTemplate(session: Session, id: string): Promise<void>;
+}
+
+export const defaultTemplateCloneDeps: TemplateCloneDeps = {
+	getTemplate: (session, id) => session.getTemplate(id),
+	async createTemplate(session, name, orgId) {
+		const response = await session.sdk?.createTemplateMinimal({ name, orgId, body: '' });
+		const template = response?.template;
+		if (!template?.id) throw new Error('createTemplateMinimal returned no template; the clone failed.');
+		return { id: template.id };
+	},
+	async updateTemplate(session, update) {
+		// updateTemplate (full TemplateUpdateInput) carries the rewritten body AND
+		// the source metadata, so a python/non-jinja or context-bearing template
+		// clones faithfully rather than as a default jinja/text template.
+		const response = await session.sdk?.updateTemplate({
+			template: {
+				id: update.id,
+				body: update.body,
+				contentType: update.contentType,
+				language: update.language,
+				context: update.context,
+				cloneOverrides: update.cloneOverrides,
+				description: update.description,
+			},
+		});
+		if (!response?.template?.id) throw new Error('updateTemplate returned no template; the clone failed.');
+	},
+	async deleteTemplate(session, id) {
+		const response = await session.sdk?.deleteTemplate({ id });
+		if (!response?.deleteTemplate) throw new Error('deleteTemplate returned no id; a rollback delete failed.');
+	},
+};
+
+/** Template ids resolve case-insensitively in Rewst; canonicalize so case-variant refs dedupe. */
+function canon(id: string): string {
+	return id.toLowerCase();
+}
+
+/**
+ * Rewrites every template('OLD') call whose id is in the map to template('NEW'),
+ * leaving the surrounding Jinja/quotes intact and leaving references not in the
+ * map (foreign-org or missing templates) untouched. Lookup is case-insensitive
+ * to match the canonicalized node keys. Uses a fresh regex so the shared global
+ * pattern's lastIndex is never a shared side effect.
+ */
+export function rewriteReferences(body: string, oldToNew: ReadonlyMap<string, string>): string {
+	const pattern = new RegExp(TEMPLATE_PATTERN.source, 'g');
+	return body.replace(pattern, (full: string, oldId: string) => {
+		const newId = oldToNew.get(canon(oldId));
+		return newId ? full.replace(oldId, newId) : full;
+	});
+}
+
+interface ClonedNode {
+	oldId: string;
+	newId: string;
+	name: string;
+}
+
+/** Best-effort delete of every already-created clone; returns ids that failed. */
+async function rollback(deps: TemplateCloneDeps, session: Session, created: readonly ClonedNode[]): Promise<string[]> {
+	const failed: string[] = [];
+	for (const { newId } of created) {
+		try {
+			await deps.deleteTemplate(session, newId);
+		} catch {
+			failed.push(newId);
+		}
+	}
+	return failed;
+}
+
+export async function runBundleClone(
+	input: Record<string, unknown>,
+	ctx: CapabilityContext,
+	deps: TemplateCloneDeps = defaultTemplateCloneDeps,
+): Promise<string> {
+	const targetOrgId = requireString(input, 'orgId');
+	const rootId = requireString(input, 'rootTemplateId');
+	const sourceOrgIdArg = asString(input, 'sourceOrgId');
+
+	let namePrefix = '';
+	if (input.namePrefix !== undefined) {
+		if (typeof input.namePrefix !== 'string') throw new Error('"namePrefix" must be a string.');
+		namePrefix = input.namePrefix;
+	}
+	let nameSuffix = DEFAULT_NAME_SUFFIX;
+	if (input.nameSuffix !== undefined) {
+		if (typeof input.nameSuffix !== 'string') throw new Error('"nameSuffix" must be a string.');
+		nameSuffix = input.nameSuffix;
+	}
+	const maxTemplates = Math.min(asPositiveInt(input, 'maxTemplates') ?? DEFAULT_MAX_TEMPLATES, MAX_MAX_TEMPLATES);
+	const maxDepth = Math.min(asPositiveInt(input, 'maxDepth') ?? DEFAULT_MAX_DEPTH, MAX_MAX_DEPTH);
+
+	// Phase 0 — fetch the root (from any session that can read it) and pin the source org.
+	const fetched = await getTemplateFromAnySession(ctx.sessions, deps.getTemplate, rootId);
+	if (!fetched) {
+		throw new Error(`Root template ${rootId} is not reachable in any active session.`);
+	}
+	const { template: root, session: sourceSession } = fetched;
+	const sourceOrgId = root.orgId;
+	if (sourceOrgIdArg && sourceOrgId !== sourceOrgIdArg) {
+		throw new Error(`Root template ${rootId} is in org ${sourceOrgId}, not ${sourceOrgIdArg}.`);
+	}
+
+	// Phase 1 — walk the transitive template() graph by RE-FETCHING each remote
+	// template (local link refs are unreliable). Cycle-safe via `visited`; keys
+	// are canonicalized so case-variant references resolve to one clone.
+	const rootKey = canon(rootId);
+	const nodes = new Map<string, { template: FullTemplateFragment; body: string }>();
+	nodes.set(rootKey, { template: root, body: root.body });
+	const visited = new Set<string>([rootKey]);
+	const queue: { id: string; depth: number }[] = [{ id: rootKey, depth: 0 }];
+	const missingReferences: string[] = [];
+	const foreignReferences: { refId: string; orgId: string }[] = [];
+	const skippedDepth: string[] = [];
+	const skippedCap: string[] = [];
+
+	while (queue.length > 0) {
+		const { id, depth } = queue.shift()!;
+		const { body } = nodes.get(id)!;
+		if (depth >= maxDepth) {
+			// Record the children actually dropped by the depth cap (not this node,
+			// which was already cloned), mirroring the other skip lists.
+			for (const rawRef of findAllTemplateReferences(body)) {
+				const refKey = canon(rawRef);
+				if (!visited.has(refKey)) {
+					visited.add(refKey);
+					skippedDepth.push(refKey);
+				}
+			}
+			continue;
+		}
+		for (const rawRef of findAllTemplateReferences(body)) {
+			const refKey = canon(rawRef);
+			if (visited.has(refKey)) continue;
+			visited.add(refKey);
+			if (nodes.size >= maxTemplates) {
+				skippedCap.push(refKey);
+				continue;
+			}
+			let referenced: FullTemplateFragment;
+			try {
+				referenced = await deps.getTemplate(sourceSession, refKey);
+			} catch {
+				missingReferences.push(refKey);
+				continue;
+			}
+			if (referenced.orgId !== sourceOrgId) {
+				foreignReferences.push({ refId: refKey, orgId: referenced.orgId });
+				continue;
+			}
+			nodes.set(refKey, { template: referenced, body: referenced.body });
+			queue.push({ id: refKey, depth: depth + 1 });
+		}
+	}
+
+	// Phase 2 — one approval scoped to (target org, root): a re-clone of the same
+	// root reuses it, but a different root (or a different write tool) re-prompts.
+	const orgName = orgDisplayName(ctx);
+	const scope: MutationScope = {
+		scopeId: `clone:${rootId}`,
+		scopeName: `clone of "${root.name}" (${nodes.size} templates)`,
+		orgId: targetOrgId,
+		orgName,
+	};
+	const summary = `Clone template "${root.name}" (${rootId}) and ${nodes.size - 1} referenced template(s) into org "${orgName}" (${targetOrgId})`;
+
+	return withMutationApproval(scope, summary, async () => {
+		const oldToNew = new Map<string, string>();
+		const created: ClonedNode[] = [];
+		try {
+			// Phase 3a — create an empty template per node to mint new ids first, so
+			// a body referencing a not-yet-created sibling never lands un-rewritten.
+			for (const [oldKey, { template }] of nodes) {
+				const name = `${namePrefix}${template.name}${nameSuffix}`;
+				const { id: newId } = await deps.createTemplate(ctx.session, name, targetOrgId);
+				oldToNew.set(oldKey, newId);
+				created.push({ oldId: oldKey, newId, name });
+			}
+			// Phase 3b — rewrite each body to the new ids and write back source metadata.
+			for (const [oldKey, { template, body }] of nodes) {
+				const newId = oldToNew.get(oldKey)!;
+				await deps.updateTemplate(ctx.session, {
+					id: newId,
+					body: rewriteReferences(body, oldToNew),
+					contentType: template.contentType,
+					language: template.language,
+					context: template.context,
+					cloneOverrides: template.cloneOverrides,
+					description: template.description,
+				});
+			}
+		} catch (error) {
+			const rollbackFailures = await rollback(deps, ctx.session, created);
+			const reason = error instanceof Error ? error.message : String(error);
+			const detail = rollbackFailures.length
+				? ` Rolled back ${created.length - rollbackFailures.length}/${created.length} created template(s); could not delete: ${rollbackFailures.join(', ')}.`
+				: ` Rolled back all ${created.length} created template(s).`;
+			throw new Error(`Clone failed: ${reason}${detail}`);
+		}
+
+		return json({
+			status: 'cloned',
+			targetOrgId,
+			targetOrgName: orgName,
+			sourceOrgId,
+			rootTemplateId: rootId,
+			newRootTemplateId: oldToNew.get(rootKey),
+			count: created.length,
+			idMap: created.map(node => ({ oldId: node.oldId, newId: node.newId, name: node.name })),
+			foreignReferences,
+			missingReferences,
+			skipped: { depth: skippedDepth, cap: skippedCap },
+			message: `Cloned ${created.length} template(s) into org "${orgName}". template() references were rewritten to the new ids, and each clone's contentType/language/context/cloneOverrides were copied (tags were not). Foreign-org and missing references were left unchanged — review foreignReferences and missingReferences.`,
+		});
+	});
+}
+
+const bundleCloneSpec: ToolSpec = {
+	name: 'buddy_template_bundle_clone',
+	args: '{"orgId": string, "rootTemplateId": string, "sourceOrgId"?: string, "namePrefix"?: string, "nameSuffix"?: string, "maxTemplates"?: number, "maxDepth"?: number}',
+	description:
+		"Deep-copy a Rewst template and the templates it references (transitively, via template('<id>') calls in the body) into NEW templates in a target org, rewriting every reference to the new template ids. Each clone copies the source name, body, contentType, language, JSON context and cloneOverrides; tags are NOT copied (they are org-scoped) and references inside context/cloneOverrides are not followed. orgId is the TARGET org the clones are created in — it must have write tools enabled, be on the write allowlist, and pass per-call approval. The source org is taken from the root template (verify it with sourceOrgId). References to templates in a different org, or that no longer exist, are left pointing at the original id and reported as foreignReferences / missingReferences. Nodes beyond maxTemplates (default 50, max 200) or maxDepth (default 10, max 25) are not cloned and are reported under skipped.cap / skipped.depth. On any failure mid-clone the templates created so far are deleted (rollback). Returns the old→new id map and the new root id; it does not create a local file link — use buddy_template_link for that.",
+	inputSchema: {
+		type: 'object',
+		properties: {
+			...ORG_ID_PROP,
+			rootTemplateId: { type: 'string', description: 'Id of the root template to deep-clone.' },
+			sourceOrgId: {
+				type: 'string',
+				description:
+					'Optional id of the org the root and its references live in. Verified against the root; defaults to the root’s org.',
+			},
+			namePrefix: { type: 'string', description: 'Optional prefix for cloned template names.' },
+			nameSuffix: {
+				type: 'string',
+				description: 'Optional suffix for cloned template names. Defaults to " (copy)".',
+			},
+			maxTemplates: {
+				type: 'number',
+				description: 'Max total templates to clone (root + references). Default 50, capped at 200.',
+			},
+			maxDepth: { type: 'number', description: 'Max reference depth to walk. Default 10, capped at 25.' },
+		},
+		required: ['orgId', 'rootTemplateId'],
+	},
+};
+
+export const TEMPLATE_CLONE_CAPABILITIES: Capability[] = [
+	{ spec: bundleCloneSpec, access: 'write', chat: false, mcp: true, run: (input, ctx) => runBundleClone(input, ctx) },
+];

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -1,0 +1,280 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import type { CapabilityContext } from '@capabilities';
+import { LinkManager, SyncOnSaveManager, type TemplateLink } from '@models';
+import type { FullTemplateFragment, Session } from '@sessions';
+import { getHash } from '@utils';
+import vscode from 'vscode';
+import {
+	resolvePathToUri,
+	runLink,
+	runSyncOnSave,
+	runUnlink,
+	TEMPLATE_LINK_CAPABILITIES,
+	type TemplateLinkDeps,
+} from './templateLinkCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+
+const REF_UUID = '11111111-1111-1111-1111-111111111111';
+const BODY_WITH_REF = `{{ template('${REF_UUID}') }}`;
+
+function makeCtx(): CapabilityContext {
+	const session = {} as unknown as Session;
+	return { session, orgId: 'org-1', sessions: [session] };
+}
+
+function fakeTemplate(over: Partial<FullTemplateFragment> = {}): FullTemplateFragment {
+	return {
+		id: 't1',
+		name: 'Greeting',
+		body: 'remote body',
+		updatedAt: '2024-05-05T00:00:00Z',
+		orgId: 'org-1',
+		organization: { id: 'org-1', name: 'Org One' },
+		contentType: 'text',
+		language: 'jinja',
+		tags: [],
+		...over,
+	} as unknown as FullTemplateFragment;
+}
+
+interface LinkDepOpts {
+	resolveUndefined?: boolean;
+	exists?: boolean;
+	body?: string;
+	getTemplate?: () => Promise<FullTemplateFragment>;
+}
+
+function makeLinkDeps(opts: LinkDepOpts = {}) {
+	const uri = vscode.Uri.file('/ws/greeting.j2');
+	const resolved = opts.resolveUndefined ? undefined : uri;
+	const calls = { getTemplate: 0, readBody: 0 };
+	const deps: TemplateLinkDeps = {
+		resolvePathToUri: () => resolved,
+		fileExists: async () => opts.exists ?? true,
+		readBody: async () => {
+			calls.readBody++;
+			return opts.body ?? BODY_WITH_REF;
+		},
+		getTemplate: async () => {
+			calls.getTemplate++;
+			return opts.getTemplate ? opts.getTemplate() : fakeTemplate();
+		},
+	};
+	return { deps, calls, uri };
+}
+
+function addLink(fsPath: string, templateId = 't1', orgId = 'org-1'): vscode.Uri {
+	const uri = vscode.Uri.file(fsPath);
+	const link: TemplateLink = {
+		uriString: uri.toString(),
+		org: { id: orgId, name: 'Org' },
+		type: 'Template',
+		template: { id: templateId, name: 'Greeting', updatedAt: '1' } as unknown as TemplateLink['template'],
+		bodyHash: 'h',
+	};
+	LinkManager.addLink(link);
+	return uri;
+}
+
+suite('Unit: templateLinkCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	suite('capability descriptors', () => {
+		test('all three are read tools, mcp-only, org-agnostic', () => {
+			for (const name of ['buddy_template_link', 'buddy_template_unlink', 'buddy_template_sync_on_save']) {
+				const c = TEMPLATE_LINK_CAPABILITIES.find(candidate => candidate.spec.name === name);
+				assert.ok(c, `missing ${name}`);
+				assert.strictEqual(c.access, 'read', `${name} access`);
+				assert.strictEqual(c.mcp, true, `${name} mcp`);
+				assert.strictEqual(c.chat, false, `${name} chat`);
+				assert.strictEqual(c.requiresOrg, false, `${name} requiresOrg`);
+			}
+		});
+	});
+
+	suite('buddy_template_link', () => {
+		test('links an existing file, storing the sentinel updatedAt and local bodyHash', async () => {
+			const { deps, uri } = makeLinkDeps({ body: BODY_WITH_REF });
+			const out = JSON.parse(await runLink({ templateId: 't1', uri: 'greeting.j2' }, makeCtx(), deps));
+
+			assert.strictEqual(out.status, 'linked');
+			assert.strictEqual(out.templateId, 't1');
+			assert.strictEqual(out.orgId, 'org-1');
+			assert.deepStrictEqual(out.referencedTemplateIds, [REF_UUID]);
+			assert.ok(LinkManager.isLinked(uri), 'link persisted');
+			const link = LinkManager.getTemplateLink(uri);
+			assert.strictEqual(link.template.updatedAt, '0', 'stores sentinel, not real remote updatedAt');
+			assert.strictEqual((link.template as { body?: unknown }).body, '');
+			assert.strictEqual(link.bodyHash, getHash(BODY_WITH_REF));
+		});
+
+		test('returns invalid_path when the path cannot be resolved', async () => {
+			const { deps } = makeLinkDeps({ resolveUndefined: true });
+			const out = JSON.parse(await runLink({ templateId: 't1', uri: '???' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'invalid_path');
+		});
+
+		test('returns file_not_found when the file does not exist', async () => {
+			const { deps, uri } = makeLinkDeps({ exists: false });
+			const out = JSON.parse(await runLink({ templateId: 't1', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'file_not_found');
+			assert.ok(!LinkManager.isLinked(uri));
+		});
+
+		test('refuses to relink an already-linked file unless overwrite is set', async () => {
+			const uri = vscode.Uri.file('/ws/greeting.j2');
+			addLink('/ws/greeting.j2', 'old-template');
+			const { deps } = makeLinkDeps({});
+
+			const blocked = JSON.parse(await runLink({ templateId: 't1', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(blocked.status, 'already_linked');
+			assert.strictEqual(LinkManager.getTemplateLink(uri).template.id, 'old-template', 'unchanged');
+
+			const replaced = JSON.parse(
+				await runLink({ templateId: 't1', uri: 'greeting.j2', overwrite: true }, makeCtx(), deps),
+			);
+			assert.strictEqual(replaced.status, 'linked');
+			assert.strictEqual(LinkManager.getTemplateLink(uri).template.id, 't1', 'replaced');
+		});
+
+		test('returns template_not_found when no session resolves the template', async () => {
+			const { deps, uri } = makeLinkDeps({
+				getTemplate: async () => {
+					throw new Error('not found');
+				},
+			});
+			const out = JSON.parse(await runLink({ templateId: 'missing', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'template_not_found');
+			assert.ok(!LinkManager.isLinked(uri));
+		});
+
+		test('returns org_mismatch when the template is in a different org than requested', async () => {
+			const { deps, uri } = makeLinkDeps({ getTemplate: async () => fakeTemplate({ orgId: 'org-2' }) });
+			const out = JSON.parse(
+				await runLink({ templateId: 't1', uri: 'greeting.j2', orgId: 'org-1' }, makeCtx(), deps),
+			);
+			assert.strictEqual(out.status, 'org_mismatch');
+			assert.ok(!LinkManager.isLinked(uri));
+		});
+
+		test('rejects a missing templateId', async () => {
+			const { deps } = makeLinkDeps({});
+			await assert.rejects(
+				() => runLink({ uri: 'greeting.j2' }, makeCtx(), deps),
+				/Missing required string argument "templateId"/,
+			);
+		});
+
+		test('finds the template via a later session when the first cannot', async () => {
+			const uri = vscode.Uri.file('/ws/greeting.j2');
+			const s1 = {} as unknown as Session;
+			const s2 = {} as unknown as Session;
+			const deps: TemplateLinkDeps = {
+				resolvePathToUri: () => uri,
+				fileExists: async () => true,
+				readBody: async () => BODY_WITH_REF,
+				getTemplate: async session => {
+					if (session === s1) throw new Error('first session cannot read it');
+					return fakeTemplate();
+				},
+			};
+			const ctx: CapabilityContext = { session: s1, orgId: 'org-1', sessions: [s1, s2] };
+			const out = JSON.parse(await runLink({ templateId: 't1', uri: 'greeting.j2' }, ctx, deps));
+			assert.strictEqual(out.status, 'linked');
+			assert.ok(LinkManager.isLinked(uri));
+		});
+	});
+
+	suite('resolvePathToUri', () => {
+		test('returns undefined for empty or whitespace input', () => {
+			assert.strictEqual(resolvePathToUri(''), undefined);
+			assert.strictEqual(resolvePathToUri('   '), undefined);
+		});
+
+		test('parses a file:// URI', () => {
+			const u = resolvePathToUri('file:///ws/x.j2');
+			assert.ok(u);
+			assert.strictEqual(u.fsPath, '/ws/x.j2');
+		});
+
+		test('treats an absolute path as a file URI', () => {
+			const u = resolvePathToUri('/ws/x.j2');
+			assert.ok(u);
+			assert.strictEqual(u.scheme, 'file');
+			assert.strictEqual(u.fsPath, '/ws/x.j2');
+		});
+
+		test('resolves a relative path against a workspace folder, or undefined without one', () => {
+			const folders = vscode.workspace.workspaceFolders;
+			const u = resolvePathToUri('sub/x.j2');
+			if (!folders || folders.length === 0) {
+				assert.strictEqual(u, undefined);
+			} else {
+				assert.ok(u);
+				assert.ok(u.fsPath.endsWith('/sub/x.j2'));
+			}
+		});
+	});
+
+	suite('buddy_template_unlink', () => {
+		test('removes the link for a linked file', async () => {
+			const uri = addLink('/ws/greeting.j2', 't1');
+			const out = JSON.parse(await runUnlink({ uri: 'greeting.j2' }, makeCtx()));
+			assert.strictEqual(out.status, 'unlinked');
+			assert.strictEqual(out.templateId, 't1');
+			assert.ok(!LinkManager.isLinked(uri), 'link removed');
+		});
+
+		test('returns not_linked when the file is not linked', async () => {
+			const out = JSON.parse(await runUnlink({ uri: 'nope.j2' }, makeCtx()));
+			assert.strictEqual(out.status, 'not_linked');
+		});
+
+		test('rejects a missing uri', async () => {
+			await assert.rejects(() => runUnlink({}, makeCtx()), /Missing required string argument "uri"/);
+		});
+	});
+
+	suite('buddy_template_sync_on_save', () => {
+		test('enables sync-on-save for a linked file', async () => {
+			const uri = addLink('/ws/greeting.j2', 't1');
+			const out = JSON.parse(await runSyncOnSave({ uri: 'greeting.j2', enabled: true }, makeCtx()));
+			assert.strictEqual(out.status, 'updated');
+			assert.strictEqual(out.syncOnSave, true);
+			assert.ok(SyncOnSaveManager.isUriSynced(uri));
+		});
+
+		test('disables sync-on-save for a linked file', async () => {
+			const uri = addLink('/ws/greeting.j2', 't1');
+			SyncOnSaveManager.enableSync(uri);
+			const out = JSON.parse(await runSyncOnSave({ uri: 'greeting.j2', enabled: false }, makeCtx()));
+			assert.strictEqual(out.syncOnSave, false);
+			assert.ok(!SyncOnSaveManager.isUriSynced(uri));
+		});
+
+		test('returns not_linked when the file is not linked', async () => {
+			const out = JSON.parse(await runSyncOnSave({ uri: 'nope.j2', enabled: true }, makeCtx()));
+			assert.strictEqual(out.status, 'not_linked');
+		});
+
+		test('rejects a non-boolean enabled', async () => {
+			addLink('/ws/greeting.j2', 't1');
+			await assert.rejects(
+				() => runSyncOnSave({ uri: 'greeting.j2', enabled: 'yes' }, makeCtx()),
+				/"enabled" must be a boolean/,
+			);
+		});
+	});
+});

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -1,0 +1,314 @@
+import { LinkManager, SyncOnSaveManager, type TemplateLink } from '@models';
+import type { FullTemplateFragment, Session } from '@sessions';
+import { findAllTemplateReferences, getHash, uriExists } from '@utils';
+import vscode from 'vscode';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asString, getTemplateFromAnySession, json, requireString } from './inputHelpers';
+import { resolveLinkedUri } from './templateSyncCapabilities';
+
+/**
+ * Local link-management tools for the MCP surface: associate a local file with a
+ * Rewst template, remove that association, and toggle sync-on-save. They mutate
+ * only the extension's own link state and never call a Rewst write API, so —
+ * per the project's decision that local-only mutations are read-tier — they are
+ * exposed as access:'read' (ungated). They reach the LinkManager /
+ * SyncOnSaveManager singletons directly, like list_template_links. They derive
+ * the org from the link/template, not from ctx.orgId (requiresOrg is false).
+ *
+ * MCP arguments are not validated against inputSchema, so every input is coerced
+ * here (requireString / explicit boolean check).
+ */
+
+const SCHEME_RE = /^[a-zA-Z][a-zA-Z0-9+.-]*:\/\//;
+// Posix (/x) or Windows (C:\x, C:/x) absolute path.
+const ABSOLUTE_RE = /^(?:[a-zA-Z]:[\\/]|[\\/])/;
+
+/**
+ * Resolves a path or file URI to a vscode.Uri WITHOUT requiring it to be linked
+ * (buddy_template_link targets a not-yet-linked file, so resolveLinkedUri does
+ * not apply). file:// URIs are parsed as-is, absolute paths become file URIs,
+ * and a bare relative path is resolved against the first workspace folder.
+ * Returns undefined when the input is empty, malformed, or relative with no
+ * workspace open.
+ */
+export function resolvePathToUri(pathOrUri: string): vscode.Uri | undefined {
+	const value = pathOrUri.trim();
+	if (value === '') return undefined;
+	try {
+		if (SCHEME_RE.test(value)) return vscode.Uri.parse(value);
+		if (ABSOLUTE_RE.test(value)) return vscode.Uri.file(value);
+		const folder = vscode.workspace.workspaceFolders?.[0];
+		if (!folder) return undefined;
+		return vscode.Uri.joinPath(folder.uri, value);
+	} catch {
+		return undefined;
+	}
+}
+
+/** Seams for unit testing; production uses {@link defaultTemplateLinkDeps}. */
+export interface TemplateLinkDeps {
+	resolvePathToUri(pathOrUri: string): vscode.Uri | undefined;
+	fileExists(uri: vscode.Uri): Promise<boolean>;
+	readBody(uri: vscode.Uri): Promise<string>;
+	getTemplate(session: Session, templateId: string): Promise<FullTemplateFragment>;
+}
+
+export const defaultTemplateLinkDeps: TemplateLinkDeps = {
+	resolvePathToUri,
+	fileExists: uri => uriExists(uri),
+	async readBody(uri) {
+		const doc = await vscode.workspace.openTextDocument(uri);
+		return doc.getText();
+	},
+	getTemplate: (session, templateId) => session.getTemplate(templateId),
+};
+
+export async function runLink(
+	input: Record<string, unknown>,
+	ctx: CapabilityContext,
+	deps: TemplateLinkDeps = defaultTemplateLinkDeps,
+): Promise<string> {
+	const templateId = requireString(input, 'templateId');
+	const rawUri = requireString(input, 'uri');
+	const requestedOrgId = asString(input, 'orgId');
+	const overwrite = input.overwrite === true;
+
+	const uri = deps.resolvePathToUri(rawUri);
+	if (!uri) {
+		return json({
+			status: 'invalid_path',
+			uri: rawUri,
+			message:
+				'Could not resolve this to a file. Pass an absolute path, a file:// URI, or a path relative to an open workspace folder.',
+		});
+	}
+	if (!(await deps.fileExists(uri))) {
+		return json({
+			status: 'file_not_found',
+			path: uri.fsPath,
+			message: 'No file exists at this path. Create and save the file first, then link it.',
+		});
+	}
+	if (LinkManager.isLinked(uri) && !overwrite) {
+		return json({
+			status: 'already_linked',
+			path: uri.fsPath,
+			message:
+				'This file is already linked to a template. Pass overwrite:true to replace the link, or unlink it first.',
+		});
+	}
+
+	const found = await getTemplateFromAnySession(ctx.sessions, deps.getTemplate, templateId);
+	if (!found) {
+		return json({
+			status: 'template_not_found',
+			templateId,
+			message:
+				'No template with this id is reachable in the active session(s). Check the id and that you are signed into its org.',
+		});
+	}
+	const template = found.template;
+	if (requestedOrgId && template.orgId !== requestedOrgId) {
+		return json({
+			status: 'org_mismatch',
+			templateId,
+			templateOrgId: template.orgId,
+			requestedOrgId,
+			message: `Template ${templateId} is in org ${template.orgId}, not ${requestedOrgId}.`,
+		});
+	}
+
+	const body = await deps.readBody(uri);
+	const referencedTemplateIds = findAllTemplateReferences(body);
+	const bodyHash = getHash(body);
+	const orgName = template.organization?.name ?? template.orgId;
+	// Mirror LinkTemplateInteractive: store the sentinel updatedAt '0' (not the
+	// real remote timestamp) and an empty body so the first sync reconciles
+	// instead of appearing already in-sync. The bodyHash is of the LOCAL file.
+	template.updatedAt = '0';
+	template.body = '';
+	const templateLink: TemplateLink = {
+		type: 'Template',
+		uriString: uri.toString(),
+		org: { id: template.orgId, name: orgName },
+		template,
+		bodyHash,
+		referencedTemplateIds,
+	};
+	LinkManager.addLink(templateLink);
+	// addLink only schedules a debounced persist; flush so the link survives
+	// before this MCP call returns.
+	await LinkManager.flush();
+
+	return json({
+		status: 'linked',
+		path: uri.fsPath,
+		uri: uri.toString(),
+		templateId: template.id,
+		templateName: template.name,
+		orgId: template.orgId,
+		orgName,
+		referencedTemplateIds,
+		message:
+			'Linked. The link starts out-of-sync (updatedAt sentinel); call buddy_template_sync_status to compare, or buddy_template_sync with a direction to reconcile.',
+	});
+}
+
+export async function runUnlink(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
+	const rawUri = requireString(input, 'uri');
+	const resolved = resolveLinkedUri(rawUri);
+	if (!resolved) {
+		return json({
+			status: 'not_linked',
+			uri: rawUri,
+			message:
+				'No template is linked to this file (or the path matches more than one link). Check list_template_links and pass a fuller path.',
+		});
+	}
+	const { uri, link } = resolved;
+	const { id, name } = link.template;
+	const orgId = link.org.id;
+	// removeLink takes the uriString (not a Uri) and clears the secondary
+	// indexes; the fired onLinksSaved prunes any sync-on-save entry for this uri.
+	LinkManager.removeLink(link.uriString);
+	await LinkManager.flush();
+	return json({
+		status: 'unlinked',
+		path: uri.fsPath,
+		templateId: id,
+		templateName: name,
+		orgId,
+		message: 'Link removed. The local file and the remote template are untouched.',
+	});
+}
+
+export async function runSyncOnSave(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
+	const rawUri = requireString(input, 'uri');
+	const enabled = input.enabled;
+	if (typeof enabled !== 'boolean') {
+		throw new Error('"enabled" must be a boolean (true to enable sync-on-save, false to disable).');
+	}
+	const resolved = resolveLinkedUri(rawUri);
+	if (!resolved) {
+		return json({
+			status: 'not_linked',
+			uri: rawUri,
+			message:
+				'No template is linked to this file (or the path matches more than one link). Link it first with buddy_template_link.',
+		});
+	}
+	const { uri, link } = resolved;
+	if (enabled) {
+		SyncOnSaveManager.enableSync(uri);
+	} else {
+		SyncOnSaveManager.disableSync(uri);
+	}
+	// Report the effective state — it depends on the rewst-buddy.syncOnSaveByDefault
+	// mode, not just raw set membership.
+	const syncOnSave = SyncOnSaveManager.isUriSynced(uri);
+	return json({
+		status: 'updated',
+		path: uri.fsPath,
+		templateId: link.template.id,
+		templateName: link.template.name,
+		syncOnSave,
+		message: syncOnSave
+			? 'Sync-on-save is ON: saving this file uploads it to Rewst.'
+			: 'Sync-on-save is OFF: saving this file does not upload it.',
+	});
+}
+
+const linkSpec: ToolSpec = {
+	name: 'buddy_template_link',
+	args: '{"templateId": string, "uri": string, "orgId"?: string, "overwrite"?: boolean}',
+	description:
+		'Associate an existing local file with an existing Rewst template, so it can be synced. Does not create the file or the template. Identify the file by an absolute path, a workspace-relative path, or a file:// URI. The link starts out-of-sync on purpose — afterwards call buddy_template_sync_status to compare, or buddy_template_sync to reconcile. Returns already_linked unless overwrite is true, and invalid_path / file_not_found / template_not_found / org_mismatch on the obvious failures. This changes only local link state (no Rewst write).',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			templateId: {
+				type: 'string',
+				description: 'Id of the existing Rewst template to link the file to (from list_templates).',
+			},
+			uri: {
+				type: 'string',
+				description: 'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
+			},
+			orgId: {
+				type: 'string',
+				description: 'Optional org id to verify the template belongs to. Defaults to the template’s own org.',
+			},
+			overwrite: {
+				type: 'boolean',
+				description: 'If the file is already linked, replace the existing link instead of failing. Default false.',
+			},
+		},
+		required: ['templateId', 'uri'],
+	},
+};
+
+const unlinkSpec: ToolSpec = {
+	name: 'buddy_template_unlink',
+	args: '{"uri": string}',
+	description:
+		'Remove the link between a local file and its Rewst template. The local file and the remote template are left untouched; only the local association (and its sync-on-save setting) is removed. Identify the file by the path shown in list_template_links or its file URI. Returns not_linked if no template is linked to it.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Path or file URI of the linked file, as shown by list_template_links.',
+			},
+		},
+		required: ['uri'],
+	},
+};
+
+const syncOnSaveSpec: ToolSpec = {
+	name: 'buddy_template_sync_on_save',
+	args: '{"uri": string, "enabled": boolean}',
+	description:
+		'Enable or disable sync-on-save for a linked file: when on, saving the file in VS Code uploads it to its Rewst template. The file must already be linked (see buddy_template_link). Returns the effective syncOnSave state, which also depends on the rewst-buddy.syncOnSaveByDefault setting. This changes only local state (no Rewst write).',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			uri: { type: 'string', description: 'Path or file URI of the linked file.' },
+			enabled: {
+				type: 'boolean',
+				description: 'true to enable sync-on-save (upload on save), false to disable.',
+			},
+		},
+		required: ['uri', 'enabled'],
+	},
+};
+
+export const TEMPLATE_LINK_CAPABILITIES: Capability[] = [
+	{
+		spec: linkSpec,
+		group: 'workspace',
+		access: 'read',
+		chat: false,
+		mcp: true,
+		requiresOrg: false,
+		run: (input, ctx) => runLink(input, ctx),
+	},
+	{
+		spec: unlinkSpec,
+		group: 'workspace',
+		access: 'read',
+		chat: false,
+		mcp: true,
+		requiresOrg: false,
+		run: (input, ctx) => runUnlink(input, ctx),
+	},
+	{
+		spec: syncOnSaveSpec,
+		group: 'workspace',
+		access: 'read',
+		chat: false,
+		mcp: true,
+		requiresOrg: false,
+		run: (input, ctx) => runSyncOnSave(input, ctx),
+	},
+];


### PR DESCRIPTION
## What

Completes #21. Builds on #84 (sync tools) to expose the rest of the extension's template/link operations over MCP. **Stacked on `feat/mcp-template-sync-tools`** — review/merge #84 first (GitHub will retarget this to `main` once #84 merges).

Four new MCP tools:

| Tool | Access | Gating | Purpose |
|---|---|---|---|
| `buddy_template_link` | read | ungated (local-only) | Associate an existing local file with a Rewst template (by id). Stores the sentinel `updatedAt` so the first sync reconciles. |
| `buddy_template_unlink` | read | ungated (local-only) | Remove a file↔template link; local file and remote template untouched. |
| `buddy_template_sync_on_save` | read | ungated (local-only) | Toggle upload-on-save for a linked file; reports the effective state. |
| `buddy_template_bundle_clone` | write | write gate + `writeOrgAllowlist` + approval | Deep-copy a template + its transitive `template('<id>')` refs into new templates in a target org, rewriting refs to the new ids. |

The three local tools are `access:'read'` per the project decision that local-only mutations are read-tier — they reach `LinkManager`/`SyncOnSaveManager` directly and never write to Rewst.

### Bundle clone — the engineering

- **Live graph walk:** re-fetches each referenced template from Rewst (local link refs are unreliable), cycle-safe BFS, **case-insensitive id dedupe**, capped by `maxTemplates` (≤200) and `maxDepth` (≤25).
- **Two-phase create→rewrite:** create an empty template per node to mint new ids, then rewrite each body's refs and **write back the source `contentType`/`language`/`context`/`cloneOverrides`** (a Python/non-Jinja or context-bearing template clones faithfully, not as a default). Tags aren't copied (org-scoped).
- **One approval** scoped to `(target org, root)`; **rollback** deletes every created template on any mid-clone failure.
- Foreign-org, missing, and depth/count-capped references are **reported** (`foreignReferences` / `missingReferences` / `skipped`), not silently dropped. Writes always target the allowlist-gated org; source is read from whatever session manages it.

## Tests

45 unit tests across the two suites: every link branch (invalid_path/file_not_found/already_linked+overwrite/template_not_found/org_mismatch/multi-session), `resolvePathToUri`, unlink, sync-on-save; and for clone — chain rewrite, cycle, diamond, case-variant dedupe, missing/foreign refs, depth/count caps, metadata propagation, create- and update-failure rollback, approval reuse, source-org verification, and the real `defaultTemplateCloneDeps` SDK glue (success + null-response throws). Full unit suite green (734 passing); tsc, eslint, markdownlint, `changelog:check` all clean.

## Review

Authored and ran an adversarial multi-agent review (5 dimensions → per-finding verification). **All 14 confirmed findings are addressed here**, including the high-severity one: the clone now copies `contentType`/`language`/`context`/`cloneOverrides` (was name+body only, which silently produced wrong-typed clones). Also fixed: per-`(org,root)` approval scope (was reusable across different clones and collided with `create_template`), `skipped.depth` now reports the dropped child not the cloned parent, case-insensitive id dedupe, shared `getTemplateFromAnySession`/`json` helpers, and added tests for the production SDK glue, create-failure rollback, multi-session fallback, and `resolvePathToUri`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Template bundle deep-cloning: Recursively clone templates with all transitive dependencies into a target organization, with automatic reference rewriting, cycle-safe processing, single approval workflow, and automatic rollback on failure
  * Template file linking: Link local files to Rewst templates with automatic resolution across sessions, toggle upload-on-save behavior, and full link management via new MCP tools

<!-- end of auto-generated comment: release notes by coderabbit.ai -->