### PR TITLE
Add Jinja filter docs MCP tool

### DIFF
--- a/changelog.d/93.md
+++ b/changelog.d/93.md
@@ -1,0 +1,6 @@
+---
+category: Added
+pr: 93
+---
+
+- **Jinja filter docs tool** — a new `get_jinja_filter_docs` MCP tool serves the full documentation for Rewst's built-in Jinja filters, so the assistant can look up what a filter does and its signature by name or keyword while writing templates.

--- a/docs/features.md
+++ b/docs/features.md
@@ -104,7 +104,7 @@ Cage-Free Rewsty is still told your VS Code working directory when one is open, 
 
 Rewst-specific actions are exposed through the Rewst Buddy MCP server instead of the chat LM tool surface. MCP exposure uses three switches:
 
-- `rewst-buddy.mcp.enable` exposes all read capabilities: `list_orgs`, `list_templates`, `get_template`, `list_workflows`, `get_workflow`, `rewst_graphql_query`, `buddy_graphql_schema`, `search_template_links`, `buddy_template_link_status`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_render_jinja`, `buddy_action_search`, and `result_read`.
+- `rewst-buddy.mcp.enable` exposes all read capabilities: `list_orgs`, `list_templates`, `get_template`, `list_workflows`, `get_workflow`, `rewst_graphql_query`, `buddy_graphql_schema`, `search_template_links`, `buddy_template_link_status`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_render_jinja`, `buddy_action_search`, `list_jinja_filters`, `get_jinja_filter_docs`, and `result_read`.
 - `rewst-buddy.mcp.enableWriteTools` adds the workflow write helpers `buddy_workflow_edit`, `buddy_workflow_autolayout`, and `buddy_workflow_run`.
 - `rewst-buddy.mcp.enableDangerousGraphqlMutation` unlocks only `rewst_graphql_mutate`, the raw GraphQL mutation tool.
 

