### PR TITLE
Fix sub-org template links being relabeled with the main org on sync

### DIFF
--- a/changelog.d/94.md
+++ b/changelog.d/94.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 94
+---
+
+- **Sub-org template links keep their real org** — Syncing a template that lives in a sub-organization no longer relabels its link with your main org, so link tools, "Open in Rewst", and sync now point at the correct sub-org. Existing mislabeled links self-correct on their next sync.

--- a/changelog.d/94.md
+++ b/changelog.d/94.md
@@ -1,6 +1,6 @@
 ---
 category: Fixed
-pr: 94
+pr: 96
 ---
 
 - **Sub-org template links keep their real org** — Syncing a template that lives in a sub-organization no longer relabels its link with your main org, so link tools, "Open in Rewst", and sync now point at the correct sub-org. Existing mislabeled links self-correct on their next sync.

--- a/src/models/SyncManager.test.ts
+++ b/src/models/SyncManager.test.ts
@@ -5,7 +5,7 @@ import { getHash } from '@utils';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import vscode from 'vscode';
-import { SyncManager } from './SyncManager';
+import { SyncManager, orgFromTemplate } from './SyncManager';
 
 const { suite, test, setup, teardown } = Mocha;
 
@@ -304,6 +304,99 @@ suite('Unit: SyncManager.checkAutoFetch', () => {
 		const updatedLink = LinkManager.getTemplateLink(uri);
 		assert.strictEqual(updatedLink.template.updatedAt, updatedAt);
 		assert.strictEqual(updatedLink.bodyHash, bodyHash);
+	});
+
+	// One session manages a parent org plus its sub-orgs. A sync must record the
+	// org the template actually belongs to (from the template), not the session's
+	// primary org — otherwise sub-org templates report the main org. See issue #94.
+	test('orgFromTemplate uses the template org, falling back to orgId without an organization', () => {
+		const withOrg = Fixtures.fullTemplate({
+			orgId: 'sub-org',
+			organization: Fixtures.org({ id: 'sub-org', name: 'Sub Org' }),
+		});
+		assert.deepStrictEqual(orgFromTemplate(withOrg), { id: 'sub-org', name: 'Sub Org' });
+
+		const withoutOrg = Fixtures.fullTemplate({ orgId: 'sub-org', organization: null as any });
+		assert.deepStrictEqual(orgFromTemplate(withoutOrg), { id: 'sub-org', name: 'sub-org' });
+	});
+
+	test('refreshLinkMetadata keeps a sub-org template in its sub-org, not the session org', () => {
+		const mainOrg = Fixtures.orgModel({ id: 'main-org', name: 'Main Org' });
+		const { session } = createMockSession({
+			profile: { org: mainOrg, allManagedOrgs: [mainOrg, { id: 'sub-org', name: 'Sub Org' }] },
+		});
+		SessionManager._setSessionsForTesting([session]);
+
+		const uri = vscode.Uri.file('/test/sub-org-template.txt');
+		const body = '// sub org template body';
+		// The link is created in the sub-org, as the link commands build it.
+		const existing: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org: { id: 'sub-org', name: 'Sub Org' },
+			template: { id: 'tpl-1', name: 'Sub Tpl', updatedAt: '0' } as any,
+			bodyHash: getHash(body),
+		};
+		LinkManager.addLink(existing);
+
+		const doc = createMockDocument({ uri, content: body });
+		const remoteTemplate = Fixtures.fullTemplate({
+			id: 'tpl-1',
+			name: 'Sub Tpl',
+			body,
+			updatedAt: '2024-02-02T00:00:00Z',
+			orgId: 'sub-org',
+			organization: Fixtures.org({ id: 'sub-org', name: 'Sub Org' }),
+		});
+
+		SyncManager.refreshLinkMetadata(doc, session, remoteTemplate, body);
+
+		const link = LinkManager.getTemplateLink(uri);
+		assert.strictEqual(link.org.id, 'sub-org', 'link must stay in the sub-org');
+		assert.strictEqual(link.org.name, 'Sub Org');
+		assert.notStrictEqual(link.org.id, mainOrg.id, 'must not be rewritten to the session primary org');
+	});
+
+	test('applyTemplateToDocument records the template sub-org, not the session org', async () => {
+		const mainOrg = Fixtures.orgModel({ id: 'main-org', name: 'Main Org' });
+		const { session } = createMockSession({
+			profile: { org: mainOrg, allManagedOrgs: [mainOrg, { id: 'sub-org', name: 'Sub Org' }] },
+		});
+		SessionManager._setSessionsForTesting([session]);
+
+		const uri = vscode.Uri.file('/test/apply-sub-org.txt');
+		const body = '// downloaded body';
+		// Pre-set with the session (main) org so a clobber would be visible.
+		const existing: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org: mainOrg,
+			template: { id: 'tpl-2', name: 'Sub Tpl 2', updatedAt: '0' } as any,
+			bodyHash: getHash('old'),
+		};
+		LinkManager.addLink(existing);
+
+		const doc = createMockDocument({ uri, content: 'old' });
+		const remoteTemplate = Fixtures.fullTemplate({
+			id: 'tpl-2',
+			name: 'Sub Tpl 2',
+			body,
+			updatedAt: '2024-03-03T00:00:00Z',
+			orgId: 'sub-org',
+			organization: Fixtures.org({ id: 'sub-org', name: 'Sub Org' }),
+		});
+
+		// applyTemplateToDocument updates the link before persisting; the final
+		// save of a non-open mock document throws in the unit host, which we ignore.
+		try {
+			await SyncManager.applyTemplateToDocument(doc, session, remoteTemplate);
+		} catch {
+			// expected: vscode.workspace.save of an unopened mock document fails here
+		}
+
+		const link = LinkManager.getTemplateLink(uri);
+		assert.strictEqual(link.org.id, 'sub-org', 'downloaded link must record the template sub-org');
+		assert.strictEqual(link.org.name, 'Sub Org');
 	});
 
 	test('should attempt to apply remote template when local unchanged and remote is newer', async () => {

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -6,6 +6,18 @@ import vscode, { Uri } from 'vscode';
 import { LinkManager } from './LinkManager';
 import { SyncOnSaveManager } from './SyncOnSaveManager';
 import { determineSyncAction, type SyncDecision } from './syncDecision';
+import type { Org } from './types';
+
+/**
+ * The org a template actually belongs to, taken from the template itself — not
+ * from the session's primary org. One session manages a parent org plus its
+ * sub-orgs, so a sub-org template's link must record the sub-org, matching how
+ * the link commands build it. Falls back to the orgId when the organization
+ * relation is absent.
+ */
+export function orgFromTemplate(template: FullTemplateFragment): Org {
+	return { id: template.orgId, name: template.organization?.name ?? template.orgId };
+}
 
 /**
  * Everything needed to act on a sync without re-fetching: the link, the session
@@ -302,7 +314,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 	 */
 	refreshLinkMetadata(
 		doc: vscode.TextDocument,
-		session: Session,
+		_session: Session,
 		remoteTemplate: FullTemplateFragment,
 		localBody: string,
 	): void {
@@ -313,7 +325,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 			referencedTemplateIds: findAllTemplateReferences(localBody),
 			template: remoteTemplate,
 			uriString: doc.uri.toString(),
-			org: session.profile.org,
+			org: orgFromTemplate(remoteTemplate),
 		};
 		this.addLink(templateLink, doc.uri);
 	}
@@ -347,7 +359,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		}
 	}
 
