### PR TITLE
Fix template link orgs and Buddy tool availability

### DIFF
--- a/changelog.d/buddy-tools-without-mcp-server.md
+++ b/changelog.d/buddy-tools-without-mcp-server.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Cage-Free Rewsty keeps Buddy tools available without the MCP server** — The in-chat Buddy tools no longer require enabling the external MCP endpoint; write tools still follow the existing write-tool gates.

--- a/changelog.d/template-link-org-fallback.md
+++ b/changelog.d/template-link-org-fallback.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Linked-template tools use the real template org** — MCP link/search/sync tools now report the template's actual organization when older local link metadata still points at the main org.

--- a/src/capabilities/Capability.ts
+++ b/src/capabilities/Capability.ts
@@ -43,10 +43,11 @@ export interface Capability {
 	/**
 	 * Exposed through the legacy VS Code language-model chat tool contribution.
 	 * Cage-Free Rewsty's current Buddy path mirrors MCP descriptors in-process,
-	 * so mcp:true capabilities can still be available there when MCP is enabled.
+	 * so mcp:true capabilities can still be available there without exposing the
+	 * external MCP server endpoint.
 	 */
 	chat: boolean;
-	/** Exposed over the MCP server surface and mirrored by Cage-Free Rewsty's Buddy path. */
+	/** Exposed over the MCP server surface and mirrored by Cage-Free Rewsty's in-process Buddy path. */
 	mcp: boolean;
 	/**
 	 * Whether the capability operates on a specific org. When false (e.g.

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -80,6 +80,30 @@ function addLink(fsPath: string, templateId = 't1', orgId = 'org-1'): vscode.Uri
 	return uri;
 }
 
+/**
+ * Adds a link whose stored org is the stale session/parent org while the template
+ * fragment carries the real sub-org. orgForTemplateLink must prefer the template's
+ * org, so the link/status/unlink surfaces should report 'org-real', not 'org-stale'.
+ */
+function addStaleOrgLink(fsPath: string): vscode.Uri {
+	const uri = vscode.Uri.file(fsPath);
+	const link: TemplateLink = {
+		uriString: uri.toString(),
+		org: { id: 'org-stale', name: 'Stale Parent' },
+		type: 'Template',
+		template: {
+			id: 't1',
+			name: 'Greeting',
+			updatedAt: '1',
+			orgId: 'org-real',
+			organization: { id: 'org-real', name: 'Real Sub Org' },
+		} as unknown as TemplateLink['template'],
+		bodyHash: 'h',
+	};
+	LinkManager.addLink(link);
+	return uri;
+}
+
 suite('Unit: templateLinkCapabilities', () => {
 	setup(() => {
 		initTestEnvironment();
@@ -270,6 +294,13 @@ suite('Unit: templateLinkCapabilities', () => {
 			assert.ok(!LinkManager.isLinked(uri), 'link removed');
 		});
 
+		test('reports the template-derived org id, not the stale link.org', async () => {
+			addStaleOrgLink('/ws/greeting.j2');
+			const out = JSON.parse(await runUnlink({ uri: 'greeting.j2' }, makeCtx()));
+			assert.strictEqual(out.status, 'unlinked');
+			assert.strictEqual(out.orgId, 'org-real');
+		});
+
 		test('returns not_linked when the file is not linked', async () => {
 			const out = JSON.parse(await runUnlink({ uri: 'nope.j2' }, makeCtx()));
 			assert.strictEqual(out.status, 'not_linked');
@@ -332,6 +363,14 @@ suite('Unit: templateLinkCapabilities', () => {
 			assert.strictEqual(out.orgId, 'org-1');
 			assert.strictEqual(out.syncOnSave, true);
 			assert.strictEqual(out.path, uri.fsPath);
+		});
+
+		test('reports the template-derived org id and name, not the stale link.org', () => {
+			addStaleOrgLink('/ws/greeting.j2');
+			const out = JSON.parse(runLinkStatus({ uri: 'greeting.j2' }));
+			assert.strictEqual(out.linked, true);
+			assert.strictEqual(out.orgId, 'org-real');
+			assert.strictEqual(out.orgName, 'Real Sub Org');
 		});
 
 		test('reports linked:false when no template is linked', () => {

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -1,4 +1,4 @@
-import { LinkManager, SyncOnSaveManager, type TemplateLink } from '@models';
+import { LinkManager, SyncOnSaveManager, orgForTemplateLink, type TemplateLink } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
 import { findAllTemplateReferences, getHash, uriExists } from '@utils';
 import vscode from 'vscode';
@@ -168,7 +168,7 @@ export async function runUnlink(input: Record<string, unknown>, _ctx: Capability
 	}
 	const { uri, link } = resolved;
 	const { id, name } = link.template;
-	const orgId = link.org.id;
+	const org = orgForTemplateLink(link);
 	// removeLink takes the uriString (not a Uri) and clears the secondary
 	// indexes; the fired onLinksSaved prunes any sync-on-save entry for this uri.
 	LinkManager.removeLink(link.uriString);
@@ -178,7 +178,7 @@ export async function runUnlink(input: Record<string, unknown>, _ctx: Capability
 		path: uri.fsPath,
 		templateId: id,
 		templateName: name,
-		orgId,
+		orgId: org.id,
 		message: 'Link removed. The local file and the remote template are untouched.',
 	});
 }
@@ -202,14 +202,15 @@ export function runLinkStatus(input: Record<string, unknown>): string {
 		});
 	}
 	const { uri, link } = resolved;
+	const org = orgForTemplateLink(link);
 	return json({
 		linked: true,
 		path: uri.fsPath,
 		uri: uri.toString(),
 		templateId: link.template.id,
 		templateName: link.template.name,
-		orgId: link.org.id,
-		orgName: link.org.name,
+		orgId: org.id,
+		orgName: org.name,
 		syncOnSave: SyncOnSaveManager.isUriSynced(uri),
 		message:
 			'Linked. This reflects local link state only (no remote comparison). Use buddy_template_sync_status to compare with the Rewst template, or buddy_search_template_links to list linked files.',

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -21,6 +21,8 @@ const { suite, test, setup, teardown } = Mocha;
 interface TargetOpts {
 	action: SyncDecision['action'];
 	orgId?: string;
+	/** Stale org stored on the link itself; defaults to the template's org. */
+	linkOrgId?: string;
 	remoteOrgId?: string;
 	templateId?: string;
 	templateName?: string;
@@ -38,7 +40,7 @@ function makeTarget(opts: TargetOpts): TemplateSyncTarget {
 	const link = {
 		type: 'Template',
 		uriString: 'file:///ws/greeting.j2',
-		org: { id: orgId, name: 'Sandbox' },
+		org: { id: opts.linkOrgId ?? orgId, name: 'Sandbox' },
 		bodyHash: 'h',
 		template: { id: templateId, name: templateName, updatedAt: opts.localUpdatedAt ?? '1', orgId },
 	} as unknown as TemplateLink;
@@ -168,10 +170,7 @@ suite('Unit: templateSyncCapabilities', () => {
 
 		test('rejects a missing uri', async () => {
 			const { deps } = makeDeps(makeTarget({ action: 'update-metadata' }));
-			await assert.rejects(
-				() => runSyncStatus({}, makeCtx(), deps),
-				/Missing required string argument "uri"/,
-			);
+			await assert.rejects(() => runSyncStatus({}, makeCtx(), deps), /Missing required string argument "uri"/);
 		});
 	});
 
@@ -356,6 +355,32 @@ suite('Unit: templateSyncCapabilities', () => {
 
 		test('refuses when the linked org differs from the requested org', async () => {
 			const { deps, calls } = makeDeps(makeTarget({ action: 'upload-local', orgId: 'org-OTHER' }));
+			setMcpMutationApprover(async () => true);
+			await assert.rejects(
+				() => runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps),
+				/linked to org org-OTHER, not org-sandbox/,
+			);
+			assert.strictEqual(calls.upload, 0);
+		});
+
+		test('uploads when link.org is stale but the template org matches the requested org', async () => {
+			// orgForTemplateLink must derive the real org from template.orgId; trusting
+			// the stale link.org ('org-STALE') would wrongly reject this upload.
+			const { deps, calls } = makeDeps(
+				makeTarget({ action: 'upload-local', orgId: 'org-sandbox', linkOrgId: 'org-STALE' }),
+			);
+			setMcpMutationApprover(async () => true);
+			const out = JSON.parse(await runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps));
+			assert.strictEqual(out.status, 'uploaded');
+			assert.strictEqual(calls.upload, 1);
+		});
+
+		test('refuses when link.org matches the request but the template org does not', async () => {
+			// The guard must follow the template's org, not the stale link.org: here the
+			// link claims the requested org yet the template belongs elsewhere.
+			const { deps, calls } = makeDeps(
+				makeTarget({ action: 'upload-local', orgId: 'org-OTHER', linkOrgId: 'org-sandbox' }),
+			);
 			setMcpMutationApprover(async () => true);
 			await assert.rejects(
 				() => runSync({ orgId: 'org-sandbox', uri: 'greeting.j2' }, makeCtx(), deps),

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -2,6 +2,7 @@ import {
 	LinkManager,
 	SyncManager,
 	SyncOnSaveManager,
+	orgForTemplateLink,
 	type SyncDecision,
 	type SyncDecisionContext,
 	type TemplateLink,
@@ -218,12 +219,13 @@ export async function runSyncStatus(
 	}
 	const { target } = prepared;
 	const { link, remoteTemplate, localBody, decision } = target.context;
+	const org = orgForTemplateLink(link);
 	return JSON.stringify(
 		{
 			linked: true,
 			path: target.uri.fsPath,
-			orgId: link.org.id,
-			orgName: link.org.name,
+			orgId: org.id,
+			orgName: org.name,
 			templateId: link.template.id,
 			templateName: link.template.name,
 			syncOnSave: deps.isSyncOnSaveEnabled(target),
@@ -262,12 +264,13 @@ export async function runSync(
 	}
 	const { target } = prepared;
 	const { link, remoteTemplate, decision } = target.context;
+	const linkedOrg = orgForTemplateLink(link);
 
 	// A session can manage several orgs, so confirm the linked file AND the remote
 	// template belong to the requested org before any upload — otherwise a file
 	// linked to a sibling org could be reached by path.
-	if (link.org.id !== orgId) {
-		throw new Error(`"${uri}" is linked to org ${link.org.id}, not ${orgId}.`);
+	if (linkedOrg.id !== orgId) {
+		throw new Error(`"${uri}" is linked to org ${linkedOrg.id}, not ${orgId}.`);
 	}
 	// Fail closed: a write tool must re-verify the resource's org, so reject an
 	// absent/non-string remote orgId as well as a mismatch.

--- a/src/models/LinkManager.test.ts
+++ b/src/models/LinkManager.test.ts
@@ -698,4 +698,41 @@ suite('Unit: LinkManager', () => {
 			assert.strictEqual(LinkManager.getOrgLinks(org2).length, 0);
 		});
 	});
+
+	suite('Template org normalization', () => {
+		// A stale parent org stored on the link; the template fragment carries the
+		// real sub-org. orgForTemplateLink prefers the template org, and both addLink
+		// and loadLinks must index under the derived org, not the stored one.
+		const staleOrg = { id: 'org-stale', name: 'Stale Parent' };
+		const realOrg = { id: 'org-real', name: 'Real Sub Org' };
+
+		const staleLink = (path: string, id: string): TemplateLink => ({
+			uriString: vscode.Uri.file(path).toString(),
+			org: staleOrg,
+			type: 'Template',
+			template: { id, name: 'T', updatedAt: '', orgId: realOrg.id, organization: realOrg } as any,
+			bodyHash: 'h',
+		});
+
+		test('addLink indexes under the template-derived org, not the stale link.org', () => {
+			const uri = vscode.Uri.file('/test/stale-org.j2');
+			LinkManager.addLink(staleLink('/test/stale-org.j2', 't-add'));
+
+			assert.strictEqual(LinkManager.getOrgLinks(staleOrg).length, 0, 'not indexed under the stale org');
+			assert.strictEqual(LinkManager.getOrgTemplateLinks(realOrg).length, 1, 'indexed under the derived org');
+			assert.strictEqual(LinkManager.getTemplateLink(uri).org.id, realOrg.id, 'stored org normalized');
+		});
+
+		test('loadLinks normalizes a persisted stale link.org', () => {
+			// eslint-disable-next-line @typescript-eslint/no-require-imports
+			const { context } = require('@global');
+			// Use a real file so pruneStaleLinks (fire-and-forget after load) keeps it.
+			context.globalState.update(LinkManager.stateKey, [staleLink(__filename, 't-load')]);
+
+			LinkManager.loadLinks();
+
+			assert.strictEqual(LinkManager.getOrgLinks(staleOrg).length, 0, 'stale org not indexed');
+			assert.strictEqual(LinkManager.getOrgTemplateLinks(realOrg).length, 1, 'derived org indexed');
+		});
+	});
 });

--- a/src/models/LinkManager.ts
+++ b/src/models/LinkManager.ts
@@ -3,7 +3,7 @@ import { context, extPrefix } from '@global';
 import { getHash, isDescendant, log } from '@utils';
 import vscode, { Uri } from 'vscode';
 import { SyncOnSaveManager } from './SyncOnSaveManager';
-import { FolderLink, Link, LinkType, Org, TemplateLink } from './types';
+import { FolderLink, Link, LinkType, Org, TemplateLink, orgForTemplateLink } from './types';
 
 const PERSIST_DEBOUNCE_MS = 300;
 const PRUNE_STAT_CHUNK_SIZE = 50;
@@ -200,6 +200,9 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 
 	addLink(link: Link): _ {
 		log.trace('LinkManager.addLink:', link);
+		if (link.type === 'Template') {
+			link = { ...(link as TemplateLink), org: orgForTemplateLink(link as TemplateLink) };
+		}
 		// Re-linking the same uri to a different template/org must drop the previous
 		// link's secondary-index entries first; otherwise a stale templateIdIndex /
 		// orgIdIndex entry survives and reverse lookups return the old file (#90).

--- a/src/models/types.ts
+++ b/src/models/types.ts
@@ -23,3 +23,22 @@ export interface TemplateLink extends Link {
 export interface FolderLink extends Link {
 	type: 'Folder';
 }
+
+function nonEmptyString(value: unknown): string | undefined {
+	return typeof value === 'string' && value.trim() !== '' ? value : undefined;
+}
+
+/**
+ * A few older flows stored the session's primary org on the link while the
+ * template fragment itself carried the sub-org it actually belonged to. Prefer
+ * the template's org when present so UI/tool surfaces agree on the real owner.
+ */
+export function orgForTemplateLink(link: TemplateLink): Org {
+	const templateOrgId = nonEmptyString(link.template.orgId) ?? nonEmptyString(link.template.organization?.id);
+	if (!templateOrgId) return link.org;
+
+	const templateOrgName = nonEmptyString(link.template.organization?.name);
+	if (templateOrgName) return { id: templateOrgId, name: templateOrgName };
+	if (templateOrgId === link.org.id && link.org.name) return link.org;
+	return { id: templateOrgId, name: templateOrgId };
+}

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
@@ -255,7 +255,7 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 		assert.ok(!textOf(harness.parts).includes('vscode-tool'), 'fence never renders');
 	});
 
-	test('advertises buddy MCP tools when the MCP server is connected', async () => {
+	test('advertises Buddy tools from the in-process Buddy path', async () => {
 		const harness = makeHarness([completeTurn('hi')], { buddyToolSpecs: () => [BUDDY_GET_SPEC] });
 		await harness.run([message(User, [text('what workflows exist?')])]);
 
@@ -265,7 +265,7 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 		assert.ok(harness.captured[0].message.includes('Fetch a workflow'), 'buddy description advertised');
 	});
 
-	test('advertises no buddy tools when the MCP server is disconnected', async () => {
+	test('advertises no Buddy tools when the Buddy spec provider returns none', async () => {
 		const harness = makeHarness([completeTurn('hi')]); // default: buddyToolSpecs → []
 		await harness.run([message(User, [text('hi')])]);
 		assert.ok(!/\bbuddy_/.test(harness.captured[0].message), 'nothing buddy-related is advertised');

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.ts
@@ -58,7 +58,7 @@ export interface ProviderDeps {
 		showActivity: boolean;
 		maxBuddyToolRounds: number;
 	};
-	/** Rewst (buddy) tools to advertise this turn; empty unless the MCP server is on. */
+	/** Rewst (buddy) tools to advertise this turn through the in-process Buddy path. */
 	buddyToolSpecs(): ToolSpec[];
 	/** Runs one buddy tool in-process through the MCP capability surface. */
 	runBuddyTool(name: string, args: Record<string, unknown>, orgId: string): Promise<BuddyToolResult>;

--- a/src/ui/chat/model/buddyChatTools.test.ts
+++ b/src/ui/chat/model/buddyChatTools.test.ts
@@ -6,6 +6,7 @@ import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import { _resetMcpThrottleForTesting, type McpToolDescriptor } from '@mcp';
 import { SessionManager } from '@sessions';
 import { buddyChatToolSpecs, runBuddyChatTool, toolSpecsFromDescriptors } from './buddyChatTools';
+import { WORKFLOW_EDIT_TOOL_NAME } from '../tools/workflowTools';
 
 const { suite, test, setup, teardown } = Mocha;
 
@@ -36,22 +37,25 @@ suite('Unit: buddyChatTools', () => {
 	});
 
 	suite('buddyChatToolSpecs()', () => {
-		test('advertises nothing while the MCP server is disabled (the default)', () => {
-			// rewst-buddy.mcp.enable defaults to false, so an opted-out user gets no
-			// buddy tools injected into Cage-Free Rewsty.
-			assert.deepStrictEqual(buddyChatToolSpecs(), []);
+		test('advertises read Buddy tools even while the external MCP server is disabled', () => {
+			// rewst-buddy.mcp.enable controls external /mcp access only. Cage-Free Rewsty
+			// still needs in-process Buddy tools so server-side Rewst tools are redirected
+			// to the local approval/scope path.
+			const names = buddyChatToolSpecs().map(spec => spec.name);
+			assert.ok(names.length > 0, 'read tools are advertised by default');
+			assert.ok(names.includes('buddy_list_orgs'), 'a known read tool is advertised');
+			assert.ok(names.includes(RESULT_READ_TOOL_NAME), 'result paging is advertised to Cage-Free Rewsty');
+			assert.ok(!names.includes(WORKFLOW_EDIT_TOOL_NAME), 'write tools stay hidden by default');
 		});
 
-		test('advertises the MCP-exposed read tools once the server is enabled', async () => {
+		test('honors the write-tool toggle without requiring the external MCP server', async () => {
 			const config = vscode.workspace.getConfiguration('rewst-buddy.mcp');
-			await config.update('enable', true, vscode.ConfigurationTarget.Global);
+			await config.update('enableWriteTools', true, vscode.ConfigurationTarget.Global);
 			try {
 				const names = buddyChatToolSpecs().map(spec => spec.name);
-				assert.ok(names.length > 0, 'enabling the server advertises the exposed tools');
-				assert.ok(names.includes('buddy_list_orgs'), 'a known read tool is advertised');
-				assert.ok(names.includes(RESULT_READ_TOOL_NAME), 'result paging is advertised to Cage-Free Rewsty');
+				assert.ok(names.includes(WORKFLOW_EDIT_TOOL_NAME), 'write tools follow enableWriteTools');
 			} finally {
-				await config.update('enable', undefined, vscode.ConfigurationTarget.Global);
+				await config.update('enableWriteTools', undefined, vscode.ConfigurationTarget.Global);
 			}
 		});
 	});

--- a/src/ui/chat/model/buddyChatTools.ts
+++ b/src/ui/chat/model/buddyChatTools.ts
@@ -1,4 +1,4 @@
-import { callTool, listTools, McpError, readMcpSettings, type McpToolDescriptor } from '@mcp';
+import { callTool, listTools, McpError, type McpToolDescriptor } from '@mcp';
 import type { ToolSpec } from '../tools/toolProtocol';
 
 /**
@@ -10,10 +10,11 @@ import type { ToolSpec } from '../tools/toolProtocol';
  * the local vscode-tool protocol. Advertising them here, sourced from the same
  * MCP surface, keeps them available regardless of the cap.
  *
- * The list mirrors the MCP exposure exactly: it is empty unless the MCP server
- * is switched on (rewst-buddy.mcp.enable), and write tools appear only when
- * their MCP toggles are on. Execution reuses {@link callTool}, so the write
- * allowlist, throttle, approval, and audit gates are identical to the MCP path.
+ * The list mirrors MCP capability exposure except for the external-server master
+ * switch: rewst-buddy.mcp.enable controls only the /mcp endpoint, not Cage-Free
+ * Rewsty's in-process Buddy path. Write tools still appear only when their MCP
+ * toggles are on. Execution reuses {@link callTool}, so the working-scope,
+ * throttle, approval, and audit gates are identical to the MCP path.
  */
 
 /** Converts MCP tool descriptors into the chat text protocol's tool specs. */
@@ -27,11 +28,11 @@ export function toolSpecsFromDescriptors(descriptors: readonly McpToolDescriptor
 }
 
 /**
- * The buddy tools currently exposed over MCP, as chat tool specs. Empty when the
- * MCP server is disabled — the user opted out, so nothing is advertised.
+ * The Buddy tools exposed to Cage-Free Rewsty, as chat tool specs. This uses the
+ * MCP capability gates for writes/dangerous tools, but intentionally ignores the
+ * external MCP server enable switch.
  */
 export function buddyChatToolSpecs(): ToolSpec[] {
-	if (!readMcpSettings().enable) return [];
 	return toolSpecsFromDescriptors(listTools());
 }
 

--- a/src/ui/chat/tools/workspaceTools.test.ts
+++ b/src/ui/chat/tools/workspaceTools.test.ts
@@ -48,6 +48,27 @@ suite('Unit: workspaceTools', () => {
 			assert.strictEqual(result.output, 'a.jinja ← "My Template" (template tpl-1, org Test Org)');
 		});
 
+		test('buddy_search_template_links reports the template org when persisted link org is stale', async () => {
+			const staleLink = {
+				uriString: vscode.Uri.file('/ws/sub.jinja').toString(),
+				org: { id: 'main-org', name: 'Main Org' },
+				type: 'Template',
+				template: {
+					id: 'tpl-sub',
+					name: 'Sub Template',
+					orgId: 'sub-org',
+					organization: { id: 'sub-org', name: 'Sub Org' },
+				} as TemplateLink['template'],
+				bodyHash: 'hash',
+			} satisfies TemplateLink;
+			const d = deps({ templateLinks: () => [staleLink] });
+
+			const [result] = await runToolRequests([{ tool: 'buddy_search_template_links', args: {} }], d);
+
+			assert.match(result.output, /org Sub Org/);
+			assert.doesNotMatch(result.output, /Main Org/);
+		});
+
 		test('buddy_search_template_links reports when nothing is linked', async () => {
 			const [result] = await runToolRequests([{ tool: 'buddy_search_template_links', args: {} }], deps());
 			assert.strictEqual(result.ok, true);

--- a/src/ui/chat/tools/workspaceTools.ts
+++ b/src/ui/chat/tools/workspaceTools.ts
@@ -1,4 +1,4 @@
-import { LinkManager, type TemplateLink } from '@models';
+import { LinkManager, orgForTemplateLink, type TemplateLink } from '@models';
 import { log } from '@utils';
 import vscode from 'vscode';
 import { describeRequest, type ToolRequest, type ToolResult, type ToolSpec } from './toolProtocol';
@@ -74,10 +74,16 @@ function searchTemplateLinks(deps: WorkspaceToolDeps, args: Record<string, unkno
 	const limit = coercePositiveLimit(args.limit, SEARCH_DEFAULT_LIMIT, SEARCH_MAX_LIMIT);
 
 	const rows = links
-		.map(link => ({ relative: deps.asRelativePath(vscode.Uri.parse(link.uriString)), link }))
-		.filter(({ relative, link }) => {
+		.map(link => ({
+			relative: deps.asRelativePath(vscode.Uri.parse(link.uriString)),
+			link,
+			org: orgForTemplateLink(link),
+		}))
+		.filter(({ relative, link, org }) => {
 			if (query === '') return true;
-			const haystack = [relative, link.template.name, link.template.id, link.org.name].join('\n').toLowerCase();
+			const haystack = [relative, link.template.name, link.template.id, org.id, org.name]
+				.join('\n')
+				.toLowerCase();
 			return haystack.includes(query);
 		})
 		.sort((a, b) => a.relative.localeCompare(b.relative));
@@ -87,8 +93,8 @@ function searchTemplateLinks(deps: WorkspaceToolDeps, args: Record<string, unkno
 	const lines = rows
 		.slice(0, limit)
 		.map(
-			({ relative, link }) =>
-				`${relative} ← "${link.template.name}" (template ${link.template.id}, org ${link.org.name})`,
+			({ relative, link, org }) =>
+				`${relative} ← "${link.template.name}" (template ${link.template.id}, org ${org.name})`,
 		);
 	if (rows.length > lines.length) {
 		lines.push(


### PR DESCRIPTION
## Summary

- Normalize template links to the linked template's organization metadata when available.
- Make template-link Buddy/search tool responses report the same organization the toolbar already shows.
- Keep in-chat Buddy tools available without requiring the external MCP server checkbox.
- Preserve the existing write-tool, dangerous GraphQL, working-scope, approval, throttle, session, and audit gates for Buddy tool execution.
- Add regressions for stale link-level org data and Buddy tool availability while external MCP is disabled.

Fixes #108
Fixes #110

## Tests

- `npm run test:grep -- "Unit: workspaceTools|Unit: LinkManager|Unit: ToolContext"`
- `npm run test:grep -- "Unit: (buddyChatTools|RoboRewstyChatModelProvider)"`
- `npm run test:unit`
- `npm run changelog:check -- --base main`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Template-link search, sync, status, and unlink now show the template’s correct organization instead of stale saved organization data.
  * Organization checks during sync now use the actual linked template organization, reducing false mismatch errors.
  * Linked template records are now stored with the proper organization association when added.

* **Tests**
  * Added coverage for template-link search results to verify the correct organization name is displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