--- a/src/capabilities/jinjaDocsCapabilities.test.ts
+++ b/src/capabilities/jinjaDocsCapabilities.test.ts
@@ -1,0 +1,187 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
+import type { CapabilityContext } from './Capability';
+import {
+	JINJA_DOCS_CAPABILITIES,
+	formatJinjaFilters,
+	parseJinjaFilters,
+	_resetJinjaFilterCacheForTesting,
+	_resetJinjaFilterFetcherForTesting,
+	_setJinjaFilterFetcherForTesting,
+	type JinjaFilterDoc,
+} from './jinjaDocsCapabilities';
+
+const { suite, test, setup, teardown } = Mocha;
+const { fakeCtx, cap } = createCapabilityTestHarness(JINJA_DOCS_CAPABILITIES);
+
+const SAMPLE_PAYLOAD = [
+	{
+		kind: 1,
+		label: { label: 'abs' },
+		insertText: 'abs',
+		detail: 'abs filter',
+		documentation: { value: 'Return the absolute value of the argument.' },
+	},
+	{
+		kind: 1,
+		label: { label: 'center', detail: '(width=80)' },
+		insertText: 'center',
+		detail: 'center filter',
+		documentation: { value: 'Centers the value in a field of a given width.' },
+	},
+	{
+		kind: 1,
+		label: 'upper',
+		insertText: 'upper',
+		documentation: 'Convert a value to uppercase.',
+	},
+];
+
+function ctxWithRegion(graphqlUrl: string): CapabilityContext {
+	const session = { profile: { region: { graphqlUrl } } } as unknown as CapabilityContext['session'];
+	return { session, orgId: 'org-1', sessions: [session] };
+}
+
+suite('Unit: jinjaDocsCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetJinjaFilterCacheForTesting();
+		_resetJinjaFilterFetcherForTesting();
+	});
+
+	teardown(() => {
+		_resetJinjaFilterCacheForTesting();
+		_resetJinjaFilterFetcherForTesting();
+	});
+
+	suite('parseJinjaFilters()', () => {
+		test('parses names, signatures, and documentation; sorts by name', () => {
+			const filters = parseJinjaFilters(SAMPLE_PAYLOAD);
+			assert.deepStrictEqual(
+				filters.map(f => f.name),
+				['abs', 'center', 'upper'],
+			);
+			const center = filters.find(f => f.name === 'center')!;
+			assert.strictEqual(center.signature, '(width=80)');
+			assert.strictEqual(center.documentation, 'Centers the value in a field of a given width.');
+		});
+
+		test('reads string label and string documentation forms', () => {
+			const filters = parseJinjaFilters(SAMPLE_PAYLOAD);
+			const upper = filters.find(f => f.name === 'upper')!;
+			assert.strictEqual(upper.signature, undefined);
+			assert.strictEqual(upper.documentation, 'Convert a value to uppercase.');
+		});
+
+		test('skips malformed entries without a name', () => {
+			const filters = parseJinjaFilters([null, 42, {}, { label: {} }, { label: { label: 'ok' } }]);
+			assert.deepStrictEqual(
+				filters.map(f => f.name),
+				['ok'],
+			);
+		});
+
+		test('throws when payload is not an array', () => {
+			assert.throws(() => parseJinjaFilters({ not: 'an array' }));
+		});
+	});
+
+	suite('formatJinjaFilters()', () => {
+		const filters: JinjaFilterDoc[] = parseJinjaFilters(SAMPLE_PAYLOAD);
+
+		test('no arguments lists every filter name with signature, compactly', () => {
+			const output = formatJinjaFilters(filters, {});
+			assert.ok(output.includes('3 Jinja filters'));
+			assert.ok(output.includes('abs'));
+			assert.ok(output.includes('center(width=80)'));
+			assert.ok(output.includes('upper'));
+			// Compact list, not full docs.
+			assert.ok(!output.includes('Centers the value in a field'));
+		});
+
+		test('name lookup returns full documentation, case-insensitively', () => {
+			const output = formatJinjaFilters(filters, { name: 'CENTER' });
+			assert.ok(output.includes('center(width=80)'));
+			assert.ok(output.includes('Centers the value in a field of a given width.'));
+			// Only the matched filter, not the others.
+			assert.ok(!output.includes('absolute value'));
+		});
+
+		test('name lookup miss reports not found', () => {
+			const output = formatJinjaFilters(filters, { name: 'does_not_exist' });
+			assert.ok(/not found/i.test(output));
+			assert.ok(output.includes('does_not_exist'));
+		});
+
+		test('search matches by name and by documentation text', () => {
+			const byName = formatJinjaFilters(filters, { search: 'abs' });
+			assert.ok(byName.includes('abs'));
+			assert.ok(byName.includes('absolute value'));
+
+			const byDoc = formatJinjaFilters(filters, { search: 'uppercase' });
+			assert.ok(byDoc.includes('upper'));
+			assert.ok(byDoc.includes('Convert a value to uppercase.'));
+		});
+
+		test('search miss reports no matches', () => {
+			const output = formatJinjaFilters(filters, { search: 'zzzznope' });
+			assert.ok(/no .*match/i.test(output));
+		});
+
+		test('name takes precedence over search when both supplied', () => {
+			const output = formatJinjaFilters(filters, { name: 'abs', search: 'center' });
+			assert.ok(output.includes('absolute value'));
+			assert.ok(!output.includes('Centers the value'));
+		});
+	});
+
+	suite('get_jinja_filter_docs capability', () => {
+		test('is a read-only, MCP-exposed, org-agnostic capability', () => {
+			const capability = cap('get_jinja_filter_docs');
+			assert.strictEqual(capability.access, 'read');
+			assert.strictEqual(capability.mcp, true);
+			assert.strictEqual(capability.requiresOrg, false);
+		});
+
+		test('fetches filters and formats them', async () => {
+			_setJinjaFilterFetcherForTesting(async () => parseJinjaFilters(SAMPLE_PAYLOAD));
+			const { ctx } = fakeCtx({});
+			const output = await cap('get_jinja_filter_docs').run({ name: 'abs' }, ctx);
+			assert.ok(output.includes('Return the absolute value of the argument.'));
+		});
+
+		test('caches the fetched filters across calls', async () => {
+			let fetchCount = 0;
+			_setJinjaFilterFetcherForTesting(async () => {
+				fetchCount++;
+				return parseJinjaFilters(SAMPLE_PAYLOAD);
+			});
+			const { ctx } = fakeCtx({});
+			await cap('get_jinja_filter_docs').run({}, ctx);
+			await cap('get_jinja_filter_docs').run({ name: 'center' }, ctx);
+			assert.strictEqual(fetchCount, 1);
+		});
+
+		test('derives the engine host from the region api host', async () => {
+			let seenBase = '';
+			_setJinjaFilterFetcherForTesting(async base => {
+				seenBase = base;
+				return parseJinjaFilters(SAMPLE_PAYLOAD);
+			});
+			await cap('get_jinja_filter_docs').run({}, ctxWithRegion('https://api.rewst.io/graphql'));
+			assert.strictEqual(seenBase, 'https://engine.rewst.io');
+		});
+
+		test('falls back to the default engine host when the region is unknown', async () => {
+			let seenBase = '';
+			_setJinjaFilterFetcherForTesting(async base => {
+				seenBase = base;
+				return parseJinjaFilters(SAMPLE_PAYLOAD);
+			});
+			const { ctx } = fakeCtx({});
+			await cap('get_jinja_filter_docs').run({}, ctx);
+			assert.strictEqual(seenBase, 'https://engine.rewst.io');
+		});
+	});
+});