-	async applyTemplateToDocument(doc: vscode.TextDocument, session: Session, remoteTemplate: FullTemplateFragment) {
+	async applyTemplateToDocument(doc: vscode.TextDocument, _session: Session, remoteTemplate: FullTemplateFragment) {
 		log.trace('applyTemplateToDocument: applying remote template', {
 			templateId: remoteTemplate.id,
 			bodyLength: remoteTemplate.body?.length ?? 0,
@@ -370,7 +382,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 			referencedTemplateIds: findAllTemplateReferences(body),
 			template: remoteTemplate,
 			uriString: doc.uri.toString(),
-			org: session.profile.org,
+			org: orgFromTemplate(remoteTemplate),
 		};
 
 		this.addLink(templateLink, doc.uri);


### PR DESCRIPTION
## Problem

A single Rewst session manages a parent (MSP) org plus its sub-orgs. When you link a template that lives in a **sub-org**, the link is created with the template's own org correctly. But on the **first metadata refresh or download sync**, the link's org was silently rewritten to the session's *primary* (main) org.

After that clobber, everything that reads `link.org` reported/targeted the wrong org:

- `buddy_template_link_status` / `search_template_links` showed the main org
- "Open in Rewst" built a `/organizations/<mainOrg>/templates/...` URL
- sync routing resolved against the main org

This is issue #94: "templates linked to a sub org return the main org when they are actually in a sub org."

## Root cause

`SyncManager.refreshLinkMetadata` and `SyncManager.applyTemplateToDocument` rebuilt the `TemplateLink` with `org: session.profile.org` — the session's primary org — instead of the org the template actually belongs to. The three link-creation sites (`LinkTemplateInteractive`, `LinkTemplateFromURL`, `runLink`) all correctly derive the org from the template (`template.orgId` / `template.organization`); only these two sync paths deviated.

## Change

- Add a small shared `orgFromTemplate(template)` helper that returns `{ id: template.orgId, name: template.organization?.name ?? template.orgId }`, matching how the link commands build the org.
- Use it in both sync paths instead of `session.profile.org`. The now-unused `session` parameter is kept (stable shared API) and marked `_session`.
- **Already-mislabeled links self-correct on their next sync**, since the sync now writes the template's true org.

Session routing is unaffected: `SessionManager.indexSession` registers the session under its primary org **and every** managed sub-org, so a sub-org-scoped link still resolves the same session via `getSessionForOrg`.

## Testing

- New colocated unit tests in `src/models/SyncManager.test.ts`:
  - `orgFromTemplate` returns the template org, with `orgId` fallback when the organization relation is absent.
  - `refreshLinkMetadata` keeps a sub-org template in its sub-org (session primary org = `main-org`, template org = `sub-org`).
  - `applyTemplateToDocument` records the template's sub-org, not the session org.
- Verified the regression tests are genuine: reverting the fix to `session.profile.org` turns `refreshLinkMetadata` red (`expected 'sub-org', actual 'main-org'`).
- Full unit suite green (`npm run test:unit`, 823 passing). Prettier + eslint clean; IDE diagnostics zero on the changed files.

No live integration test was added: this is local link-state logic (org derived from a template object), not API or assistant-steering behavior, and it's fully covered by deterministic unit tests.

Addresses #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sub-organization templates now keep the correct organization label when links are synced.
  * “Open in Rewst” and similar tooling now point to the right sub-organization instead of the main org.
  * Previously mislabeled links will automatically correct themselves on the next sync.

* **Tests**
  * Added coverage for sub-organization link handling during template sync and metadata refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->