### PR TITLE
Fix remaining workflow approval issues

### DIFF
--- a/changelog.d/101-103.md
+++ b/changelog.d/101-103.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- Fixed working-scope approval modal visibility, redundant workflow success fallbacks, and workflow run approvals so test/run prompts every time.

--- a/src/capabilities/index.ts
+++ b/src/capabilities/index.ts
@@ -16,6 +16,8 @@ export {
 export {
 	_resetWorkingScopeApproverForTesting,
 	setWorkingScopeApprover,
+	workingScopeApprovalText,
+	type WorkingScopeApprovalText,
 	type WorkingScopeApprover,
 	type WorkingScopeChangeRequest,
 } from './workingScopeCapability';

--- a/src/capabilities/workflowMutateCapability.ts
+++ b/src/capabilities/workflowMutateCapability.ts
@@ -10,6 +10,7 @@ import {
 	WORKFLOW_RUN_TOOL_NAME,
 	runWorkflowTool,
 	workflowEditScope,
+	workflowToolAlwaysPrompts,
 } from '../ui/chat/tools/workflowTools';
 import type { CapabilityContext } from './Capability';
 import { requestMcpMutationApproval } from './graphqlMutateCapability';
@@ -48,7 +49,7 @@ export async function runWorkflowMutationWithApproval(
 	const scope = workflowEditScope(spec.name, input);
 	if (!scope) return missingScopeResult(spec.name);
 
-	const alwaysPrompt = spec.name === WORKFLOW_RUN_TOOL_NAME;
+	const alwaysPrompt = workflowToolAlwaysPrompts(spec.name);
 	if (alwaysPrompt || !isMutationScopeApproved(scope)) {
 		if (!(await requestMcpMutationApproval(scope, operationSummary(spec.name, scope)))) {
 			return approvalRequiredResult();

--- a/src/capabilities/workflowMutateCapability.ts
+++ b/src/capabilities/workflowMutateCapability.ts
@@ -48,11 +48,12 @@ export async function runWorkflowMutationWithApproval(
 	const scope = workflowEditScope(spec.name, input);
 	if (!scope) return missingScopeResult(spec.name);
 
-	if (!isMutationScopeApproved(scope)) {
+	const alwaysPrompt = spec.name === WORKFLOW_RUN_TOOL_NAME;
+	if (alwaysPrompt || !isMutationScopeApproved(scope)) {
 		if (!(await requestMcpMutationApproval(scope, operationSummary(spec.name, scope)))) {
 			return approvalRequiredResult();
 		}
-		approveMutationScope(scope);
+		if (!alwaysPrompt) approveMutationScope(scope);
 	}
 
 	return runWorkflowTool({ tool: spec.name, args: input }, createGraphqlDeps(ctx.session));

--- a/src/capabilities/workingScopeCapability.test.ts
+++ b/src/capabilities/workingScopeCapability.test.ts
@@ -145,4 +145,26 @@ suite('Unit: workingScopeCapability', () => {
 		assert.match(text.detail, /Orgs: Acme \(org-1\)/);
 		assert.match(text.detail, /Workflows: wf-1/);
 	});
+
+	test('working scope approval text uses the MCP requester wording and "set" verb for replace requests', () => {
+		const text = workingScopeApprovalText(
+			{
+				orgs: [{ id: 'org-1', name: 'Acme' }],
+				workflows: ['wf-1'],
+				replace: true,
+			},
+			'mcp',
+		);
+
+		assert.match(text.message, /An external MCP client/);
+		assert.match(text.message, /wants to set the working scope/);
+		assert.match(text.message, /Acme \(org-1\)/);
+	});
+
+	test('working scope approval text falls back to a generic target summary when nothing is requested', () => {
+		const text = workingScopeApprovalText({ orgs: [], workflows: [], replace: false }, 'chat');
+
+		assert.match(text.message, /add to the working scope for the requested targets/);
+		assert.strictEqual(text.detail, '');
+	});
 });

--- a/src/capabilities/workingScopeCapability.test.ts
+++ b/src/capabilities/workingScopeCapability.test.ts
@@ -9,6 +9,7 @@ import {
 	getWorkingScopeCapability,
 	setWorkingScopeApprover,
 	setWorkingScopeCapability,
+	workingScopeApprovalText,
 } from './workingScopeCapability';
 
 const { suite, test, setup, teardown } = Mocha;
@@ -126,5 +127,22 @@ suite('Unit: workingScopeCapability', () => {
 		await setWorkingScopeCapability.run({ workflows: ['wf-1'], replace: true }, ctx);
 
 		assert.deepStrictEqual(WorkingScopeManager.getWorkflows(), ['wf-1']);
+	});
+
+	test('working scope approval text surfaces requested org names and workflow ids in the visible message', () => {
+		const text = workingScopeApprovalText(
+			{
+				orgs: [{ id: 'org-1', name: 'Acme' }],
+				workflows: ['wf-1'],
+				replace: false,
+			},
+			'chat',
+		);
+
+		assert.match(text.message, /Cage-Free Rewsty/);
+		assert.match(text.message, /Acme \(org-1\)/);
+		assert.match(text.message, /wf-1/);
+		assert.match(text.detail, /Orgs: Acme \(org-1\)/);
+		assert.match(text.detail, /Workflows: wf-1/);
 	});
 });

--- a/src/capabilities/workingScopeCapability.ts
+++ b/src/capabilities/workingScopeCapability.ts
@@ -29,6 +29,11 @@ export interface WorkingScopeChangeRequest {
 
 export type WorkingScopeApprover = (request: WorkingScopeChangeRequest, origin: ApprovalOrigin) => Promise<boolean>;
 
+export interface WorkingScopeApprovalText {
+	message: string;
+	detail: string;
+}
+
 // Defaults to reject so a misconfigured host never silently widens scope.
 let approver: WorkingScopeApprover = async () => false;
 
@@ -72,6 +77,31 @@ function managedOrgs(sessions: Session[]): Map<string, string> {
 
 function currentScope(): { orgs: string[]; workflows: string[] } {
 	return { orgs: WorkingScopeManager.getOrgs(), workflows: WorkingScopeManager.getWorkflows() };
+}
+
+function formatNamedOrg(org: NamedOrg): string {
+	return `${org.name} (${org.id})`;
+}
+
+function formatWorkflowId(id: string): string {
+	return `workflow ${id}`;
+}
+
+export function workingScopeApprovalText(
+	request: WorkingScopeChangeRequest,
+	origin: ApprovalOrigin,
+): WorkingScopeApprovalText {
+	const requester = origin === 'chat' ? 'Cage-Free Rewsty' : 'An external MCP client';
+	const verb = request.replace ? 'set' : 'add to';
+	const targets = [...request.orgs.map(formatNamedOrg), ...request.workflows.map(formatWorkflowId)];
+	const targetSummary = targets.length > 0 ? targets.join(', ') : 'the requested targets';
+	const detailParts: string[] = [];
+	if (request.orgs.length > 0) detailParts.push(`Orgs: ${request.orgs.map(formatNamedOrg).join(', ')}`);
+	if (request.workflows.length > 0) detailParts.push(`Workflows: ${request.workflows.join(', ')}`);
+	return {
+		message: `${requester} wants to ${verb} the working scope for ${targetSummary}. Tools will then be allowed to operate within it.`,
+		detail: detailParts.join('\n'),
+	};
 }
 
 const getWorkingScopeSpec: ToolSpec = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,5 +1,5 @@
 import { CommandInitiater } from '@commands';
-import { setMcpMutationApprover, setWorkingScopeApprover } from '@capabilities';
+import { setMcpMutationApprover, setWorkingScopeApprover, workingScopeApprovalText } from '@capabilities';
 import { extPrefix, context as globalVSContext } from '@global';
 import { McpDefinitionProvider, McpServerController } from '@mcp';
 import {
@@ -44,15 +44,10 @@ export async function activate(context: vscode.ExtensionContext) {
 	});
 
 	setWorkingScopeApprover(async (request, origin) => {
-		const requester = origin === 'chat' ? 'Cage-Free Rewsty' : 'An external MCP client';
-		const verb = request.replace ? 'set' : 'add to';
-		const orgList = request.orgs.map(org => `${org.name} (${org.id})`).join(', ');
-		const detailParts: string[] = [];
-		if (request.orgs.length > 0) detailParts.push(`Orgs: ${orgList}`);
-		if (request.workflows.length > 0) detailParts.push(`Workflows: ${request.workflows.join(', ')}`);
+		const approvalText = workingScopeApprovalText(request, origin);
 		const choice = await vscode.window.showWarningMessage(
-			`${requester} wants to ${verb} the working scope. Tools will then be allowed to operate within it.`,
-			{ modal: true, detail: detailParts.join('\n') },
+			approvalText.message,
+			{ modal: true, detail: approvalText.detail },
 			'Approve',
 		);
 		return choice === 'Approve';

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -100,6 +100,14 @@ function workflowMutationRawGraphqlResponse(request: { query?: string }): { data
 	throw new Error(`Unexpected rawGraphql operation in workflow mutation test: ${query}`);
 }
 
+function workflowRunRawGraphqlResponse(request: { query?: string }): { data: unknown } {
+	const query = request.query ?? '';
+	if (query.includes('RewstBuddyTestWorkflow')) {
+		return { data: { data: { testWorkflow: { executionId: 'exec-new' } } } };
+	}
+	throw new Error(`Unexpected rawGraphql operation in workflow run test: ${query}`);
+}
+
 function detectGraphqlOperation(query: string): string {
 	const match = /\b(query|mutation|subscription)\s+([A-Za-z_][A-Za-z0-9_]*)/.exec(query);
 	return match ? `${match[1]} ${match[2]}` : 'rawGraphql';
@@ -616,6 +624,42 @@ suite('Unit: McpActions', () => {
 			const calls = wrapper.getCallsFor('rawGraphql');
 			assert.ok(calls.some(call => String(call.variables.query).includes('RewstBuddyWorkflowGet')));
 			assert.ok(calls.some(call => String(call.variables.query).includes('RewstBuddyWorkflowUpdate')));
+		});
+
+		test('buddy_workflow_run asks for approval every time even after the workflow was approved', async () => {
+			const { session, wrapper } = useSession('org-1', 'Acme');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when<unknown>('rawGraphql', workflowRunRawGraphqlResponse);
+			let approvals = 0;
+			setMcpMutationApprover(async () => {
+				approvals++;
+				return true;
+			});
+			const runRequest = {
+				name: WORKFLOW_RUN_TOOL_NAME,
+				arguments: {
+					orgId: 'org-1',
+					workflowId: 'wf-1',
+					workflowName: 'MCP Sample Workflow',
+					orgName: 'Acme',
+					wait: false,
+				},
+			};
+
+			const first = await callTool(
+				runRequest,
+				settings({ enableWriteTools: true, alwaysAllowedOrgs: ['org-1'] }),
+			);
+			const second = await callTool(
+				runRequest,
+				settings({ enableWriteTools: true, alwaysAllowedOrgs: ['org-1'] }),
+			);
+
+			assert.ok(!first.isError, first.text);
+			assert.ok(!second.isError, second.text);
+			assert.match(first.text, /exec-new/);
+			assert.match(second.text, /exec-new/);
+			assert.strictEqual(approvals, 2, 'running/testing a workflow requires a fresh modal every time');
 		});
 
 		test('an org-scoped tool without orgId throws org_required', async () => {

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -243,10 +243,9 @@ suite('Unit: workflowTools', () => {
 			assert.deepStrictEqual(end.next![0].do, [notify.id]);
 		});
 
-		test('connect inserts a success edge before a pre-existing targetless terminal', () => {
+		test('connect replaces a pre-existing targetless terminal with the real success edge', () => {
 			// A task saved once carries a terminal {{ SUCCEEDED }} with do:[]. Connecting
-			// from it must place the new success edge first, or FOLLOW_FIRST lets the
-			// empty terminal shadow it.
+			// from it must not leave that empty fallback behind once a real success edge exists.
 			const tasksIn = sampleTasks();
 			tasksIn[1].next = [{ when: '{{ SUCCEEDED }}', label: '', do: [], publish: [] }];
 			const ops: WorkflowOperation[] = [
@@ -256,8 +255,8 @@ suite('Unit: workflowTools', () => {
 			const { tasks } = applyOperations(tasksIn as never, ops, NOOP_REF);
 			const end = tasks.find(t => t.name === 'end')!;
 			const after = tasks.find(t => t.name === 'after')!;
-			assert.deepStrictEqual(end.next![0].do, [after.id], 'new connection evaluated first');
-			assert.deepStrictEqual(end.next![1].do, [], 'empty terminal pushed after');
+			assert.strictEqual(end.next!.length, 1);
+			assert.deepStrictEqual(end.next![0].do, [after.id], 'real success edge is the only success fallback');
 		});
 
 		test('add_task with subWorkflowId calls another workflow (its id is the action id)', () => {
@@ -491,6 +490,22 @@ suite('Unit: workflowTools', () => {
 			const start = tasks.find(t => t.name === 'start')!;
 			assert.strictEqual(start.next!.length, 1);
 			assert.deepStrictEqual(start.next![0].do, []);
+		});
+
+		test('connect replaces a targetless success fallback with the real success edge', () => {
+			const tasksIn = sampleTasks();
+			tasksIn[0].next = [{ when: '{{ SUCCEEDED }}', label: '', do: [], publish: [] }];
+
+			const { tasks } = applyOperations(
+				tasksIn as never,
+				[{ op: 'connect', from: 'start', to: 'end' }],
+				NO_ACTIONS,
+			);
+
+			const start = tasks.find(t => t.name === 'start')!;
+			assert.strictEqual(start.next!.length, 1, 'the redundant terminal fallback is removed');
+			assert.strictEqual(start.next![0].when, '{{ SUCCEEDED }}');
+			assert.deepStrictEqual(start.next![0].do, ['bb02']);
 		});
 
 		test('set_transition edits the single transition', () => {
@@ -1499,6 +1514,16 @@ suite('Unit: workflowTools', () => {
 			assert.ok(confirmation);
 			assert.match(confirmation!.message, /Run workflow/);
 			assert.match(confirmation!.message, /executes the workflow/i);
+		});
+
+		test('buddy_workflow_run still prompts after the workflow scope was approved', () => {
+			const args = { workflowId: 'wf-1', workflowName: 'WF', orgId: 'org-1', orgName: 'Acme', input: { a: 1 } };
+			approveMutationScope({ scopeId: 'wf-1', scopeName: 'WF', orgId: 'org-1', orgName: 'Acme' });
+
+			const confirmation = workflowEditConfirmation(WORKFLOW_RUN_TOOL_NAME, args);
+
+			assert.ok(confirmation, 'running/testing a workflow requires approval every time');
+			assert.match(confirmation!.message, /Run workflow/);
 		});
 
 		test('buddy_workflow_edit refuses when scope fields are missing', async () => {

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -508,6 +508,28 @@ suite('Unit: workflowTools', () => {
 			assert.deepStrictEqual(start.next![0].do, ['bb02']);
 		});
 
+		test('keeps a targetless success transition that still publishes context', () => {
+			// A terminal {{ SUCCEEDED }} edge with do:[] but a real publish list is not
+			// a redundant fallback — pruning it would silently drop the published vars.
+			const tasksIn = sampleTasks();
+			tasksIn[0].next = [
+				{ when: '{{ SUCCEEDED }}', label: '', do: ['bb02'], publish: [] },
+				{ when: '{{ SUCCEEDED }}', label: '', do: [], publish: [{ key: 'out', value: '{{ 1 }}' }] },
+			] as never;
+
+			const { tasks } = applyOperations(
+				tasksIn as never,
+				[{ op: 'reposition', task: 'end', x: 5, y: 5 }],
+				NO_ACTIONS,
+			);
+
+			const start = tasks.find(t => t.name === 'start')!;
+			assert.strictEqual(start.next!.length, 2, 'the publishing terminal edge is preserved');
+			const publishing = start.next!.find(t => (t.do ?? []).length === 0);
+			assert.ok(publishing, 'publish-only terminal edge survives');
+			assert.strictEqual((publishing!.publish ?? []).length, 1);
+		});
+
 		test('set_transition edits the single transition', () => {
 			const ops: WorkflowOperation[] = [{ op: 'set_transition', from: 'start', set: { label: 'go' } }];
 			const { tasks } = applyOperations(sampleTasks() as never, ops, NO_ACTIONS);

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -32,6 +32,14 @@ export const WORKFLOW_RUN_TOOL_NAME = 'buddy_workflow_run';
 export const WORKFLOW_EXECUTION_LOGS_TOOL_NAME = 'buddy_execution_logs';
 export const WORKFLOW_SEARCH_TOOL_NAME = 'buddy_workflow_search';
 
+/**
+ * Running a workflow actually executes its automation, so it requires a fresh
+ * approval every time and is never remembered per-session — unlike edit/autolayout.
+ */
+export function workflowToolAlwaysPrompts(name: string): boolean {
+	return name === WORKFLOW_RUN_TOOL_NAME;
+}
+
 /** Identifying fields a workflow-mutation request must carry (org + workflow). */
 const MUTATION_SCOPE_KEYS = ['workflowId', 'workflowName', 'orgId', 'orgName'] as const;
 
@@ -1150,7 +1158,11 @@ function removeRedundantTerminalSuccessTransitions(tasks: RawTask[]): void {
 		if (!transitions || transitions.length < 2) continue;
 		const hasTargetedSuccess = transitions.some(t => isSuccessCondition(t.when) && (t.do ?? []).length > 0);
 		if (!hasTargetedSuccess) continue;
-		task.next = transitions.filter(t => !(isSuccessCondition(t.when) && (t.do ?? []).length === 0));
+		// Only a truly empty fallback is redundant — a targetless success edge that
+		// still publishes context is real work and must survive.
+		task.next = transitions.filter(
+			t => !(isSuccessCondition(t.when) && (t.do ?? []).length === 0 && (t.publish ?? []).length === 0),
+		);
 	}
 }
 
@@ -2033,7 +2045,7 @@ function describeOperation(operation: WorkflowOperation): string {
 export function workflowEditConfirmation(name: string, input: unknown): GraphqlMutationConfirmation | undefined {
 	const scope = workflowEditScope(name, input);
 	if (!scope) return undefined;
-	const alwaysPrompt = name === WORKFLOW_RUN_TOOL_NAME;
+	const alwaysPrompt = workflowToolAlwaysPrompts(name);
 	if (!alwaysPrompt && isMutationScopeApproved(scope)) return undefined;
 	const args = asObject(input);
 	const approvalMemory = alwaysPrompt

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -142,7 +142,7 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 		name: WORKFLOW_RUN_TOOL_NAME,
 		args: '{"workflowId": string, "workflowName": string, "orgId": string, "orgName": string, "input"?: object, "wait"?: boolean}',
 		description:
-			"Trigger a run of a Rewst workflow (via testWorkflow) — to test a workflow end to end or kick it off for another purpose. Pass input as the workflow's run inputs (the parameters from buddy_workflow_get's workflow.inputs). By default the tool WAITS for the run to finish and reports the final status; if it failed it automatically includes the failing task's log (status, message, input, result) so you see the cause in one call without a separate buddy_execution_logs round-trip. Pass wait:false to return immediately with just the execution id. The execution id is included either way; feed it to buddy_execution_logs or buddy_render_jinja to dig further. This actually executes the workflow's automation, so it requires user approval, remembered per workflow for the session.",
+			"Trigger a run of a Rewst workflow (via testWorkflow) — to test a workflow end to end or kick it off for another purpose. Pass input as the workflow's run inputs (the parameters from buddy_workflow_get's workflow.inputs). By default the tool WAITS for the run to finish and reports the final status; if it failed it automatically includes the failing task's log (status, message, input, result) so you see the cause in one call without a separate buddy_execution_logs round-trip. Pass wait:false to return immediately with just the execution id. The execution id is included either way; feed it to buddy_execution_logs or buddy_render_jinja to dig further. This actually executes the workflow's automation, so it requires user approval every time.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -1106,6 +1106,7 @@ export function applyOperations(
 		}
 	}
 	ensureTerminalTransitions(next);
+	removeRedundantTerminalSuccessTransitions(next);
 	orderTransitionsByCondition(next);
 	ensureTaskDefaults(next);
 	layoutNewTasks(next);
@@ -1140,6 +1141,16 @@ function ensureTerminalTransitions(tasks: RawTask[]): void {
 		if ((task.next ?? []).length === 0) {
 			task.next = [{ when: '{{ SUCCEEDED }}', label: '', do: [], publish: [] }];
 		}
+	}
+}
+
+function removeRedundantTerminalSuccessTransitions(tasks: RawTask[]): void {
+	for (const task of tasks) {
+		const transitions = task.next;
+		if (!transitions || transitions.length < 2) continue;
+		const hasTargetedSuccess = transitions.some(t => isSuccessCondition(t.when) && (t.do ?? []).length > 0);
+		if (!hasTargetedSuccess) continue;
+		task.next = transitions.filter(t => !(isSuccessCondition(t.when) && (t.do ?? []).length === 0));
 	}
 }
 
@@ -2021,9 +2032,14 @@ function describeOperation(operation: WorkflowOperation): string {
  */
 export function workflowEditConfirmation(name: string, input: unknown): GraphqlMutationConfirmation | undefined {
 	const scope = workflowEditScope(name, input);
-	if (!scope || isMutationScopeApproved(scope)) return undefined;
+	if (!scope) return undefined;
+	const alwaysPrompt = name === WORKFLOW_RUN_TOOL_NAME;
+	if (!alwaysPrompt && isMutationScopeApproved(scope)) return undefined;
 	const args = asObject(input);
-	const lead = `workflow **${scope.scopeName}** (\`${scope.scopeId}\`) in org **${scope.orgName}** (\`${scope.orgId}\`)? Approving also lets further actions on this same workflow run for the rest of this session without asking again.`;
+	const approvalMemory = alwaysPrompt
+		? ''
+		: ' Approving also lets further actions on this same workflow run for the rest of this session without asking again.';
+	const lead = `workflow **${scope.scopeName}** (\`${scope.scopeId}\`) in org **${scope.orgName}** (\`${scope.orgId}\`)?${approvalMemory}`;
 	let lines: string[];
 	let title = 'Cage-Free Rewsty wants to edit a Rewst workflow';
 	if (name === WORKFLOW_AUTOLAYOUT_TOOL_NAME) {


### PR DESCRIPTION
## What & why

- Fixes working-scope approval visibility by putting requested org names and workflow ids in the modal's main message.
- Removes redundant targetless `{{ SUCCEEDED }}` fallback transitions once a real success edge exists.
- Requires a fresh approval every time `buddy_workflow_run` / `testWorkflow` executes, even after the workflow scope was previously approved.

## Related issues

Closes #101
Closes #102
Closes #103

## Testing

- `npm run test:grep -- "connect replaces|buddy_workflow_run still prompts|working scope approval text|buddy_workflow_run asks for approval every time"` (4 passing)
- `npm run test:grep -- "Unit: workflowTools|Unit: workingScopeCapability|Unit: McpActions"` (149 passing)
- `git diff --check HEAD`
- `npm run type-check`
- `npm run lint`
- `npm run test:changelog` (21 passing)
- `npm run test:unit` (879 passing; VS Code runner emitted existing `Logger.trace` warnings but exited 0)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved working-scope approval dialog text to consistently show org/workflow target details (chat vs external client wording).

* **Bug Fixes**
  * Fixed approval behavior so workflow-run confirmation reliably prompts every time, including when the session previously approved the scope.
  * Removed redundant untargeted success fallback transitions when connecting workflow steps, while preserving published context.
  * Ensured approval prompts appear consistently across workflow run and related approval flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->