--- a/src/capabilities/jinjaDocsCapabilities.test.ts
+++ b/src/capabilities/jinjaDocsCapabilities.test.ts
@@ -183,5 +183,54 @@ suite('Unit: jinjaDocsCapabilities', () => {
 			await cap('get_jinja_filter_docs').run({}, ctx);
 			assert.strictEqual(seenBase, 'https://engine.rewst.io');
 		});
+
+		// Raw MCP arguments are passed to run() without inputSchema validation, so
+		// run() must coerce defensively. asString() drops non-string values, which
+		// makes a bad name/search behave as if it were absent.
+		test('ignores non-string name/search arguments instead of throwing', async () => {
+			_setJinjaFilterFetcherForTesting(async () => parseJinjaFilters(SAMPLE_PAYLOAD));
+			const { ctx } = fakeCtx({});
+
+			// Both fields wrong-typed → treated as no arguments → the index listing.
+			const index = await cap('get_jinja_filter_docs').run({ name: 123, search: [] }, ctx);
+			assert.ok(index.includes('3 Jinja filters'));
+			assert.ok(!index.includes('absolute value'));
+
+			// Wrong-typed name is ignored, but a valid search still applies.
+			const searched = await cap('get_jinja_filter_docs').run({ name: 123, search: 'uppercase' }, ctx);
+			assert.ok(searched.includes('Convert a value to uppercase.'));
+		});
+
+		test('does not cache a failed fetch; a later call retries', async () => {
+			let calls = 0;
+			_setJinjaFilterFetcherForTesting(async () => {
+				calls++;
+				if (calls === 1) throw new Error('engine unavailable');
+				return parseJinjaFilters(SAMPLE_PAYLOAD);
+			});
+			const { ctx } = fakeCtx({});
+
+			await assert.rejects(() => cap('get_jinja_filter_docs').run({}, ctx), /engine unavailable/);
+			const output = await cap('get_jinja_filter_docs').run({ name: 'abs' }, ctx);
+			assert.ok(output.includes('Return the absolute value of the argument.'));
+			assert.strictEqual(calls, 2, 'a failed fetch is retried, not served from cache');
+		});
+
+		test('default fetcher throws with status detail on a non-OK response', async () => {
+			_resetJinjaFilterFetcherForTesting(); // exercise the real defaultFetcher
+			const originalFetch = globalThis.fetch;
+			globalThis.fetch = (async () => ({
+				ok: false,
+				status: 503,
+				statusText: 'Service Unavailable',
+				json: async () => [],
+			})) as unknown as typeof fetch;
+			try {
+				const { ctx } = fakeCtx({});
+				await assert.rejects(() => cap('get_jinja_filter_docs').run({}, ctx), /HTTP 503 Service Unavailable/);
+			} finally {
+				globalThis.fetch = originalFetch;
+			}
+		});
 	});
 });

--- a/src/capabilities/jinjaDocsCapabilities.ts
+++ b/src/capabilities/jinjaDocsCapabilities.ts
@@ -17,6 +17,8 @@ const FILTERS_PATH = '/jinja/intellisense/filters';
 const DEFAULT_ENGINE_BASE = 'https://engine.rewst.io';
 /** Upper bound on filters rendered for a search, before output-level capping. */
 const MAX_SEARCH_RESULTS = 25;
+/** Abort the catalog fetch if the engine host stalls, so a call can't hang. */
+const FETCH_TIMEOUT_MS = 10_000;
 
 export interface JinjaFilterDoc {
 	/** Filter name as used in a pipe, e.g. `center`. */
@@ -165,7 +167,7 @@ function engineBaseFrom(ctx: CapabilityContext): string {
 
 async function defaultFetcher(engineBaseUrl: string): Promise<JinjaFilterDoc[]> {
 	const url = `${engineBaseUrl}${FILTERS_PATH}`;
-	const response = await fetch(url);
+	const response = await fetch(url, { signal: AbortSignal.timeout(FETCH_TIMEOUT_MS) });
 	if (!response.ok) {
 		throw new Error(
 			`Failed to fetch Jinja filter docs from ${url}: HTTP ${response.status} ${response.statusText}`,

--- a/src/capabilities/jinjaDocsCapabilities.ts
+++ b/src/capabilities/jinjaDocsCapabilities.ts
@@ -1,0 +1,218 @@
+/**
+ * Read-only access to Rewst's Jinja filter documentation.
+ *
+ * Rewst publishes its Jinja intellisense catalog (the same data its in-app
+ * editor uses for autocomplete) at `/jinja/intellisense/filters` on the region's
+ * engine host. This capability fetches that catalog and serves it to assistants
+ * so they can look up filter signatures and docs while writing Rewst templates,
+ * instead of guessing. The catalog is platform-wide (not org-scoped), so the
+ * tool needs no orgId; the engine host is derived from the session's region.
+ */
+
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { asString } from './inputHelpers';
+
+const FILTERS_PATH = '/jinja/intellisense/filters';
+const DEFAULT_ENGINE_BASE = 'https://engine.rewst.io';
+/** Upper bound on filters rendered for a search, before output-level capping. */
+const MAX_SEARCH_RESULTS = 25;
+
+export interface JinjaFilterDoc {
+	/** Filter name as used in a pipe, e.g. `center`. */
+	name: string;
+	/** Parameter signature when the filter takes arguments, e.g. `(width=80)`. */
+	signature?: string;
+	/** Human-readable documentation, possibly multi-line. */
+	documentation: string;
+}
+
+interface FormatInput {
+	name?: string;
+	search?: string;
+}
+
+/** Fetches and parses the filter catalog for one engine base URL. */
+export type JinjaFilterFetcher = (engineBaseUrl: string) => Promise<JinjaFilterDoc[]>;
+
+let activeFetcher: JinjaFilterFetcher | undefined;
+const cacheByBase = new Map<string, JinjaFilterDoc[]>();
+
+/** Test seam: replace the network fetcher with a stub. */
+export function _setJinjaFilterFetcherForTesting(fetcher: JinjaFilterFetcher): void {
+	activeFetcher = fetcher;
+}
+
+/** Test seam: restore the default network fetcher. */
+export function _resetJinjaFilterFetcherForTesting(): void {
+	activeFetcher = undefined;
+}
+
+/** Test seam: drop the in-memory catalog cache. */
+export function _resetJinjaFilterCacheForTesting(): void {
+	cacheByBase.clear();
+}
+
+function readString(value: unknown): string | undefined {
+	return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Parses Rewst's intellisense payload into filter docs. Each entry's name comes
+ * from `label.label` (or a bare string `label`, or `insertText`); the optional
+ * parameter signature from `label.detail`; documentation from
+ * `documentation.value` (or a bare string `documentation`). Malformed entries
+ * without a name are skipped; results are sorted by name for stable output.
+ */
+export function parseJinjaFilters(payload: unknown): JinjaFilterDoc[] {
+	if (!Array.isArray(payload)) {
+		throw new Error('Unexpected Jinja filter payload: expected a JSON array.');
+	}
+	const filters: JinjaFilterDoc[] = [];
+	for (const item of payload) {
+		if (!item || typeof item !== 'object') continue;
+		const record = item as Record<string, unknown>;
+		const label = record.label;
+		let name: string | undefined;
+		let signature: string | undefined;
+		if (typeof label === 'string') {
+			name = label;
+		} else if (label && typeof label === 'object') {
+			const labelRecord = label as Record<string, unknown>;
+			name = readString(labelRecord.label);
+			signature = readString(labelRecord.detail);
+		}
+		name ??= readString(record.insertText);
+		if (!name) continue;
+
+		const doc = record.documentation;
+		let documentation = '';
+		if (typeof doc === 'string') {
+			documentation = doc;
+		} else if (doc && typeof doc === 'object') {
+			documentation = readString((doc as Record<string, unknown>).value) ?? '';
+		}
+		filters.push({ name, signature, documentation });
+	}
+	filters.sort((a, b) => a.name.localeCompare(b.name));
+	return filters;
+}
+
+function displayName(filter: JinjaFilterDoc): string {
+	return filter.signature ? `${filter.name}${filter.signature}` : filter.name;
+}
+
+function renderFull(filter: JinjaFilterDoc): string {
+	const doc = filter.documentation.trim() || '(no documentation provided)';
+	return `## ${displayName(filter)}\n\n${doc}`;
+}
+
+/**
+ * Renders the catalog for the caller. With no arguments, lists every filter name
+ * and signature compactly (one per line). With `name`, returns full docs for the
+ * single matching filter (case-insensitive). With `search`, returns full docs
+ * for filters whose name or documentation contains the term. `name` wins when
+ * both are supplied.
+ */
+export function formatJinjaFilters(filters: JinjaFilterDoc[], input: FormatInput): string {
+	const name = input.name?.trim();
+	if (name) {
+		const lower = name.toLowerCase();
+		const match = filters.find(f => f.name.toLowerCase() === lower);
+		if (!match) {
+			return `Jinja filter "${name}" not found. Call get_jinja_filter_docs with no arguments to see all filter names, or with "search" to match by keyword.`;
+		}
+		return renderFull(match);
+	}
+
+	const search = input.search?.trim();
+	if (search) {
+		const lower = search.toLowerCase();
+		const matches = filters.filter(
+			f => f.name.toLowerCase().includes(lower) || f.documentation.toLowerCase().includes(lower),
+		);
+		if (matches.length === 0) {
+			return `No Jinja filters match "${search}". Call get_jinja_filter_docs with no arguments to see all filter names.`;
+		}
+		const shown = matches.slice(0, MAX_SEARCH_RESULTS);
+		const header =
+			matches.length > shown.length
+				? `${matches.length} Jinja filters match "${search}" (showing first ${shown.length}; narrow your search to see the rest):`
+				: `${matches.length} Jinja filter${matches.length === 1 ? '' : 's'} match "${search}":`;
+		return [header, '', ...shown.map(renderFull)].join('\n\n');
+	}
+
+	const lines = filters.map(f => `- ${displayName(f)}`);
+	return [
+		`${filters.length} Jinja filters available. Pass "name" for one filter's full docs, or "search" to match by keyword.`,
+		'',
+		...lines,
+	].join('\n');
+}
+
+/** Derives the engine host from the session's region (api.* → engine.*). */
+function engineBaseFrom(ctx: CapabilityContext): string {
+	const graphqlUrl = ctx.session?.profile?.region?.graphqlUrl;
+	if (typeof graphqlUrl !== 'string') return DEFAULT_ENGINE_BASE;
+	try {
+		const url = new URL(graphqlUrl);
+		if (!url.host.startsWith('api.')) return DEFAULT_ENGINE_BASE;
+		return `${url.protocol}//engine.${url.host.slice('api.'.length)}`;
+	} catch {
+		return DEFAULT_ENGINE_BASE;
+	}
+}
+
+async function defaultFetcher(engineBaseUrl: string): Promise<JinjaFilterDoc[]> {
+	const url = `${engineBaseUrl}${FILTERS_PATH}`;
+	const response = await fetch(url);
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch Jinja filter docs from ${url}: HTTP ${response.status} ${response.statusText}`,
+		);
+	}
+	return parseJinjaFilters(await response.json());
+}
+
+async function getFilters(ctx: CapabilityContext): Promise<JinjaFilterDoc[]> {
+	const base = engineBaseFrom(ctx);
+	const cached = cacheByBase.get(base);
+	if (cached) return cached;
+	const fetcher = activeFetcher ?? defaultFetcher;
+	const filters = await fetcher(base);
+	cacheByBase.set(base, filters);
+	return filters;
+}
+
+const getJinjaFilterDocsSpec: ToolSpec = {
+	name: 'get_jinja_filter_docs',
+	args: '{"name"?: string, "search"?: string}',
+	description:
+		'Read the documentation for Rewst\'s built-in Jinja filters (the same catalog Rewst\'s in-app editor uses, including the prose docs that list_jinja_filters omits). Pass "name" for one filter\'s full documentation, or "search" to match filters by name or documentation keyword. With no arguments, lists every filter name and signature so you can pick one. Read-only and not org-specific.',
+	inputSchema: {
+		type: 'object',
+		properties: {
+			name: {
+				type: 'string',
+				description: 'Exact filter name to fetch full documentation for (case-insensitive).',
+			},
+			search: { type: 'string', description: 'Keyword to match against filter names and documentation.' },
+		},
+	},
+};
+
+async function runGetJinjaFilterDocs(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const filters = await getFilters(ctx);
+	return formatJinjaFilters(filters, { name: asString(input, 'name'), search: asString(input, 'search') });
+}
+
+export const JINJA_DOCS_CAPABILITIES: Capability[] = [
+	{
+		spec: getJinjaFilterDocsSpec,
+		access: 'read',
+		chat: false,
+		mcp: true,
+		requiresOrg: false,
+		run: runGetJinjaFilterDocs,
+	},
+];

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -17,6 +17,7 @@ import { TEMPLATE_SYNC_CAPABILITIES } from './templateSyncCapabilities';
 import { TEMPLATE_LINK_CAPABILITIES } from './templateLinkCapabilities';
 import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
 import { WORKING_SCOPE_CAPABILITIES } from './workingScopeCapability';
+import { JINJA_DOCS_CAPABILITIES } from './jinjaDocsCapabilities';
 
 /**
  * The single source of truth for Rewst capabilities. Surfaces (chat, MCP) filter
@@ -41,6 +42,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...TEMPLATE_LINK_CAPABILITIES,
 	...TEMPLATE_CLONE_CAPABILITIES,
 	...WORKING_SCOPE_CAPABILITIES,
+	...JINJA_DOCS_CAPABILITIES,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];


### PR DESCRIPTION
## What & why

Introduces a read-only MCP capability **`get_jinja_filter_docs`** that exposes
Rewst's Jinja filter documentation — the same intellisense catalog the in-app
editor uses (`/jinja/intellisense/filters` on the region's engine host).

We already have `list_jinja_filters`, but it sources from the GraphQL
`jinjaFiltersDocumentation` field, which only returns **names + signatures** —
not the prose docs that explain what each filter does. The intellisense endpoint
is the only source that carries the `documentation` text, so this adds a
complementary tool rather than changing the existing one.

The tool is read-only and org-agnostic (`requiresOrg: false`):
- **no args** → compact index of every filter name + signature
- **`name`** → full documentation for one filter (case-insensitive)
- **`search`** → filters matching a keyword in name or docs, with full docs

`src/capabilities/jinjaDocsCapabilities.ts` holds the fetcher, parser,
formatter, in-memory cache, and engine-host derivation (`api.*` → `engine.*`,
falling back to `https://engine.rewst.io`). It's registered in the capabilities
registry, so it surfaces over MCP and in Cage-Free Rewsty in-process. Reachable
when `rewst-buddy.mcp.enable` is on.

## Related issue(s)

Closes #93

## Testing

- **Unit:** added `src/capabilities/jinjaDocsCapabilities.test.ts` (15 cases) —
  parsing (label/doc shapes, malformed entries, non-array input), all three
  format modes plus miss/precedence paths, capability gating
  (read/MCP/org-agnostic), catalog caching, and engine-host
  derivation/fallback. A test seam injects the fetcher so no network is hit.
- Capability registry suite still green (17 passing) — confirms no
  duplicate-name collision with the existing `list_jinja_filters`.
- `npm run type-check` and `eslint` clean.
- Note: `npm test` couldn't run end-to-end in my env (couldn't download VS Code
  1.126.0); ran the suites against the cached `1.125.1` via
  `npx vscode-test --code-version 1.125.1`. Worth a clean run in CI.
- No integration test added — the tool is a plain HTTP fetch with an injected
  fetcher, no live Rewst API surface to exercise.

## Checklist

- [x] Added a changelog note under `changelog.d/` (`changelog.d/93.md`)
- [x] Tests added/updated for the change (unit; no API surface so no integration)
- [x] Docs updated if user-facing (`docs/features.md` tool list)
- [x] Self-reviewed the diff

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Jinja filter documentation tool for looking up built-in filter behavior, signatures, and related details by name or keyword.
  * Expanded the available MCP read tools so the new documentation lookup is exposed alongside existing capabilities.

* **Bug Fixes**
  * Improved filter lookups with clearer matching, better handling of unknown or malformed entries, and more consistent results.
  * Added caching and region-aware routing so documentation is fetched more reliably and efficiently.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->