### PR TITLE
Add OpenSpec baseline and gap coverage

### DIFF
--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -37,7 +37,11 @@ reviews:
               test-first. Any new or changed behavior that lacks a colocated *.test.ts
               case asserting that behavior (plus an integration test under
               src/test/integration/ when live API or assistant behavior is involved) is
-              a blocking issue — request changes, do not approve. The test must assert
+              a blocking issue — request changes, do not approve. Behavior is also
+              specified in openspec/specs/**: a change to observable behavior that
+              contradicts a requirement there, or that lacks a matching spec update in
+              the same PR, is a blocking issue — spec, test, and code move together. The
+              test must assert
               the behavior, not merely that the code runs; flag tests that only cover
               the happy path and skip the error, edge, and skip branches. Do not add
               obvious or redundant comments — match the surrounding comment density and
@@ -99,6 +103,29 @@ reviews:
               Marketplace/GitHub landing page — short and user-facing. Flag coding
               conventions, contributor workflow, or internal technical detail; those
               live in CLAUDE.md or internal docs, not here.
+        - path: 'openspec/specs/**/*.md'
+          instructions: >-
+              OpenSpec capability specs are the behavioral baseline — the normative
+              contract the code and tests must satisfy (conventions in
+              openspec/specs/README.md). Enforce internal consistency: every
+              Requirement uses "SHALL" and carries at least one GIVEN/WHEN/THEN
+              Scenario, and every Scenario sits under a Requirement. Enforce cross-spec
+              consistency: a requirement that references another spec (by backticked
+              title) must name a requirement that exists and must not contradict it;
+              keep terminology identical across specs — flag drift such as renaming the
+              same concept differently in two files; Source lines follow the README
+              convention (point at files, no private function names or line numbers);
+              settings, command titles, and storage keys quoted here mirror package.json
+              contributes.* and the persistence keys. Where a requirement states the
+              target contract but the code does not implement it yet, that gap belongs
+              in a short "Implementation status" note under the requirement, not in
+              softened requirement wording. Most importantly, keep spec and tests
+              aligned: a changed or added requirement/scenario must land in the same PR
+              with the colocated *.test.ts (and an integration test under
+              src/test/integration/ when live API or assistant behavior is involved)
+              that asserts that behavior — flag a spec change with no corresponding test
+              change, and a scenario whose asserted behavior no test covers, as a
+              blocking issue.
 
     # Auto-label PRs by area so reviews and history are easy to scan.
     auto_apply_labels: true
@@ -109,6 +136,8 @@ reviews:
           instructions: 'Changes README.md, docs/, or CLAUDE.md.'
         - label: 'tests'
           instructions: 'Adds or changes *.test.ts files.'
+        - label: 'spec'
+          instructions: 'Changes OpenSpec capability specs under openspec/specs/.'
         - label: 'release'
           instructions: 'A release/* branch: version bump and collated CHANGELOG.md.'
         - label: 'ci'
@@ -134,10 +163,12 @@ reviews:
         semgrep:
             enabled: true
 
-# Let CodeRabbit treat CLAUDE.md and docs as authoritative project guidelines.
+# Let CodeRabbit treat CLAUDE.md, docs, and the OpenSpec baseline as
+# authoritative project guidelines — so code is reviewed against the specs.
 knowledge_base:
     code_guidelines:
         enabled: true
         filePatterns:
             - 'CLAUDE.md'
             - 'docs/**'
+            - 'openspec/specs/**'

--- a/.coderabbit.yaml
+++ b/.coderabbit.yaml
@@ -121,8 +121,9 @@ reviews:
               in a short "Implementation status" note under the requirement, not in
               softened requirement wording. Most importantly, keep spec and tests
               aligned: a changed or added requirement/scenario must land in the same PR
-              with the colocated *.test.ts (and an integration test under
-              src/test/integration/ when live API or assistant behavior is involved)
+              with a corresponding *.test.ts under src/ (colocated with the code it
+              covers, not beside the spec), plus an integration test under
+              src/test/integration/ when live API or assistant behavior is involved,
               that asserts that behavior — flag a spec change with no corresponding test
               change, and a scenario whose asserted behavior no test covers, as a
               blocking issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,6 +344,27 @@ Hover, completion, and definition providers are called frequently during editing
 - Cache regex results when processing the same document repeatedly
 - Keep provider logic minimal - offload to cached manager data
 
+## Spec-Driven Development
+
+`openspec/specs/` holds the behavioral baseline — OpenSpec-style capability specs distilled from the code (conventions in `openspec/specs/README.md`). They are the normative, human-readable contract that sits above the tests: each `Requirement` is a `SHALL` guarantee, each `Scenario` a `GIVEN/WHEN/THEN` behavior under it. Specs describe _what_ the extension guarantees, not _how_ the code is structured — no private function names or line numbers; the `Source:` line points at files for traceability.
+
+**Behavior moves as a trio — spec, test, code — in the same PR.** When you change observable behavior:
+
+1. Update the affected `Requirement`/`Scenario` (or add one) in the relevant `openspec/specs/*/spec.md`.
+2. Write or adjust the colocated `*.test.ts` (plus an integration test when live API or assistant behavior is involved) so a test asserts that scenario. Tests stay the executable contract; the spec is the normative layer above them.
+3. Make the code satisfy both.
+
+Never let them drift: code that contradicts a requirement, a requirement no test covers, and a spec change with no matching test are all gaps to fix, not to defer.
+
+**Consistency when editing a spec:**
+
+- Every `Requirement` uses `SHALL` and carries at least one `Scenario`; every `Scenario` sits under a `Requirement`.
+- Cross-spec references (a requirement citing another spec's requirement by backticked title) must name a requirement that exists and must not contradict it. Keep terminology identical across specs — don't rename the same concept differently in two files.
+- Settings, command titles, and storage keys quoted in a spec mirror `package.json` `contributes.*` and the persistence keys.
+- **Implementation status convention:** when a requirement states the intended contract but the code doesn't fully implement it yet, keep the requirement as the target and add a short _Implementation status_ note under it describing the gap — don't soften the requirement to match a bug.
+
+CodeRabbit enforces this: `openspec/specs/**` is registered as authoritative guidelines so code is reviewed against the specs, and per-path review instructions flag spec/test drift and cross-spec inconsistency.
+
 ## Testing
 
 **IMPORTANT: Write the test first.** Tests are the definition and contract of behavior — every feature and fix starts with a failing test that asserts the intended behavior, then the implementation that makes it pass. No functionality changes without a test that defines it: a colocated `*.test.ts` unit test, plus an integration test when live API or assistant behavior is involved. CodeRabbit treats a functionality change with no test as a blocking issue.

--- a/changelog.d/clear-sessions-secret-leak.md
+++ b/changelog.d/clear-sessions-secret-leak.md
@@ -1,0 +1,5 @@
+---
+category: Security
+---
+
+- **"Clear Sessions" now actually deletes stored credentials** — Previously it only cleared the in-memory session list; saved cookies, the known-profile cache, and the Sessions tree could all still show or restore a "cleared" session. Clearing now removes every stored cookie (including managed-org keys) and the known-profile cache.

--- a/changelog.d/credential-server-host-cors-hardening.md
+++ b/changelog.d/credential-server-host-cors-hardening.md
@@ -1,0 +1,5 @@
+---
+category: Security
+---
+
+- **Local server now enforces loopback-only access** — The credential server refuses to bind a non-localhost host, and rejects any session or template-open request whose remote address, `Host`, or browser `Origin` isn't local, instead of using wildcard CORS.

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -34,3 +34,8 @@ baseline of the extension as it exists today.
 - **Scenario:** a concrete behavior under that requirement, in `GIVEN/WHEN/THEN`.
 - Settings, command titles, and storage keys quoted here mirror
   `package.json` `contributes.*` and the extension's persistence keys.
+- **Implementation status:** when a requirement states the intended/correct
+  contract but the current code does not yet fully implement it, a short
+  _Implementation status_ note follows the requirement saying so. The
+  requirement stays the target contract; the note tracks the gap rather than
+  letting the requirement quietly describe a bug as if it were the design.

--- a/openspec/specs/README.md
+++ b/openspec/specs/README.md
@@ -1,0 +1,36 @@
+# Rewst Buddy — Distilled Specifications
+
+This directory captures the **current** behavior of the Rewst Buddy VS Code
+extension as OpenSpec-style capability specifications. It was distilled from the
+existing codebase (not authored before it) — a brownfield snapshot of what the
+extension does today, so future changes can be proposed as deltas against a
+known baseline.
+
+Each spec describes observable behavior using normative requirements
+(`The system SHALL ...`) and `GIVEN / WHEN / THEN` scenarios. Specs intentionally
+avoid naming private functions or line numbers — they describe _what_ the system
+guarantees, not _how_ the code is structured. The "Source" line under each
+capability points at the implementation for traceability.
+
+## Capability map
+
+| Capability                                         | What it covers                                                                              | Status  |
+| -------------------------------------------------- | ------------------------------------------------------------------------------------------- | ------- |
+| [session-auth](session-auth/spec.md)               | Establishing, persisting, restoring, refreshing Rewst sessions; multi-region; multi-org     | Drafted |
+| [template-linking](template-linking/spec.md)       | Associating local files/folders with Rewst templates; rename/delete tracking; stale pruning | Drafted |
+| [template-sync](template-sync/spec.md)             | Sync-on-save, auto-fetch-on-open, conflict detection, folder background fetch               | Drafted |
+| [template-management](template-management/spec.md) | Create / delete / open / copy-id / open-in-Rewst / bundle templates                         | Drafted |
+| [mcp-bridge](mcp-bridge/spec.md)                   | MCP server exposure, token, read/write tool gating, working scope                           | Drafted |
+| [ai-chat](ai-chat/spec.md)                         | Cage-Free Rewsty chat provider, Ask Rewst AI, Buddy tool protocol, apply edits              | Drafted |
+| [credential-server](credential-server/spec.md)     | Local HTTP server that receives session cookies from the browser extension                  | Drafted |
+| [language-navigation](language-navigation/spec.md) | Hover info and Ctrl+Click navigation for `template()` references                            | Drafted |
+
+Each capability above is written out in full. Together they form a behavioral
+baseline of the extension as it exists today.
+
+## Conventions
+
+- **Requirement:** a single normative guarantee, stated with `SHALL`.
+- **Scenario:** a concrete behavior under that requirement, in `GIVEN/WHEN/THEN`.
+- Settings, command titles, and storage keys quoted here mirror
+  `package.json` `contributes.*` and the extension's persistence keys.

--- a/openspec/specs/ai-chat/spec.md
+++ b/openspec/specs/ai-chat/spec.md
@@ -78,21 +78,33 @@ prompt.
 ### Requirement: Control activity visibility
 
 The system SHALL show the assistant's live activity (searches, tool calls) when
-`rewst-buddy.ai.showActivity` is on, and otherwise wait silently until the answer
-is ready.
+`rewst-buddy.ai.showActivity` is on, and otherwise suppress those intermediate
+activity lines. This setting SHALL NOT disable answer streaming itself; answer
+text may still appear incrementally as the backend produces it.
 
 #### Scenario: Activity hidden
 
 - **GIVEN** `ai.showActivity` is false
 - **WHEN** the assistant runs tools mid-response
-- **THEN** intermediate activity is not surfaced; only the final answer appears
+- **THEN** intermediate activity is not surfaced
+- **AND** answer text may still stream normally
 
 ### Requirement: Run in-process Buddy tools with a per-response cap
 
 The system SHALL let the assistant request local "Buddy" tools via fenced
 `vscode-tool` JSON blocks that the extension intercepts and routes through the
-MCP capability surface, and SHALL cap the number of Buddy tool rounds per
+capability registry, and SHALL cap the number of Buddy tool rounds per
 response at `rewst-buddy.ai.maxBuddyToolRounds` (1–100, default 8).
+Cage-Free Rewsty SHALL have its contributed Buddy tools available in-process
+whenever the model is used, regardless of `rewst-buddy.mcp.enable`; that setting
+controls the external `/mcp` bridge, not the chat model's local tool
+contribution. The in-process path SHALL still honor the capability registry's
+write-tool, dangerous-GraphQL, working-scope, approval, throttle, and
+per-capability gates. Each in-process Buddy tool call SHALL request fresh
+confirmation through VS Code's native tool-confirmation UI; the extension does
+not implement its own approval-reuse cache for this path the way mcp-bridge's
+session-scoped reuse applies to the external MCP transport — any once-vs-session
+memory here comes from VS Code's own auto-approve setting, not the extension.
 
 #### Scenario: Assistant requests a tool
 
@@ -100,6 +112,16 @@ response at `rewst-buddy.ai.maxBuddyToolRounds` (1–100, default 8).
 - **WHEN** the assistant emits a `vscode-tool` block
 - **THEN** the extension parses it, runs the named Buddy tool in-process, and
   feeds the result back as the next turn
+
+#### Scenario: External MCP disabled
+
+- **GIVEN** `rewst-buddy.mcp.enable` is false
+- **AND** the user is chatting with the Cage-Free Rewsty model
+- **WHEN** the model is prepared for a turn
+- **THEN** read-tier Buddy tools are still advertised through the local
+  `vscode-tool` protocol
+- **AND** write-tier and dangerous tools follow their own explicit toggles rather
+  than the external MCP bridge toggle
 
 #### Scenario: Round cap reached
 
@@ -140,11 +162,11 @@ SHALL cap the number of parsed requests from one assistant reply.
 
 ### Requirement: Redirect backend-native Rewst tool attempts
 
-When local Buddy tools are available, the system SHALL prevent backend-native
-Rewst tool activity from being rendered as the final path. It SHALL interrupt the
-native attempt, send a neutral correction that names the local `vscode-tool`
-transport, carry through any resolved native tool arguments, and suppress
-abandoned native output.
+When local Buddy tools are available, including when the external MCP bridge is
+disabled, the system SHALL prevent backend-native Rewst tool activity from being
+rendered as the final path. It SHALL interrupt the native attempt, send a neutral
+correction that names the local `vscode-tool` transport, carry through any
+resolved native tool arguments, and suppress abandoned native output.
 
 #### Scenario: Backend tries a native Rewst tool
 
@@ -153,6 +175,14 @@ abandoned native output.
 - **THEN** the extension sends a correction turn in the same backend conversation
   explaining the local fenced protocol
 - **AND** the abandoned native tool card and output are not shown to the user
+
+#### Scenario: External MCP disabled but Buddy tools available
+
+- **GIVEN** `rewst-buddy.mcp.enable` is false
+- **AND** Cage-Free Rewsty has local Buddy tools available
+- **WHEN** the backend emits native Rewst tool activity
+- **THEN** the extension redirects that native attempt to the local `vscode-tool`
+  transport
 
 #### Scenario: Buddy tools disabled
 

--- a/openspec/specs/ai-chat/spec.md
+++ b/openspec/specs/ai-chat/spec.md
@@ -28,6 +28,33 @@ active organization's session.
 - **THEN** the message is sent to Rewst's AI backend and the streamed response is
   shown in the chat view
 
+### Requirement: Preserve conversation continuity safely
+
+The system SHALL reuse a warm backend conversation for follow-up turns in the
+same visible chat when the replayed VS Code history is still at the backend
+conversation tip. It SHALL fork a fresh backend conversation when the visible
+history has been rewound, and SHALL forget/delete the stale backend conversation
+so rolled-back turns are not reattached later.
+
+#### Scenario: Follow-up turn
+
+- **GIVEN** a user has sent a first message and the backend returned a
+  conversation id
+- **WHEN** the user sends the next message in the same visible chat
+- **THEN** the extension sends only the incremental user turn to the existing
+  backend conversation
+- **AND** it does not re-send the full visible transcript or the transport
+  directive
+
+#### Scenario: Restored checkpoint
+
+- **GIVEN** a visible chat has been restored to an earlier checkpoint
+- **WHEN** the user asks a different follow-up
+- **THEN** the extension starts a fresh backend conversation with a stateless
+  visible transcript
+- **AND** the old backend conversation is forgotten so hidden rolled-back turns
+  cannot leak into the new branch
+
 ### Requirement: Honor conversation type and custom instructions
 
 The system SHALL send the configured conversation type
@@ -79,6 +106,79 @@ response at `rewst-buddy.ai.maxBuddyToolRounds` (1–100, default 8).
 - **GIVEN** an assistant response that keeps requesting tools
 - **WHEN** the number of Buddy tool rounds reaches the configured cap
 - **THEN** further tool rounds are stopped for that response
+
+### Requirement: Parse the local tool protocol defensively
+
+The system SHALL only treat line-start fenced `vscode-tool` JSON blocks as local
+tool requests. It SHALL accept a single request object, an array of request
+objects, and the shorthand shape where tool arguments live at the top level. It
+SHALL ignore malformed blocks, non-line-start fences, and prose wrappers, and
+SHALL cap the number of parsed requests from one assistant reply.
+
+#### Scenario: Multiple local tool requests
+
+- **GIVEN** an assistant reply with a `vscode-tool` block containing an array of
+  valid requests
+- **WHEN** the reply is parsed
+- **THEN** each request is routed in order up to the per-reply request cap
+
+#### Scenario: Invalid protocol text
+
+- **GIVEN** an assistant reply with malformed JSON or an inline non-line-start
+  `vscode-tool` fence
+- **WHEN** the reply is parsed
+- **THEN** no local tool request is emitted from that text
+
+#### Scenario: Mixed Buddy and VS Code tools
+
+- **GIVEN** a parsed reply requests both in-process Buddy tools and VS Code native
+  editor tools
+- **WHEN** Buddy tools are available
+- **THEN** Buddy requests run through the in-process path first
+- **AND** native VS Code tool calls are deferred or surfaced only when they are
+  the remaining available route
+
+### Requirement: Redirect backend-native Rewst tool attempts
+
+When local Buddy tools are available, the system SHALL prevent backend-native
+Rewst tool activity from being rendered as the final path. It SHALL interrupt the
+native attempt, send a neutral correction that names the local `vscode-tool`
+transport, carry through any resolved native tool arguments, and suppress
+abandoned native output.
+
+#### Scenario: Backend tries a native Rewst tool
+
+- **GIVEN** Buddy tools are advertised locally
+- **WHEN** the backend emits activity for a native Rewst tool
+- **THEN** the extension sends a correction turn in the same backend conversation
+  explaining the local fenced protocol
+- **AND** the abandoned native tool card and output are not shown to the user
+
+#### Scenario: Buddy tools disabled
+
+- **GIVEN** no Buddy tools are available locally
+- **WHEN** the backend emits native Rewst tool activity
+- **THEN** that native activity is allowed to stream normally
+
+### Requirement: Surface sources and context usage
+
+The system SHALL append backend-provided sources to final answers and SHALL track
+backend context-window usage so the status bar can show the current org's usage
+percentage and token counts.
+
+#### Scenario: Sources returned
+
+- **GIVEN** the backend completes an answer with source references
+- **WHEN** the answer is rendered
+- **THEN** the visible response includes the source list after the answer
+
+#### Scenario: Context usage returned
+
+- **GIVEN** the backend reports context usage for an org
+- **WHEN** the event is processed
+- **THEN** the current context usage state is updated
+- **AND** the context usage status bar shows the rounded percentage and token
+  breakdown
 
 ### Requirement: Open the assistant quickly
 

--- a/openspec/specs/ai-chat/spec.md
+++ b/openspec/specs/ai-chat/spec.md
@@ -100,11 +100,14 @@ whenever the model is used, regardless of `rewst-buddy.mcp.enable`; that setting
 controls the external `/mcp` bridge, not the chat model's local tool
 contribution. The in-process path SHALL still honor the capability registry's
 write-tool, dangerous-GraphQL, working-scope, approval, throttle, and
-per-capability gates. Each in-process Buddy tool call SHALL request fresh
-confirmation through VS Code's native tool-confirmation UI; the extension does
-not implement its own approval-reuse cache for this path the way mcp-bridge's
-session-scoped reuse applies to the external MCP transport — any once-vs-session
-memory here comes from VS Code's own auto-approve setting, not the extension.
+per-capability gates. Each in-process Buddy tool call that mutates Rewst data
+SHALL be confirmed through the same custom approval modal and session-scoped
+mutation-scope reuse cache that mcp-bridge's external MCP transport uses (see
+mcp-bridge's `Reuse approvals only for reusable mutation scopes` requirement) —
+Buddy tools never surface as native `vscode.lm` tool calls, so VS Code's own
+per-tool confirmation/auto-approve UI does not apply to this path. Approving a
+mutation scope from chat also satisfies it for the external MCP transport
+within the same extension session, and vice versa.
 
 #### Scenario: Assistant requests a tool
 

--- a/openspec/specs/ai-chat/spec.md
+++ b/openspec/specs/ai-chat/spec.md
@@ -1,0 +1,118 @@
+# AI Chat Specification
+
+## Purpose
+
+The extension surfaces Rewst's AI assistant ("Cage-Free Rewsty") as a VS Code
+chat model, lets the assistant run a bounded set of in-process "Buddy" tools, and
+lets users apply the assistant's suggested edits behind a diff preview. This
+capability covers the chat provider, its settings, the tool protocol, and the
+related commands.
+
+Source: `src/ui/chat/` (`model/RoboRewstyChatModelProvider.ts`,
+`tools/toolProtocol.ts`, tool specs), `src/commands/ui/AskRewstAI.ts`,
+`src/commands/ui/ResumeRewstAiConversation.ts`,
+`src/commands/ui/ApplyRewstAiEdit.ts`.
+
+## Requirements
+
+### Requirement: Provide a Rewst-backed chat model
+
+The system SHALL register a VS Code chat model (vendor `rewst-buddy`, displayed
+as "Cage-Free Rewsty") that streams responses from Rewst's AI backend for the
+active organization's session.
+
+#### Scenario: User chats with the model
+
+- **GIVEN** an authenticated session
+- **WHEN** the user selects the Cage-Free Rewsty model and sends a message
+- **THEN** the message is sent to Rewst's AI backend and the streamed response is
+  shown in the chat view
+
+### Requirement: Honor conversation type and custom instructions
+
+The system SHALL send the configured conversation type
+(`rewst-buddy.ai.conversationType`, `HELP_DOCS` or `WORKFLOW_DIAGNOSIS`) with each
+message, and SHALL prepend `rewst-buddy.ai.customInstructions` to every message
+when set. Custom instructions SHALL NOT be able to override Rewst's own system
+prompt.
+
+#### Scenario: Workflow diagnosis mode
+
+- **GIVEN** `ai.conversationType` is `WORKFLOW_DIAGNOSIS`
+- **WHEN** the user sends a message
+- **THEN** the backend conversation is started in workflow-diagnosis mode
+
+#### Scenario: Standing instructions
+
+- **GIVEN** `ai.customInstructions` is set
+- **WHEN** any message is sent
+- **THEN** those instructions are prepended to the user's message
+
+### Requirement: Control activity visibility
+
+The system SHALL show the assistant's live activity (searches, tool calls) when
+`rewst-buddy.ai.showActivity` is on, and otherwise wait silently until the answer
+is ready.
+
+#### Scenario: Activity hidden
+
+- **GIVEN** `ai.showActivity` is false
+- **WHEN** the assistant runs tools mid-response
+- **THEN** intermediate activity is not surfaced; only the final answer appears
+
+### Requirement: Run in-process Buddy tools with a per-response cap
+
+The system SHALL let the assistant request local "Buddy" tools via fenced
+`vscode-tool` JSON blocks that the extension intercepts and routes through the
+MCP capability surface, and SHALL cap the number of Buddy tool rounds per
+response at `rewst-buddy.ai.maxBuddyToolRounds` (1–100, default 8).
+
+#### Scenario: Assistant requests a tool
+
+- **GIVEN** an in-progress assistant response
+- **WHEN** the assistant emits a `vscode-tool` block
+- **THEN** the extension parses it, runs the named Buddy tool in-process, and
+  feeds the result back as the next turn
+
+#### Scenario: Round cap reached
+
+- **GIVEN** an assistant response that keeps requesting tools
+- **WHEN** the number of Buddy tool rounds reaches the configured cap
+- **THEN** further tool rounds are stopped for that response
+
+### Requirement: Open the assistant quickly
+
+The system SHALL provide an `Ask Rewst AI` command (bound to Ctrl+Alt+R /
+Cmd+Alt+R) that opens the chat view, and a command to resume a prior
+conversation.
+
+#### Scenario: Ask Rewst AI
+
+- **WHEN** the user presses Ctrl+Alt+R
+- **THEN** the chat view opens ready for a message
+
+#### Scenario: Resume a conversation
+
+- **GIVEN** prior conversations exist for the org
+- **WHEN** the user runs `Resume Rewst AI Conversation`
+- **THEN** recent conversations are listed and the chosen one's transcript opens
+  as a markdown document
+
+### Requirement: Apply suggested edits behind a diff preview
+
+The system SHALL apply an assistant-suggested code change only after showing a
+diff and an explicit confirmation, and SHALL NOT auto-save the result (leaving
+save — and any resulting sync — to the user).
+
+#### Scenario: User applies a suggestion
+
+- **GIVEN** an assistant answer containing a code block and an active file
+- **WHEN** the user runs `Apply Rewst AI Suggestion`
+- **THEN** a diff of the proposed change is shown, and on confirmation the edit is
+  applied to the file without saving it
+
+#### Scenario: Multiple code blocks
+
+- **GIVEN** an assistant answer with several code blocks
+- **WHEN** the user applies a suggestion
+- **THEN** the user is prompted to choose which block to apply

--- a/openspec/specs/credential-server/spec.md
+++ b/openspec/specs/credential-server/spec.md
@@ -23,11 +23,6 @@ non-loopback interface. The server SHALL run when either
 `rewst-buddy.server.enabled` or `rewst-buddy.mcp.enable` is on, and SHALL guard
 against concurrent starts.
 
-**Implementation status:** today the configured host is passed to `listen()`
-unchecked — a non-loopback `server.host` value is not validated or rejected
-before binding. Validating the host and refusing non-loopback values, as
-described above, is tracked as a security-relevant follow-up.
-
 #### Scenario: Server enabled
 
 - **GIVEN** `rewst-buddy.server.enabled` is on
@@ -66,13 +61,6 @@ when the request still targets a loopback host and remote address. The server
 SHALL NOT use wildcard CORS for routes that can ingest credentials or trigger
 actions; preflight responses SHALL be emitted only after the same local request
 validation passes.
-
-**Implementation status:** today only the external `/mcp` route enforces a Host
-allowlist (via the MCP SDK's `allowedHosts`); the session-ingestion and
-template-open routes perform no Host or remote-address check and respond with a
-wildcard `Access-Control-Allow-Origin: *`. Implementing the loopback enforcement
-and non-wildcard CORS described above for those routes is tracked as a
-security-relevant follow-up.
 
 #### Scenario: Non-local Host header
 

--- a/openspec/specs/credential-server/spec.md
+++ b/openspec/specs/credential-server/spec.md
@@ -14,16 +14,33 @@ Source: `src/server/` (`Server.ts`, `config.ts`, request handlers),
 
 ### Requirement: Run a localhost-only server when enabled
 
-The system SHALL run an HTTP server bound to `rewst-buddy.server.host` (default
-`127.0.0.1`, localhost-only) and `rewst-buddy.server.port` (default `27121`,
-range 1024–65535). The server SHALL run when either `rewst-buddy.server.enabled`
-or `rewst-buddy.mcp.enable` is on, and SHALL guard against concurrent starts.
+The system SHALL run an HTTP server bound only to a loopback host from
+`rewst-buddy.server.host` (default `127.0.0.1`; allowed forms are
+`127.0.0.1`, `localhost`, `::1`, or `[::1]`) and
+`rewst-buddy.server.port` (default `27121`, range 1024–65535). The server SHALL
+refuse to start rather than bind to a wildcard, LAN, public, or otherwise
+non-loopback interface. The server SHALL run when either
+`rewst-buddy.server.enabled` or `rewst-buddy.mcp.enable` is on, and SHALL guard
+against concurrent starts.
+
+**Implementation status:** today the configured host is passed to `listen()`
+unchecked — a non-loopback `server.host` value is not validated or rejected
+before binding. Validating the host and refusing non-loopback values, as
+described above, is tracked as a security-relevant follow-up.
 
 #### Scenario: Server enabled
 
 - **GIVEN** `rewst-buddy.server.enabled` is on
 - **WHEN** the extension activates
-- **THEN** the server listens on the configured host and port
+- **THEN** the server listens on the validated loopback host and port
+
+#### Scenario: Non-loopback host is rejected
+
+- **GIVEN** `rewst-buddy.server.host` is `0.0.0.0`, `::`, a LAN address, a
+  public address, or a hostname that does not resolve to loopback
+- **WHEN** the extension attempts to start the credential server
+- **THEN** the server does not bind the port
+- **AND** the user is notified that only localhost bindings are allowed
 
 #### Scenario: Kept alive by the MCP bridge
 
@@ -36,10 +53,64 @@ or `rewst-buddy.mcp.enable` is on, and SHALL guard against concurrent starts.
 - **WHEN** the user runs `Rewst Buddy: Start Server`
 - **THEN** the server starts if it is not already running
 
+### Requirement: Reject non-local HTTP requests
+
+The system SHALL treat the credential server as a localhost-only control plane.
+For every route, including session ingestion, template-open requests, static
+responses, and the external MCP endpoint, the server SHALL require a loopback
+remote address and a loopback `Host` header. Requests with a non-loopback host,
+forwarded host, or HTTP(S) browser origin that would allow remote websites or
+network peers to drive the server SHALL be rejected before reading credentials
+or executing actions. Companion browser-extension origins MAY be allowed only
+when the request still targets a loopback host and remote address. The server
+SHALL NOT use wildcard CORS for routes that can ingest credentials or trigger
+actions; preflight responses SHALL be emitted only after the same local request
+validation passes.
+
+**Implementation status:** today only the external `/mcp` route enforces a Host
+allowlist (via the MCP SDK's `allowedHosts`); the session-ingestion and
+template-open routes perform no Host or remote-address check and respond with a
+wildcard `Access-Control-Allow-Origin: *`. Implementing the loopback enforcement
+and non-wildcard CORS described above for those routes is tracked as a
+security-relevant follow-up.
+
+#### Scenario: Non-local Host header
+
+- **GIVEN** the server is listening on `127.0.0.1`
+- **WHEN** a request arrives with `Host: attacker.example`
+- **THEN** the request is rejected before any credential, MCP, or template action
+  runs
+
+#### Scenario: Missing or invalid Host header
+
+- **GIVEN** the server receives a request for a credential or action route
+- **WHEN** the `Host` header is missing, malformed, or names a non-loopback host
+- **THEN** the request is rejected before reading the request body
+
+#### Scenario: Browser request from remote origin
+
+- **GIVEN** a browser sends an add-session or open-template request
+- **AND** the request origin or forwarded-host metadata indicates a non-loopback
+  HTTP(S) web origin
+- **WHEN** the server handles the request
+- **THEN** the request is rejected rather than relying on permissive CORS
+
+#### Scenario: Local preflight
+
+- **GIVEN** a browser sends an `OPTIONS` preflight to a credential or action
+  route
+- **AND** the remote address, `Host`, and `Origin` are loopback or an allowed
+  browser-extension origin targeting loopback
+- **WHEN** the server answers the preflight
+- **THEN** the CORS response names the allowed origin instead of `*`
+
 ### Requirement: Create a session from a posted cookie
 
 The system SHALL accept a request to add a session carrying a non-empty cookie
-string, create and validate a session from it, and report the outcome.
+string, create and validate a session from it, and report the outcome. Session
+creation from a posted cookie SHALL reuse the same region-detection and
+session-establishment path as a manually entered cookie (see session-auth's
+`Detect the correct region automatically` requirement).
 
 #### Scenario: Valid cookie posted
 

--- a/openspec/specs/credential-server/spec.md
+++ b/openspec/specs/credential-server/spec.md
@@ -1,0 +1,79 @@
+# Credential Server Specification
+
+## Purpose
+
+Copying a Rewst session cookie by hand is awkward, so the extension runs a small
+localhost HTTP server that a companion browser extension can post the cookie to,
+turning it into a session automatically. The same endpoint can also ask the
+extension to open a specific template. This capability covers that server.
+
+Source: `src/server/` (`Server.ts`, `config.ts`, request handlers),
+`src/commands/server/StartServer.ts`.
+
+## Requirements
+
+### Requirement: Run a localhost-only server when enabled
+
+The system SHALL run an HTTP server bound to `rewst-buddy.server.host` (default
+`127.0.0.1`, localhost-only) and `rewst-buddy.server.port` (default `27121`,
+range 1024–65535). The server SHALL run when either `rewst-buddy.server.enabled`
+or `rewst-buddy.mcp.enable` is on, and SHALL guard against concurrent starts.
+
+#### Scenario: Server enabled
+
+- **GIVEN** `rewst-buddy.server.enabled` is on
+- **WHEN** the extension activates
+- **THEN** the server listens on the configured host and port
+
+#### Scenario: Kept alive by the MCP bridge
+
+- **GIVEN** `rewst-buddy.server.enabled` is off but `rewst-buddy.mcp.enable` is on
+- **WHEN** the extension runs
+- **THEN** the server stays up to serve the bridge
+
+#### Scenario: Manual start
+
+- **WHEN** the user runs `Rewst Buddy: Start Server`
+- **THEN** the server starts if it is not already running
+
+### Requirement: Create a session from a posted cookie
+
+The system SHALL accept a request to add a session carrying a non-empty cookie
+string, create and validate a session from it, and report the outcome.
+
+#### Scenario: Valid cookie posted
+
+- **GIVEN** the browser extension posts an add-session request with a valid cookie
+- **WHEN** the server handles it
+- **THEN** a session is created and validated and the response reports success
+  with the session label
+
+#### Scenario: Cookie creates but fails validation
+
+- **GIVEN** a posted cookie that builds a session but fails validation
+- **WHEN** the server handles it
+- **THEN** the response reports a validation failure
+
+#### Scenario: Malformed request
+
+- **GIVEN** a request missing the required cookie string
+- **WHEN** the server handles it
+- **THEN** the request is rejected as invalid
+
+### Requirement: Open a template on request
+
+The system SHALL accept a request to open a template by org id and template id,
+reusing an existing link when present and otherwise fetching and linking a new
+local file.
+
+#### Scenario: Open a linked template
+
+- **GIVEN** an open-template request whose template is already linked
+- **WHEN** the server handles it
+- **THEN** the linked file is refreshed from remote and shown
+
+#### Scenario: Open an unlinked template
+
+- **GIVEN** an open-template request whose template has no local link
+- **WHEN** the server handles it
+- **THEN** the template is fetched and the user is prompted to save and link it

--- a/openspec/specs/language-navigation/spec.md
+++ b/openspec/specs/language-navigation/spec.md
@@ -1,0 +1,79 @@
+# Language Navigation Specification
+
+## Purpose
+
+Rewst templates reference other templates by id with `template('<uuid>')` calls.
+The extension makes those references navigable inside linked files: hovering shows
+what a referenced template is, and Ctrl+Click jumps to it. This capability covers
+the hover and definition providers and their matching rules.
+
+Source: `src/providers/` (`templatePatternUtils.ts`, `TemplateHoverProvider.ts`,
+`TemplateDefinitionProvider.ts`), `src/models/TemplateMetadataStore.ts`.
+
+## Requirements
+
+### Requirement: Recognize template references
+
+The system SHALL recognize `template('<uuid>')` calls (single or double quotes,
+with optional surrounding whitespace) and identify the referenced template id at
+a given cursor position.
+
+#### Scenario: Cursor inside a reference
+
+- **GIVEN** a line containing `template('<uuid>')`
+- **WHEN** the cursor is within that call
+- **THEN** the provider extracts the referenced template id
+
+### Requirement: Return immediately for unrelated documents
+
+To stay fast during editing, the hover and definition providers SHALL return
+immediately when the document is not a linked template file, before any lookup.
+
+#### Scenario: Hover in an unlinked file
+
+- **GIVEN** a document that is not a linked template
+- **WHEN** the user hovers anywhere
+- **THEN** the provider returns with no work done
+
+### Requirement: Show reference details on hover
+
+On hovering a recognized reference, the system SHALL show the referenced
+template's name and organization when known — preferring a local link, then a
+cached metadata entry — and SHALL indicate when the template is unknown.
+
+#### Scenario: Referenced template is linked locally
+
+- **GIVEN** a reference whose template is linked to a local file
+- **WHEN** the user hovers it
+- **THEN** the hover shows the template name and org
+
+#### Scenario: Referenced template only in cache
+
+- **GIVEN** a reference whose template is not linked but was seen before
+- **WHEN** the user hovers it
+- **THEN** the hover shows the name and org from cached metadata
+
+#### Scenario: Referenced template unknown
+
+- **GIVEN** a reference whose template is neither linked nor cached
+- **WHEN** the user hovers it
+- **THEN** the hover shows the id and marks the template as unknown
+
+### Requirement: Navigate to the referenced template
+
+On Ctrl+Click of a recognized reference, the system SHALL navigate to the linked
+local file when one exists, and otherwise — when the template is known from cache
+— fetch and open it in the background, linking the new file.
+
+#### Scenario: Jump to a linked file
+
+- **GIVEN** a reference whose template is linked locally
+- **WHEN** the user Ctrl+Clicks it
+- **THEN** VS Code navigates to that local file
+
+#### Scenario: Open a cached-but-unlinked template
+
+- **GIVEN** a reference whose template is known from cache but not linked
+- **WHEN** the user Ctrl+Clicks it
+- **THEN** the template is fetched, saved, and linked in the background, and the
+  new file opens

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -3,10 +3,10 @@
 ## Purpose
 
 The extension can expose its authenticated Rewst sessions to external MCP clients
-(and to its own in-process chat) as a set of tools, without handing those clients
-a Rewst credential. This capability covers enabling the bridge, the localhost
-token, which tools are exposed, and the working-scope rules that bound what a tool
-may touch.
+(and to its own in-process chat) as a set of tools and lightweight resources,
+without handing those clients a Rewst credential. This capability covers enabling
+the bridge, the localhost token, which tools and resources are exposed, and the
+working-scope rules that bound what a tool may touch.
 
 Source: `src/mcp/` (`McpServerController.ts`, `McpActions.ts`,
 `McpDefinitionProvider.ts`, `runtime.ts`, `settings.ts`, `throttle.ts`),
@@ -64,6 +64,62 @@ way to register the bridge natively in VS Code with live token injection.
 - **THEN** the bridge is enabled if needed, the native provider is refreshed, and
   VS Code injects the live token without an env-var step
 
+#### Scenario: Tool-set changes force reconnect
+
+- **GIVEN** the bridge is registered with VS Code's native MCP surface
+- **WHEN** the host, port, write-tool toggle, or dangerous-GraphQL toggle changes
+- **THEN** the advertised MCP definition version changes so VS Code can reconnect
+  to the current tool set
+- **AND** the token itself is not included in that version string
+
+### Requirement: Expose the registry-backed tool catalog
+
+The system SHALL expose every capability that opts into MCP from the central
+capability registry, subject to the bridge enablement, write-tool, dangerous
+GraphQL, working-scope, and per-capability access gates. The catalog includes
+Rewst read tools, GraphQL query/schema tools, workflow helpers, workspace
+template-link helpers, template link/sync/mutation/clone tools, workflow CRUD,
+trigger, form, tag, org variable, org/user, pack/integration, page/site/Jinja,
+working-scope, and cached-result tools.
+
+#### Scenario: Read catalog is listed
+
+- **GIVEN** the bridge is enabled and write toggles are off
+- **WHEN** an MCP client lists tools
+- **THEN** read capabilities such as org/template/workflow listing, GraphQL
+  query/schema, workspace template-link search, working-scope reads, and
+  cached-result reads are listed
+- **AND** raw chat-only or write-only tools are not listed
+
+#### Scenario: Capability opts out of MCP
+
+- **GIVEN** a capability that is chat-only
+- **WHEN** an MCP client lists or calls tools
+- **THEN** that capability is unavailable on the MCP surface
+
+### Requirement: Expose bounded MCP resources
+
+The system SHALL expose MCP resources as thin collection views backed by the same
+read capabilities and gates as tools. Resource URIs SHALL use the
+`rewst://{orgId}/templates`, `rewst://{orgId}/templates/{templateId}`,
+`rewst://{orgId}/workflows`, and `rewst://{orgId}/workflows/{workflowId}` forms.
+
+#### Scenario: List resources
+
+- **GIVEN** active sessions and exposed backing list tools
+- **WHEN** an MCP client lists resources
+- **THEN** the bridge advertises template and workflow collection resources for
+  active primary organizations
+
+#### Scenario: Read a collection resource
+
+- **GIVEN** a `rewst://org-1/templates` resource URI
+- **WHEN** an MCP client reads that resource
+- **THEN** the bridge runs the same gated capability used by
+  `buddy_list_templates`
+- **AND** the read is subject to the same scope and rate-limit rules as a tool
+  call
+
 ### Requirement: Gate write tools behind explicit settings
 
 The system SHALL expose write tools (those with `access: 'write'`) only when
@@ -76,6 +132,16 @@ Read tools are available without these switches.
 - **GIVEN** `enableWriteTools` is false
 - **WHEN** a client lists tools
 - **THEN** workflow/template/trigger/variable mutation tools are not callable
+
+#### Scenario: Local workspace state tools
+
+- **GIVEN** the bridge is enabled
+- **WHEN** a client lists tools
+- **THEN** local workspace operations such as `buddy_template_link`,
+  `buddy_template_unlink`, and `buddy_template_sync_on_save` may be exposed as
+  read-access tools because they do not mutate Rewst data
+- **AND** tools that push changes to Rewst, such as `buddy_template_sync` upload
+  paths, remain write-gated
 
 ### Requirement: Bound writes to the effective allowed organizations
 
@@ -134,6 +200,19 @@ discovery tools (those not requiring an org, e.g. `buddy_list_orgs`,
 - **WHEN** `buddy_list_orgs` is called
 - **THEN** it runs without a scope check
 
+#### Scenario: Sole pinned org fills a missing org id
+
+- **GIVEN** exactly one working org is pinned
+- **AND** a tool requires an organization but the caller omits `orgId`
+- **WHEN** the tool runs
+- **THEN** the bridge uses the pinned org as the target org
+
+#### Scenario: Missing org cannot be inferred
+
+- **GIVEN** no working org is pinned, or more than one working org is pinned
+- **WHEN** an org-scoped tool is called without `orgId`
+- **THEN** the bridge rejects the call with `org_required`
+
 ### Requirement: A model may only request a scope change
 
 The system SHALL treat the working scope as the user's deliberate selection. A
@@ -169,3 +248,53 @@ duration), and tag the approval origin so that approval prompts name the caller.
 - **GIVEN** an MCP client issuing many calls in a short window
 - **WHEN** the rate limit is exceeded
 - **THEN** further calls are throttled
+
+#### Scenario: Audit log cannot be forged
+
+- **GIVEN** a caller supplies a tool name or input containing line separators or
+  secret-looking values
+- **WHEN** the bridge writes the audit record
+- **THEN** the audit line contains the tool, resolved org, outcome, and duration
+- **AND** the log does not include tool arguments or embedded line separators
+
+### Requirement: Page oversized tool results
+
+The system SHALL keep MCP tool responses below the transport-friendly output
+limit by returning a preview for oversized text results and caching the full
+result in memory for `buddy_result_read`. Cached result reads SHALL support
+offset/limit paging and line search, and SHALL fail clearly when an id has been
+evicted or was never cached.
+
+#### Scenario: Oversized output
+
+- **GIVEN** a tool produces text longer than the MCP output preview limit
+- **WHEN** the bridge formats the result
+- **THEN** the returned text contains a preview, a cache id, a continuation call
+  for `buddy_result_read`, and a search example
+
+#### Scenario: Read cached output
+
+- **GIVEN** an oversized result was cached
+- **WHEN** `buddy_result_read` is called with that id and an offset
+- **THEN** the bridge returns the requested character slice without re-running the
+  original Rewst API call
+
+### Requirement: Reuse approvals only for reusable mutation scopes
+
+The system SHALL remember approval for mutation scopes that are safe to reuse
+within the current extension session, such as repeated writes to the same
+approved GraphQL or workflow-edit scope. It SHALL still require fresh approval
+for operations whose execution itself is the risky action, such as running a
+workflow.
+
+#### Scenario: Reused raw GraphQL mutation approval
+
+- **GIVEN** a raw GraphQL mutation scope was approved for an org and resource
+- **WHEN** the same mutation scope is requested again in the same session
+- **THEN** the mutation can run without prompting again
+
+#### Scenario: Workflow run approval is always fresh
+
+- **GIVEN** a workflow run was approved previously
+- **WHEN** the same workflow is run again
+- **THEN** the user is prompted again before the run starts

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -1,0 +1,171 @@
+# MCP Bridge Specification
+
+## Purpose
+
+The extension can expose its authenticated Rewst sessions to external MCP clients
+(and to its own in-process chat) as a set of tools, without handing those clients
+a Rewst credential. This capability covers enabling the bridge, the localhost
+token, which tools are exposed, and the working-scope rules that bound what a tool
+may touch.
+
+Source: `src/mcp/` (`McpServerController.ts`, `McpActions.ts`,
+`McpDefinitionProvider.ts`, `runtime.ts`, `settings.ts`, `throttle.ts`),
+`src/commands/mcp/`, `src/capabilities/*Capabilities.ts`,
+`src/models/WorkingScopeManager.ts`.
+
+## Requirements
+
+### Requirement: Enable the bridge and run a localhost server
+
+The system SHALL run the MCP bridge as a localhost HTTP server only when
+`rewst-buddy.mcp.enable` is on (or the credential server is independently
+enabled), and SHALL reject all MCP requests when the bridge is disabled.
+
+#### Scenario: Bridge disabled
+
+- **GIVEN** `rewst-buddy.mcp.enable` is false
+- **WHEN** an MCP client calls a tool
+- **THEN** the request is rejected because the bridge is not enabled
+
+### Requirement: Guard with a stable, rotatable token
+
+The system SHALL protect the localhost endpoint with a token that is stable
+across reloads, compared in constant time, and rotatable on demand. The token
+guards localhost only and is not a Rewst credential.
+
+#### Scenario: Token persists across reloads
+
+- **GIVEN** the bridge minted a token on first use
+- **WHEN** the window reloads
+- **THEN** the same token remains valid
+
+#### Scenario: Rotate the token
+
+- **GIVEN** an active token
+- **WHEN** the user runs `Rotate MCP Token` and confirms
+- **THEN** a new token replaces it and clients holding the old token lose access
+
+### Requirement: Export client configuration without embedding the token
+
+The system SHALL provide a way to copy a credential-free client config that
+references the token via the `REWST_BUDDY_MCP_TOKEN` environment variable, and a
+way to register the bridge natively in VS Code with live token injection.
+
+#### Scenario: Copy MCP config
+
+- **GIVEN** the bridge is enabled
+- **WHEN** the user runs `Copy MCP Config to Clipboard`
+- **THEN** the copied JSON points at the localhost `/mcp` URL and carries the
+  token only as an env-var placeholder, not the literal value
+
+#### Scenario: Add to VS Code
+
+- **WHEN** the user runs `Add MCP Server to VS Code`
+- **THEN** the bridge is enabled if needed, the native provider is refreshed, and
+  VS Code injects the live token without an env-var step
+
+### Requirement: Gate write tools behind explicit settings
+
+The system SHALL expose write tools (those with `access: 'write'`) only when
+`rewst-buddy.mcp.enableWriteTools` is on, and SHALL expose the raw GraphQL
+mutation tool only when `rewst-buddy.mcp.enableDangerousGraphqlMutation` is on.
+Read tools are available without these switches.
+
+#### Scenario: Write tools disabled
+
+- **GIVEN** `enableWriteTools` is false
+- **WHEN** a client lists tools
+- **THEN** workflow/template/trigger/variable mutation tools are not callable
+
+### Requirement: Bound writes to the effective allowed organizations
+
+For every write tool, the system SHALL verify the target organization is in the
+effective allowed set — the user's pinned working scope unioned with
+`rewst-buddy.mcp.alwaysAllowedOrgs` — before any authenticated write, rejecting
+out-of-scope orgs with `org_out_of_scope`. An empty effective set SHALL mean no
+writes are allowed.
+
+#### Scenario: Target org is in scope
+
+- **GIVEN** a working org is pinned and a write tool targets that org
+- **WHEN** the tool runs
+- **THEN** the scope check passes and the write proceeds (subject to approval)
+
+#### Scenario: Target org is out of scope
+
+- **GIVEN** a write tool targets an org not in the effective allowed set
+- **WHEN** the tool runs
+- **THEN** it is rejected with `org_out_of_scope` before any authenticated I/O
+
+#### Scenario: No working org set
+
+- **GIVEN** no working org is pinned and `alwaysAllowedOrgs` is empty
+- **WHEN** any write tool runs
+- **THEN** it is rejected because the effective allowed set is empty
+
+### Requirement: Bound writes to a pinned working workflow
+
+When a working workflow is pinned, the system SHALL require a workflow-targeting
+write to name a workflow in scope, rejecting others with `workflow_out_of_scope`.
+
+#### Scenario: Write targets an out-of-scope workflow
+
+- **GIVEN** a specific workflow is pinned as the working scope
+- **WHEN** a write tool targets a different workflow
+- **THEN** it is rejected with `workflow_out_of_scope`
+
+### Requirement: Scope reads per configuration
+
+The system SHALL scope reads to the effective allowed set only when
+`rewst-buddy.mcp.workingOrgScope` is `strict` and a working org is pinned. Under
+`writes`, reads may target any organization the session manages. Organization-
+discovery tools (those not requiring an org, e.g. `buddy_list_orgs`,
+`buddy_get_working_scope`) SHALL never be scoped.
+
+#### Scenario: Strict read scoping
+
+- **GIVEN** `workingOrgScope` is `strict` and a working org is pinned
+- **WHEN** a read tool targets a different org
+- **THEN** it is rejected as out of scope
+
+#### Scenario: Discovery tool is never gated
+
+- **GIVEN** any scope configuration
+- **WHEN** `buddy_list_orgs` is called
+- **THEN** it runs without a scope check
+
+### Requirement: A model may only request a scope change
+
+The system SHALL treat the working scope as the user's deliberate selection. A
+model-driven tool SHALL only be able to _request_ a scope change
+(`buddy_set_working_scope`), which takes effect after a VS Code modal; it SHALL
+NOT be able to widen `alwaysAllowedOrgs`.
+
+#### Scenario: Model requests a scope change
+
+- **WHEN** a tool calls `buddy_set_working_scope`
+- **THEN** the change is applied only after the user accepts the VS Code modal
+
+### Requirement: Validate tool inputs defensively
+
+Because tool inputs are not validated against the advertised `inputSchema`, each
+capability SHALL validate and coerce every input itself (required strings,
+clamped numbers, enum checks) rather than trusting the schema.
+
+#### Scenario: Out-of-range numeric input
+
+- **GIVEN** a tool that accepts a `limit`
+- **WHEN** a caller passes a value past the maximum
+- **THEN** the capability clamps it to the allowed maximum rather than honoring
+  the raw value
+
+### Requirement: Rate-limit, audit, and attribute tool calls
+
+The system SHALL rate-limit tool calls, audit every call (tool, org, outcome,
+duration), and tag the approval origin so that approval prompts name the caller.
+
+#### Scenario: Burst of calls
+
+- **GIVEN** an MCP client issuing many calls in a short window
+- **WHEN** the rate limit is exceeded
+- **THEN** further calls are throttled

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -13,7 +13,8 @@ working-scope rules that bound what a tool may touch.
 Source: `src/mcp/` (`McpServerController.ts`, `McpActions.ts`,
 `McpDefinitionProvider.ts`, `runtime.ts`, `settings.ts`, `throttle.ts`),
 `src/commands/mcp/`, `src/capabilities/*Capabilities.ts`,
-`src/models/WorkingScopeManager.ts`.
+`src/models/WorkingScopeManager.ts`, `src/ui/chat/tools/graphqlTool.ts`,
+`src/ui/chat/tools/workflowTools.ts`, `src/extension.ts`.
 
 ## Requirements
 
@@ -211,6 +212,38 @@ writes are allowed.
 - **WHEN** any write tool runs
 - **THEN** it is rejected because the effective allowed set is empty
 
+### Requirement: Verify resource ownership before approval on by-id writes
+
+For every by-id write capability in the org-variable, tag, trigger, and
+workflow CRUD families, the system SHALL fetch the target resource by id
+scoped to the requested `orgId` and reject with a resource-specific "not in
+org" error before requesting mutation approval. This pre-flight ownership
+check is a distinct, additional verification step from the generic
+`org_out_of_scope` check described above: the generic check validates only
+that the requested `orgId` argument itself is in the effective allowed set,
+while this check re-verifies that the specific resource id supplied actually
+belongs to that org — closing the gap where a caller supplies an in-scope
+`orgId` together with a resource id that belongs to a different org the same
+session happens to manage.
+
+#### Scenario: Resource id belongs to a different org
+
+- **GIVEN** a write tool's `orgId` argument is in the effective allowed set
+- **AND** the supplied resource id (e.g. a variable, tag, trigger, or workflow
+  id) actually belongs to a different org
+- **WHEN** the tool runs
+- **THEN** it is rejected with a "not in org" error naming the resource and the
+  requested org
+- **AND** no approval prompt is shown and no mutation runs
+
+#### Scenario: Ownership check runs before approval
+
+- **GIVEN** a by-id write tool targets a resource that does belong to the
+  requested org
+- **WHEN** the tool runs
+- **THEN** the ownership read happens first, then the mutation approval
+  prompt, then the mutation itself
+
 ### Requirement: Bound writes to a pinned working workflow
 
 When a working workflow is pinned, the system SHALL require a workflow-targeting
@@ -221,6 +254,69 @@ write to name a workflow in scope, rejecting others with `workflow_out_of_scope`
 - **GIVEN** a specific workflow is pinned as the working scope
 - **WHEN** a write tool targets a different workflow
 - **THEN** it is rejected with `workflow_out_of_scope`
+
+### Requirement: Round-trip workflow fields exactly when editing
+
+The system SHALL apply `buddy_workflow_edit` and `buddy_workflow_autolayout`
+operations by reading the full workflow and resending every task in a single
+`updateWorkflow` call, because the GraphQL `tasks` array is a full replace — a
+task omitted from that array is deleted, not left alone. Each resent task
+SHALL explicitly carry forward its existing advanced settings
+(`transitionMode`, `join`, `publishResultAs`, `timeout`, `humanSecondsSaved`,
+`isMocked`, `mockInput`, `runAsOrgId`, `retry`, `with`, `metadata`,
+`packOverrides`) so that an edit unrelated to those fields does not reset them.
+Top-level workflow fields the tool does not read or write (such as `output`,
+`tags`, `notes`, `triggers`, and the workflow's own `humanSecondsSaved`) SHALL
+be left untouched by the mutation rather than reset, since `updateWorkflow`
+only replaces fields actually present in its input — unlike the per-task
+`tasks` array, the top level of the mutation behaves as a patch, not a full
+replace. A `buddy_workflow_edit` operation that sets a task's `input` or
+`with` object SHALL accept that value as a JSON-encoded string and parse it
+back into an object rather than storing the literal string. A `set_transition`
+operation that omits both `to` and `transitionId` SHALL resolve to the task's
+sole outgoing transition when exactly one exists, and SHALL error asking the
+caller to disambiguate with `to` or `transitionId` otherwise.
+
+#### Scenario: Saving resends every existing task
+
+- **GIVEN** a workflow has several tasks and an edit only adds one new task
+- **WHEN** `buddy_workflow_edit` saves the workflow
+- **THEN** the `updateWorkflow` mutation's `tasks` array includes every
+  existing task plus the new one, not just the new one
+
+#### Scenario: Editing one task preserves another task's advanced settings
+
+- **GIVEN** a workflow has a task with a human-authored `transitionMode` of
+  `FOLLOW_ALL` and a `packOverrides` entry
+- **WHEN** `buddy_workflow_edit` applies an operation to a different task
+- **THEN** the unrelated task's resent fields still carry its `transitionMode`,
+  `join`, and `packOverrides` unchanged
+
+#### Scenario: Untouched top-level fields are left as-is
+
+- **GIVEN** a workflow has tags, notes, triggers, and output configured
+  directly in Rewst
+- **WHEN** `buddy_workflow_edit` saves an unrelated task change
+- **THEN** the mutation input does not include `tags`, `notes`, `triggers`, or
+  the workflow-level `humanSecondsSaved`
+- **AND** those fields remain whatever they were before the edit
+
+#### Scenario: A JSON-string task input is parsed
+
+- **GIVEN** an `add_task` or `update_task` operation supplies a task's
+  `"input"` (or `"with"`) as a JSON-encoded string rather than an object
+- **WHEN** `buddy_workflow_edit` applies the operation
+- **THEN** the string is parsed into an object before being sent, rather than
+  stored as a literal string value
+
+#### Scenario: set_transition disambiguates a single outgoing edge
+
+- **GIVEN** a task has exactly one outgoing transition and the operation
+  supplies neither `to` nor `transitionId`
+- **WHEN** `set_transition` runs
+- **THEN** it targets that sole transition
+- **AND** if the task has more than one outgoing transition instead, the
+  operation errors asking for `to` or `transitionId`
 
 ### Requirement: Scope reads per configuration
 
@@ -321,19 +417,63 @@ evicted or was never cached.
 - **THEN** the bridge returns the requested character slice without re-running the
   original Rewst API call
 
+### Requirement: Derive the Jinja docs engine host and cache only successful fetches
+
+`buddy_get_jinja_filter_docs` SHALL derive the Jinja engine host from the
+session's region GraphQL host by replacing a leading `api.` with `engine.`,
+falling back to a hardcoded `https://engine.rewst.io` default when the
+region's host is missing, does not start with `api.`, or fails to parse as a
+URL. A successfully fetched filter catalog SHALL be cached in memory per engine
+host for the life of the extension session. A failed fetch SHALL NOT be
+cached, so the next call retries the fetch rather than repeating the failure
+from a cached error.
+
+#### Scenario: Region host maps to the engine host
+
+- **GIVEN** the session's region GraphQL host is `api.rewst.io`
+- **WHEN** `buddy_get_jinja_filter_docs` runs
+- **THEN** the catalog is fetched from `engine.rewst.io`
+
+#### Scenario: Unrecognized region falls back to the default engine host
+
+- **GIVEN** the session's region host is missing or does not start with `api.`
+- **WHEN** `buddy_get_jinja_filter_docs` runs
+- **THEN** the catalog is fetched from the hardcoded default engine host
+
+#### Scenario: A failed fetch is not cached
+
+- **GIVEN** a catalog fetch for an engine host fails
+- **WHEN** `buddy_get_jinja_filter_docs` is called again
+- **THEN** the tool retries the fetch rather than reusing a cached failure
+
 ### Requirement: Reuse approvals only for reusable mutation scopes
 
 The system SHALL remember approval for mutation scopes that are safe to reuse
 within the current extension session, such as repeated writes to the same
-approved GraphQL or workflow-edit scope. It SHALL still require fresh approval
-for operations whose execution itself is the risky action, such as running a
-workflow.
+approved GraphQL or workflow-edit scope, in a single process-global cache keyed
+by organization id and resource id. This cache is not transport-specific: it
+is shared by both the in-process Cage-Free Rewsty chat tool path and the
+external MCP transport, behind the one mutation-approval modal both paths
+call — see ai-chat's `Run in-process Buddy tools with a per-response cap`
+requirement for the chat-side description of this same mechanism. The system
+SHALL still require fresh approval for operations whose execution itself is
+the risky action, such as running a workflow.
 
 #### Scenario: Reused raw GraphQL mutation approval
 
 - **GIVEN** a raw GraphQL mutation scope was approved for an org and resource
 - **WHEN** the same mutation scope is requested again in the same session
 - **THEN** the mutation can run without prompting again
+
+#### Scenario: Approval reuse crosses the chat/MCP transport boundary
+
+- **GIVEN** a mutation scope was approved through the in-process Cage-Free
+  Rewsty chat tool path
+- **WHEN** the same org+resource scope is requested again through the external
+  MCP transport in the same extension session
+- **THEN** the mutation can run without prompting again
+- **AND** the reverse also holds: a scope approved through the external MCP
+  transport is reused for the in-process chat path
 
 #### Scenario: Workflow run approval is always fresh
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -3,9 +3,11 @@
 ## Purpose
 
 The extension can expose its authenticated Rewst sessions to external MCP clients
-(and to its own in-process chat) as a set of tools and lightweight resources,
-without handing those clients a Rewst credential. This capability covers enabling
-the bridge, the localhost token, which tools and resources are exposed, and the
+as a set of tools and lightweight resources, without handing those clients a
+Rewst credential. The same central capability registry can also contribute tools
+to in-process chat models, but chat tool availability is not controlled by the
+external bridge enablement setting. This capability covers enabling the external
+bridge, the localhost token, which tools and resources are exposed, and the
 working-scope rules that bound what a tool may touch.
 
 Source: `src/mcp/` (`McpServerController.ts`, `McpActions.ts`,
@@ -15,17 +17,30 @@ Source: `src/mcp/` (`McpServerController.ts`, `McpActions.ts`,
 
 ## Requirements
 
-### Requirement: Enable the bridge and run a localhost server
+### Requirement: Enable the external bridge and run a localhost server
 
-The system SHALL run the MCP bridge as a localhost HTTP server only when
-`rewst-buddy.mcp.enable` is on (or the credential server is independently
-enabled), and SHALL reject all MCP requests when the bridge is disabled.
+The system SHALL expose the external MCP bridge at `/mcp` only when
+`rewst-buddy.mcp.enable` is on, while allowing the underlying localhost
+credential server to run independently when `rewst-buddy.server.enabled` is on.
+The system SHALL reject all external MCP requests when the bridge is disabled.
+This setting SHALL NOT disable in-process Buddy tools contributed to Cage-Free
+Rewsty chat.
 
 #### Scenario: Bridge disabled
 
 - **GIVEN** `rewst-buddy.mcp.enable` is false
 - **WHEN** an MCP client calls a tool
 - **THEN** the request is rejected because the bridge is not enabled
+
+#### Scenario: Cage-Free Rewsty tools are unaffected
+
+- **GIVEN** the user selects the Cage-Free Rewsty chat model
+- **AND** `rewst-buddy.mcp.enable` is false
+- **WHEN** the chat model lists available in-process Buddy tools
+- **THEN** registry-backed Buddy tools are still contributed to chat subject to
+  their local-tool eligibility, write-tool, dangerous-GraphQL, approval,
+  throttle, and scope gates
+- **AND** only the external `/mcp` transport is unavailable
 
 ### Requirement: Guard with a stable, rotatable token
 
@@ -75,12 +90,15 @@ way to register the bridge natively in VS Code with live token injection.
 ### Requirement: Expose the registry-backed tool catalog
 
 The system SHALL expose every capability that opts into MCP from the central
-capability registry, subject to the bridge enablement, write-tool, dangerous
-GraphQL, working-scope, and per-capability access gates. The catalog includes
-Rewst read tools, GraphQL query/schema tools, workflow helpers, workspace
-template-link helpers, template link/sync/mutation/clone tools, workflow CRUD,
-trigger, form, tag, org variable, org/user, pack/integration, page/site/Jinja,
-working-scope, and cached-result tools.
+capability registry on the external bridge, subject to the bridge enablement,
+write-tool, dangerous GraphQL, working-scope, and per-capability access gates.
+The in-process Cage-Free Rewsty chat catalog SHALL use the same `mcp: true`
+capability descriptors and gates, except that it is not gated by external bridge
+enablement. The catalog includes Rewst read tools, GraphQL query/schema tools,
+workflow helpers, workspace template-link helpers, template
+link/sync/mutation/clone tools, workflow CRUD, trigger, form, tag, org variable,
+org/user, pack/integration, page/site/Jinja, working-scope, and cached-result
+tools.
 
 #### Scenario: Read catalog is listed
 
@@ -122,16 +140,22 @@ read capabilities and gates as tools. Resource URIs SHALL use the
 
 ### Requirement: Gate write tools behind explicit settings
 
-The system SHALL expose write tools (those with `access: 'write'`) only when
-`rewst-buddy.mcp.enableWriteTools` is on, and SHALL expose the raw GraphQL
-mutation tool only when `rewst-buddy.mcp.enableDangerousGraphqlMutation` is on.
-Read tools are available without these switches.
+The system SHALL expose external MCP tools classified with `access: 'write'`
+only when `rewst-buddy.mcp.enableWriteTools` is on, and SHALL expose the raw
+GraphQL mutation tool only when
+`rewst-buddy.mcp.enableDangerousGraphqlMutation` is on. Read-tier tools are
+available without these switches, but a read-tier tool MAY still mutate local
+workspace metadata when it does not mutate Rewst data; such behavior SHALL be
+explicit in the tool description and result.
 
 #### Scenario: Write tools disabled
 
 - **GIVEN** `enableWriteTools` is false
 - **WHEN** a client lists tools
-- **THEN** workflow/template/trigger/variable mutation tools are not callable
+- **THEN** workflow, template, trigger, tag, form, org-variable, and other Rewst
+  mutation tools are not callable
+- **AND** the raw GraphQL mutation tool is also unavailable unless its separate
+  dangerous-GraphQL setting is enabled
 
 #### Scenario: Local workspace state tools
 
@@ -139,9 +163,27 @@ Read tools are available without these switches.
 - **WHEN** a client lists tools
 - **THEN** local workspace operations such as `buddy_template_link`,
   `buddy_template_unlink`, and `buddy_template_sync_on_save` may be exposed as
-  read-access tools because they do not mutate Rewst data
-- **AND** tools that push changes to Rewst, such as `buddy_template_sync` upload
-  paths, remain write-gated
+  read-tier tools because they do not mutate Rewst data
+- **AND** their descriptions and results state that they may change local link
+  metadata, sync-on-save state, or workspace files
+- **AND** they canonicalize and validate file paths or URIs, reject malformed or
+  ambiguous targets, and report whether a target is workspace-relative,
+  absolute, or already linked before changing local state
+- **AND** `buddy_template_sync` is write-gated in every direction — including
+  download and metadata-only calls — because it can both push to Rewst and
+  overwrite a workspace file; see template-sync's `Expose explicit sync tools`
+  requirement for the full classification
+
+#### Scenario: Read-tier label does not hide local mutation
+
+- **GIVEN** a read-tier tool mutates local template link state
+- **WHEN** the tool is advertised to chat or external MCP clients
+- **THEN** the tool remains classified by Rewst write risk rather than by local
+  filesystem mutation alone
+- **AND** the advertised description and runtime result disclose the local state
+  mutation clearly enough for an agent to choose it intentionally
+- **AND** any tool that can overwrite local file contents is either classified as
+  write-tier or has an explicit local-file overwrite contract and target guard
 
 ### Requirement: Bound writes to the effective allowed organizations
 

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -1,0 +1,132 @@
+# Session & Authentication Specification
+
+## Purpose
+
+Rewst Buddy talks to the Rewst GraphQL API on the user's behalf using a session
+cookie copied from a logged-in browser. This capability covers turning that
+credential into a working session, discovering the correct region, persisting
+the credential securely, restoring it across restarts, keeping it fresh, and
+managing the multiple organizations a single login can reach.
+
+Source: `src/sessions/Session.ts`, `src/sessions/SessionManager.ts`,
+`src/sessions/SessionProfile.ts`, `src/sessions/RegionConfig.ts`,
+`src/sessions/CookieString.ts`.
+
+## Requirements
+
+### Requirement: Establish a session from a cookie/token
+
+The system SHALL accept a Rewst session cookie (entered by the user or relayed
+by the browser extension) and produce an authenticated session, or fail clearly
+if the cookie is not usable.
+
+#### Scenario: User provides a valid cookie
+
+- **GIVEN** the user runs `Rewst Buddy: New Rewst Session`
+- **WHEN** they enter a valid session cookie into the masked input
+- **THEN** the extension builds a GraphQL client, validates it with a `User`
+  query, and creates a session whose label is `"{username} ({orgName})"`
+
+#### Scenario: Empty input
+
+- **GIVEN** the New Session prompt is open
+- **WHEN** the user submits an empty value
+- **THEN** the extension rejects the input and does not create a session
+
+### Requirement: Detect the correct region automatically
+
+The system SHALL try the cookie against each configured region in
+`rewst-buddy.regions` and use the first region whose `User` query returns a user
+id, so the user never has to pick a region manually.
+
+#### Scenario: Cookie belongs to a non-default region
+
+- **GIVEN** regions are configured for North America and Europe
+- **AND** the cookie is only valid in Europe
+- **WHEN** a session is established
+- **THEN** the extension probes North America, observes failure, probes Europe,
+  succeeds, and binds the session to the European region's GraphQL endpoint
+
+#### Scenario: Cookie is invalid everywhere
+
+- **GIVEN** a cookie that no configured region accepts
+- **WHEN** a session is attempted
+- **THEN** no session is created and the user is shown an authentication error
+
+### Requirement: Store credentials securely
+
+The system SHALL store the raw session cookie only in VS Code `secrets`, keyed by
+organization id, and SHALL store non-secret session metadata (region, org,
+managed orgs, label, user) in `globalState` under `RewstSessionProfiles`. The
+cookie SHALL NOT be written to `globalState`.
+
+#### Scenario: Credential placement after login
+
+- **GIVEN** a session is successfully established for org `org-123`
+- **WHEN** persistence runs
+- **THEN** the cookie value is stored via `secrets` under key `org-123`
+- **AND** the session profile (without the cookie) is stored under
+  `RewstSessionProfiles`
+
+### Requirement: Restore sessions on activation
+
+The system SHALL recreate previously authenticated sessions on extension startup
+from the saved profiles plus the cookies held in `secrets`, without prompting the
+user again.
+
+#### Scenario: Restart with a saved session
+
+- **GIVEN** a session profile and its cookie were persisted in a prior run
+- **WHEN** the extension activates
+- **THEN** the session is rebuilt from storage and appears in the Sessions tree
+  without re-entering a cookie
+
+### Requirement: Refresh credentials on a schedule
+
+The system SHALL refresh active sessions periodically (every 15 minutes) by
+re-requesting the region login URL with the current cookie and replacing the
+stored cookie with the refreshed one.
+
+#### Scenario: Background refresh succeeds
+
+- **GIVEN** an active session whose cookie is approaching expiry
+- **WHEN** the refresh interval fires
+- **THEN** the extension obtains a new cookie from the login response, validates
+  it, and updates both the in-memory session and the stored secret
+
+### Requirement: Manage multiple organizations per session
+
+The system SHALL treat one login as managing a primary organization plus all of
+its managed sub-organizations, and SHALL resolve the correct session for any
+given organization id.
+
+#### Scenario: Operation targets a managed sub-org
+
+- **GIVEN** a session whose login manages a parent org and several sub-orgs
+- **WHEN** an operation references a sub-org id
+- **THEN** the extension selects the session that manages that sub-org
+
+### Requirement: Cache validation
+
+The system SHALL cache a successful session validation for 24 hours to avoid
+re-querying the API on every use, while still re-validating after the cache
+expires.
+
+#### Scenario: Repeated use within the cache window
+
+- **GIVEN** a session validated less than 24 hours ago
+- **WHEN** it is used again
+- **THEN** the extension treats it as valid without issuing another validation
+  query
+
+### Requirement: Clear sessions
+
+The system SHALL provide a way to remove all sessions, deleting their profiles
+from `globalState`, their cookies from `secrets`, and their in-memory state.
+
+#### Scenario: User clears sessions
+
+- **GIVEN** one or more active sessions
+- **WHEN** the user runs `Rewst Buddy: Clear Sessions`
+- **THEN** all stored profiles and secrets are removed and the Sessions tree is
+  emptied

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -211,12 +211,6 @@ present. It SHALL remove `SessionProfiles` and `RewstAllKnownProfiles` from
 known-profile caches, and update extension context so no session is considered
 active.
 
-**Implementation status:** today `Clear Sessions` removes `SessionProfiles` and
-`RewstAllKnownProfiles` from `globalState` and clears in-memory state, but does
-not call `secrets.delete()` — stored cookies are not removed, so a cleared
-session's credential remains in VS Code `secrets`. Wiring secret deletion into
-Clear Sessions is tracked as a security-relevant follow-up.
-
 #### Scenario: User clears sessions
 
 - **GIVEN** one or more active sessions

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -57,7 +57,9 @@ id, so the user never has to pick a region manually.
 
 The system SHALL store the raw session cookie only in VS Code `secrets`, keyed by
 organization id, and SHALL store non-secret session metadata (region, org,
-managed orgs, label, user) in `globalState` under `RewstSessionProfiles`. The
+managed orgs, label, user) in `globalState` under `SessionProfiles`. The system
+SHALL also maintain a non-secret `RewstAllKnownProfiles` cache for profiles that
+have been seen before, including profiles that are not currently active. The
 cookie SHALL NOT be written to `globalState`.
 
 #### Scenario: Credential placement after login
@@ -66,7 +68,15 @@ cookie SHALL NOT be written to `globalState`.
 - **WHEN** persistence runs
 - **THEN** the cookie value is stored via `secrets` under key `org-123`
 - **AND** the session profile (without the cookie) is stored under
-  `RewstSessionProfiles`
+  `SessionProfiles`
+- **AND** the profile is included in `RewstAllKnownProfiles`
+
+#### Scenario: Known profile lookup
+
+- **GIVEN** a previously saved profile for org `org-123`
+- **WHEN** a feature needs non-secret org metadata without an active session
+- **THEN** the profile can be resolved from the known-profile cache by any
+  managed org id it contains
 
 ### Requirement: Restore sessions on activation
 
@@ -106,6 +116,29 @@ given organization id.
 - **WHEN** an operation references a sub-org id
 - **THEN** the extension selects the session that manages that sub-org
 
+#### Scenario: Re-auth drops an old managed org
+
+- **GIVEN** a saved session for user `u1` that managed orgs A and B
+- **WHEN** the same user authenticates again and the new profile only manages A
+- **THEN** org A resolves to the new session
+- **AND** org B no longer resolves through the active-session index
+
+### Requirement: Run authenticated raw GraphQL requests
+
+The system SHALL support raw GraphQL requests through an active session by
+reading the session cookie from `secrets`, sending it to the session's regional
+GraphQL endpoint, and returning the raw GraphQL `{ data, errors }` shape to the
+caller.
+
+#### Scenario: Raw GraphQL query
+
+- **GIVEN** an active session with a cookie stored in `secrets`
+- **WHEN** a raw GraphQL request is made through that session
+- **THEN** the request carries the stored cookie to the session's regional
+  GraphQL endpoint
+- **AND** the response returns the backend `data` and `errors` values without
+  transforming them into SDK-specific types
+
 ### Requirement: Cache validation
 
 The system SHALL cache a successful session validation for 24 hours to avoid
@@ -121,12 +154,14 @@ expires.
 
 ### Requirement: Clear sessions
 
-The system SHALL provide a way to remove all sessions, deleting their profiles
-from `globalState`, their cookies from `secrets`, and their in-memory state.
+The system SHALL provide a way to remove all active sessions, clearing the active
+profile list from `globalState`, clearing the in-memory session and org indexes,
+and updating extension context so no session is considered active.
 
 #### Scenario: User clears sessions
 
 - **GIVEN** one or more active sessions
 - **WHEN** the user runs `Rewst Buddy: Clear Sessions`
-- **THEN** all stored profiles and secrets are removed and the Sessions tree is
-  emptied
+- **THEN** active profiles are removed from `SessionProfiles`
+- **AND** no org id resolves to an active session
+- **AND** the Sessions tree is emptied

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -56,11 +56,20 @@ id, so the user never has to pick a region manually.
 ### Requirement: Store credentials securely
 
 The system SHALL store the raw session cookie only in VS Code `secrets`, keyed by
-organization id, and SHALL store non-secret session metadata (region, org,
-managed orgs, label, user) in `globalState` under `SessionProfiles`. The system
-SHALL also maintain a non-secret `RewstAllKnownProfiles` cache for profiles that
-have been seen before, including profiles that are not currently active. The
-cookie SHALL NOT be written to `globalState`.
+the session profile's primary organization id. Non-secret session metadata
+(region, org, managed orgs, label, user) SHALL be stored in `globalState` under
+`SessionProfiles`. The system SHALL also maintain a non-secret
+`RewstAllKnownProfiles` cache for profiles that have been seen before, including
+profiles that are not currently active. Managed organization ids MAY resolve to
+the profile through non-secret indexes, but their ids SHALL NOT be relied on as
+the primary secret key for restoration. The cookie SHALL NOT be written to
+`globalState`.
+
+**Implementation status:** today known-profile lookup resolves by org id without
+distinguishing region, and does not report ambiguity when two known profiles
+share an org id in different regions; the region-aware and ambiguity-reporting
+behavior described in the scenario below is the target lookup contract.
+Region-aware known-profile resolution is tracked as follow-up work.
 
 #### Scenario: Credential placement after login
 
@@ -77,6 +86,16 @@ cookie SHALL NOT be written to `globalState`.
 - **WHEN** a feature needs non-secret org metadata without an active session
 - **THEN** the profile can be resolved from the known-profile cache by any
   managed org id it contains
+
+#### Scenario: Known profile lookup is region-aware
+
+- **GIVEN** two known profiles contain the same managed org id in different
+  regions
+- **WHEN** a feature resolves known metadata with both an org id and Rewst base
+  URL
+- **THEN** the profile whose region matches the base URL is selected
+- **AND** if no region is supplied and the org id is ambiguous, the lookup
+  reports ambiguity rather than silently picking a default profile
 
 ### Requirement: Restore sessions on activation
 
@@ -108,13 +127,42 @@ stored cookie with the refreshed one.
 
 The system SHALL treat one login as managing a primary organization plus all of
 its managed sub-organizations, and SHALL resolve the correct session for any
-given organization id.
+given organization id by checking both the primary org and all managed orgs. When
+a base URL or region is available, session resolution SHALL first narrow to
+active sessions in that region and then match the requested org against primary
+and managed org ids. When no region is available and more than one active session
+can manage the org id, resolution SHALL fail as ambiguous rather than silently
+choosing one.
+
+**Implementation status:** today active-session resolution (`getOrgSession`)
+matches only a session's primary organization id; resolving an operation against
+a _managed_ sub-organization id, and failing closed when two active sessions
+ambiguously report the same org id, are not yet implemented — these are the
+target multi-org resolution contract described above. Implementing managed-org
+matching and ambiguous-duplicate detection is tracked as follow-up work.
 
 #### Scenario: Operation targets a managed sub-org
 
 - **GIVEN** a session whose login manages a parent org and several sub-orgs
 - **WHEN** an operation references a sub-org id
 - **THEN** the extension selects the session that manages that sub-org
+
+#### Scenario: Duplicate org id requires region
+
+- **GIVEN** two active sessions in different regions both report access to the
+  same managed org id
+- **WHEN** an operation references that org id without a base URL or region
+- **THEN** session resolution fails as ambiguous and asks the caller to supply
+  region context
+
+#### Scenario: URL targets a managed sub-org in the session region
+
+- **GIVEN** a Rewst URL whose base URL identifies the European region
+- **AND** the parsed organization id is a managed sub-org of an active European
+  session
+- **WHEN** the extension resolves a session for that URL
+- **THEN** it selects the European session that manages the sub-org
+- **AND** it does not fall back to a different region or default organization
 
 #### Scenario: Re-auth drops an old managed org
 
@@ -154,14 +202,37 @@ expires.
 
 ### Requirement: Clear sessions
 
-The system SHALL provide a way to remove all active sessions, clearing the active
-profile list from `globalState`, clearing the in-memory session and org indexes,
-and updating extension context so no session is considered active.
+The system SHALL provide a way to remove all saved Rewst sessions, not merely
+disconnect active in-memory sessions. Clearing sessions SHALL delete raw cookies
+from VS Code `secrets` for every active or known session profile, including
+primary organization keys and any legacy managed-organization secret keys if
+present. It SHALL remove `SessionProfiles` and `RewstAllKnownProfiles` from
+`globalState`, clear in-memory sessions, org indexes, validation caches, and
+known-profile caches, and update extension context so no session is considered
+active.
+
+**Implementation status:** today `Clear Sessions` removes `SessionProfiles` and
+`RewstAllKnownProfiles` from `globalState` and clears in-memory state, but does
+not call `secrets.delete()` — stored cookies are not removed, so a cleared
+session's credential remains in VS Code `secrets`. Wiring secret deletion into
+Clear Sessions is tracked as a security-relevant follow-up.
 
 #### Scenario: User clears sessions
 
 - **GIVEN** one or more active sessions
 - **WHEN** the user runs `Rewst Buddy: Clear Sessions`
 - **THEN** active profiles are removed from `SessionProfiles`
+- **AND** all known profiles are removed from `RewstAllKnownProfiles`
+- **AND** raw cookies for active, known, and legacy managed-org profile keys are
+  deleted from VS Code `secrets`
 - **AND** no org id resolves to an active session
 - **AND** the Sessions tree is emptied
+
+#### Scenario: User clears known-only sessions
+
+- **GIVEN** no session is active
+- **AND** `RewstAllKnownProfiles` contains previously saved profiles
+- **WHEN** the user runs `Rewst Buddy: Clear Sessions`
+- **THEN** known profiles and their primary-org and legacy managed-org secrets
+  are removed
+- **AND** future startup does not restore those sessions without a new cookie

--- a/openspec/specs/template-linking/spec.md
+++ b/openspec/specs/template-linking/spec.md
@@ -30,9 +30,37 @@ body, and the ids of any templates the body references.
 #### Scenario: Re-linking a file already linked
 
 - **GIVEN** a file already linked to template A
-- **WHEN** the user links the same file to template B
+- **WHEN** a lower-level linking path explicitly replaces the link with template B
 - **THEN** the old association and its reverse-lookup entries are removed before
   the new link is recorded, leaving no orphaned index entries
+
+#### Scenario: User command refuses an already linked file
+
+- **GIVEN** a file already linked to a template
+- **WHEN** the user runs an interactive link command for that file
+- **THEN** the command refuses before template selection instead of silently
+  replacing the link
+
+### Requirement: Link files from path-like tool inputs
+
+The system SHALL let MCP callers link and unlink local files by path or `file://`
+URI, resolving relative paths against the workspace when possible. The tool path
+SHALL report clear status values for invalid paths, missing files, already linked
+files, missing templates, and org mismatches.
+
+#### Scenario: Relative path link
+
+- **GIVEN** a workspace folder and an existing unlinked file
+- **WHEN** `buddy_template_link` receives a relative path and template id
+- **THEN** the path resolves inside the workspace
+- **AND** the file is linked to the remote template
+
+#### Scenario: Overwrite requested
+
+- **GIVEN** a file already linked to template A
+- **WHEN** `buddy_template_link` is called for template B with overwrite enabled
+- **THEN** the link moves to template B
+- **AND** reverse lookups for template A no longer include the file
 
 ### Requirement: Never persist template bodies
 
@@ -137,6 +165,27 @@ folder.
 - **WHEN** the user runs `Link Folder to Organization` and then `Fetch Folder`
 - **THEN** the folder is associated with the chosen org and the org's templates
   are materialized as local files linked to their templates
+
+#### Scenario: Folder fetch skips existing templates
+
+- **GIVEN** a folder linked to an org
+- **AND** one remote template is already linked locally
+- **WHEN** the folder is fetched
+- **THEN** only missing templates are materialized as new local files
+
+#### Scenario: Folder fetch handles partial failures
+
+- **GIVEN** a folder fetch over several remote templates
+- **WHEN** one template cannot be fetched or written
+- **THEN** the fetch continues for the remaining templates
+- **AND** the user-facing result reports the successful and failed counts
+
+#### Scenario: Local filenames are safe and unique
+
+- **GIVEN** remote template names that contain path-unsafe characters or collide
+  with existing files
+- **WHEN** the folder fetch creates local files
+- **THEN** filenames are sanitized and made unique before links are recorded
 
 ### Requirement: Emit change events with batching
 

--- a/openspec/specs/template-linking/spec.md
+++ b/openspec/specs/template-linking/spec.md
@@ -1,0 +1,164 @@
+# Template Linking Specification
+
+## Purpose
+
+The extension lets users edit Rewst templates as ordinary local files. This
+capability covers the association between a local file (or folder) and a Rewst
+template (or organization): creating, removing, moving, and pruning those links,
+and persisting them efficiently without ever storing template bodies.
+
+Source: `src/models/LinkManager.ts`, `src/models/types.ts`,
+`src/utils/getHash.ts`; commands under `src/commands/template/link/` and
+`src/commands/folders/`.
+
+## Requirements
+
+### Requirement: Link a local file to a template
+
+The system SHALL associate a local file URI with a Rewst template, recording the
+template metadata, the owning organization, a content hash of the current local
+body, and the ids of any templates the body references.
+
+#### Scenario: User links an open file
+
+- **GIVEN** an authenticated session and an open local file
+- **WHEN** the user runs `Link File to Template` and selects a template
+- **THEN** a link is created keyed by the file URI string
+- **AND** the link records the template metadata, the org, a `bodyHash` of the
+  file's current text, and the referenced template ids
+
+#### Scenario: Re-linking a file already linked
+
+- **GIVEN** a file already linked to template A
+- **WHEN** the user links the same file to template B
+- **THEN** the old association and its reverse-lookup entries are removed before
+  the new link is recorded, leaving no orphaned index entries
+
+### Requirement: Never persist template bodies
+
+The system SHALL persist links in `globalState` under `RewstTemplateLinks` and
+SHALL retain only a `bodyHash` for change detection — the template body itself is
+never written to persistent storage.
+
+#### Scenario: Inspecting persisted state
+
+- **GIVEN** a linked file with body content
+- **WHEN** the links are persisted
+- **THEN** the stored record contains the template metadata and `bodyHash`
+- **AND** does not contain the template body text
+
+### Requirement: Fast reverse lookups
+
+The system SHALL maintain secondary indexes so that "which files are linked to
+this template id" and "which links belong to this org id" are answered without
+scanning all links.
+
+#### Scenario: Lookup by template id
+
+- **GIVEN** several files linked across multiple templates
+- **WHEN** the extension needs the files linked to a given template id
+- **THEN** it resolves them via the template-id index rather than filtering the
+  full link collection
+
+### Requirement: Track file renames and moves
+
+The system SHALL follow links when their underlying files are renamed or moved,
+updating the stored URI and re-indexing any descendant links under a moved
+folder.
+
+#### Scenario: Linked file renamed
+
+- **GIVEN** a linked file `a.txt`
+- **WHEN** it is renamed to `b.txt`
+- **THEN** the link's URI is updated to `b.txt` and reverse indexes are updated,
+  preserving the association
+
+### Requirement: Track file deletions
+
+The system SHALL remove a link when its underlying file (or an ancestor folder)
+is deleted, cleaning up the secondary indexes.
+
+#### Scenario: Linked file deleted
+
+- **GIVEN** a linked file
+- **WHEN** the file is deleted on disk
+- **THEN** its link and all index entries are removed
+
+### Requirement: Prune stale links on load
+
+The system SHALL remove links whose files no longer exist when links are loaded,
+so a deleted-while-closed file does not leave a dangling association.
+
+#### Scenario: File removed while extension was not running
+
+- **GIVEN** a persisted link whose file was deleted outside VS Code
+- **WHEN** links are loaded on activation
+- **THEN** the stale link is pruned during load
+
+### Requirement: Resolve the owning organization correctly
+
+The system SHALL prefer the template's own (sub-)organization over the
+organization stored on a legacy link, so links created before sub-org tracking
+still resolve to the correct org.
+
+#### Scenario: Legacy link stored under a parent org
+
+- **GIVEN** a link whose stored org is the parent but whose template belongs to a
+  sub-org
+- **WHEN** the owning org is resolved
+- **THEN** the template's sub-org is used
+
+### Requirement: Unlink files
+
+The system SHALL let users remove a single file's link or clear all template
+links at once.
+
+#### Scenario: Unlink one file
+
+- **GIVEN** a linked file
+- **WHEN** the user runs `Unlink from Template`
+- **THEN** that file's link is removed while other links remain
+
+#### Scenario: Unlink everything
+
+- **GIVEN** multiple linked files
+- **WHEN** the user runs `Unlink All Templates`
+- **THEN** all template links are removed
+
+### Requirement: Link a folder to an organization
+
+The system SHALL let users link a local folder to an organization so the folder
+mirrors that org's templates, and SHALL support fetching and unlinking that
+folder.
+
+#### Scenario: Link and fetch a folder
+
+- **GIVEN** an authenticated session
+- **WHEN** the user runs `Link Folder to Organization` and then `Fetch Folder`
+- **THEN** the folder is associated with the chosen org and the org's templates
+  are materialized as local files linked to their templates
+
+### Requirement: Emit change events with batching
+
+The system SHALL emit a change event after link mutations so UI components can
+react, and SHALL support a batch mode that defers events and persistence until
+the batch completes.
+
+#### Scenario: Bulk link during folder fetch
+
+- **GIVEN** a folder fetch that creates many links
+- **WHEN** the links are added inside a batch
+- **THEN** a single change event and a single persistence write occur when the
+  batch ends, rather than one per link
+
+### Requirement: Non-blocking persistence
+
+The system SHALL persist link changes on a short debounce without blocking the
+user action that triggered them.
+
+#### Scenario: Rapid successive link changes
+
+- **GIVEN** several link mutations in quick succession
+- **WHEN** they occur
+- **THEN** persistence is coalesced into a debounced write and the user is not
+  blocked waiting on storage

--- a/openspec/specs/template-linking/spec.md
+++ b/openspec/specs/template-linking/spec.md
@@ -8,8 +8,7 @@ template (or organization): creating, removing, moving, and pruning those links,
 and persisting them efficiently without ever storing template bodies.
 
 Source: `src/models/LinkManager.ts`, `src/models/types.ts`,
-`src/utils/getHash.ts`; commands under `src/commands/template/link/` and
-`src/commands/folders/`.
+`src/utils/getHash.ts`, `src/commands/template/link/`, `src/commands/folders/`.
 
 ## Requirements
 
@@ -127,7 +126,10 @@ so a deleted-while-closed file does not leave a dangling association.
 
 The system SHALL prefer the template's own (sub-)organization over the
 organization stored on a legacy link, so links created before sub-org tracking
-still resolve to the correct org.
+still resolve to the correct org. For MCP- and URL-driven calls, template-sync's
+organization-normalization guard (see template-sync's
+`Normalize organizations during sync updates` requirement) layers additional
+verification before this resolution is allowed to change a link's stored org.
 
 #### Scenario: Legacy link stored under a parent org
 

--- a/openspec/specs/template-management/spec.md
+++ b/openspec/specs/template-management/spec.md
@@ -6,9 +6,10 @@ Beyond linking and syncing existing templates, the extension lets users create,
 delete, open, locate, and group Rewst templates from inside VS Code. This
 capability covers those lifecycle and navigation operations.
 
-Source: `src/commands/template/` (and subdirectories),
-`src/utils/openTemplateById.ts`, `src/utils/createAndLinkNewTemplate.ts`,
-`src/models/TemplateBundleManager.ts`, `src/utils/findAllTemplateReferences.ts`.
+Source: `src/commands/template/`, `src/utils/openTemplateById.ts`,
+`src/utils/createAndLinkNewTemplate.ts`,
+`src/providers/templatePatternUtils.ts`, `src/models/TemplateBundleManager.ts`,
+`src/capabilities/templateCloneCapabilities.ts`.
 
 ## Requirements
 
@@ -74,8 +75,17 @@ template and create a new local file.
 ### Requirement: Open or link a template from its Rewst URL
 
 The system SHALL accept a Rewst template URL, parse the organization, template,
-and base URL from it, and either open the template (reusing a link when present)
-or link an existing local file to it.
+and base URL from it, resolve a session whose region matches that base URL and
+whose primary or managed organizations include the parsed organization, and
+either open the template (reusing a link when present) or link an existing local
+file to it.
+
+**Implementation status:** resolving a parsed organization that is a managed
+sub-organization (rather than a session's primary organization) depends on
+session-auth's managed-org resolution, which is not yet implemented (see
+session-auth's `Manage multiple organizations per session` requirement); today
+this resolution succeeds reliably only when the parsed organization is a
+session's primary organization.
 
 #### Scenario: Open from URL
 
@@ -83,6 +93,8 @@ or link an existing local file to it.
 - **WHEN** the user runs `Open Template from URL`
 - **THEN** the org/template/base are parsed and the template is opened with the
   same reuse behavior as interactive open
+- **AND** if the parsed org is a managed sub-organization, the session is
+  resolved by both matching region/base URL and managed-org membership
 
 #### Scenario: Link a local file from URL
 
@@ -185,7 +197,23 @@ its same-org referenced template graph into a target organization. The clone
 operation SHALL prompt once per target org/root template scope, rewrite
 references to newly created clone ids, deduplicate repeated dependencies, bound
 the traversal by depth and template count, and roll back created clones if a
-create or update step fails.
+create or update step fails. The target organization is the write destination and
+SHALL pass external MCP write-tool enablement, working-scope or allowlist gates,
+and per-call approval before any clone template is created. The source root
+SHALL be read from an active session that can reach it, and an optional
+`sourceOrgId` SHALL be verified against the root template's owning organization.
+The operation creates remote Rewst templates only; it SHALL NOT create local
+files or local template links.
+
+The dependency graph SHALL be derived from detected template body references
+only, using supported `template('<id>')`-style references. The clone SHALL copy
+body, content type, language, context, clone overrides, and description when
+available, but SHALL NOT copy tags unless that behavior is specified by a future
+capability. References embedded only in context or clone overrides SHALL NOT be
+followed or rewritten. Detected foreign-org, missing, depth-limited, or
+count-limited body references SHALL be left unchanged and reported as skipped;
+unsupported or dynamic references that the parser cannot detect are outside the
+clone graph and are not guaranteed to be reported.
 
 #### Scenario: Clone a dependency chain
 
@@ -207,6 +235,30 @@ create or update step fails.
 - **WHEN** the bundle is cloned
 - **THEN** the foreign template is not cloned
 - **AND** the result reports that the reference was skipped
+
+#### Scenario: Clone metadata caveats
+
+- **GIVEN** a root template has tags and clone overrides
+- **AND** a dependency id appears only inside clone overrides
+- **WHEN** the bundle is cloned
+- **THEN** body, content type, language, context, clone overrides, and
+  description are copied when available
+- **AND** tags are not copied
+- **AND** the dependency id inside clone overrides is not followed or rewritten
+- **AND** only detected body references are included in skipped-reference
+  reporting
+
+#### Scenario: Clone verifies source org
+
+- **GIVEN** the caller passes a `sourceOrgId`
+- **WHEN** the root template is fetched from a different owning org
+- **THEN** the clone is rejected before creating any target templates
+
+#### Scenario: Clone creates no local link
+
+- **GIVEN** a bundle clone completes successfully
+- **WHEN** the new templates are created in the target org
+- **THEN** no local file or link is created automatically
 
 #### Scenario: Clone rollback
 

--- a/openspec/specs/template-management/spec.md
+++ b/openspec/specs/template-management/spec.md
@@ -1,0 +1,134 @@
+# Template Management Specification
+
+## Purpose
+
+Beyond linking and syncing existing templates, the extension lets users create,
+delete, open, locate, and group Rewst templates from inside VS Code. This
+capability covers those lifecycle and navigation operations.
+
+Source: `src/commands/template/` (and subdirectories),
+`src/utils/openTemplateById.ts`, `src/utils/createAndLinkNewTemplate.ts`,
+`src/models/TemplateBundleManager.ts`, `src/utils/findAllTemplateReferences.ts`.
+
+## Requirements
+
+### Requirement: Create a template from a local file
+
+The system SHALL create a new Rewst template from a saved, not-yet-linked local
+file, then link that file to the new template.
+
+#### Scenario: User creates a template
+
+- **GIVEN** a saved local file that is not already linked
+- **WHEN** the user runs `Create Template`, picks an organization, and confirms a
+  name (defaulting to the file's base name)
+- **THEN** the extension creates the template in Rewst with the file's current
+  text as the body
+- **AND** links the file to the new template, recording its content hash and any
+  referenced template ids
+
+#### Scenario: File already linked
+
+- **GIVEN** a file that is already linked to a template
+- **WHEN** the user runs `Create Template`
+- **THEN** the command refuses, since the file is already associated
+
+### Requirement: Delete a template with confirmation
+
+The system SHALL delete a template from Rewst only after an explicit modal
+confirmation, and SHALL remove the local link after a successful remote delete.
+
+#### Scenario: User confirms deletion
+
+- **GIVEN** a linked file
+- **WHEN** the user runs `Delete Template` and confirms the "cannot be undone"
+  modal
+- **THEN** the template is deleted in Rewst and the local link is removed
+
+#### Scenario: User cancels
+
+- **GIVEN** the delete confirmation modal
+- **WHEN** the user dismisses it
+- **THEN** nothing is deleted and the link remains
+
+### Requirement: Open a template, reusing an existing link
+
+The system SHALL open a template by id, and SHALL reuse an already-linked local
+file rather than creating a duplicate; only when no link exists does it fetch the
+template and create a new local file.
+
+#### Scenario: Template already linked locally
+
+- **GIVEN** a template that is already linked to a local file
+- **WHEN** the user opens that template (interactively or from a URL)
+- **THEN** the existing local file is opened instead of fetching a duplicate
+- **AND** if several files link the same template, the user is offered a choice
+
+#### Scenario: Template not yet linked
+
+- **GIVEN** a template with no local link
+- **WHEN** the user opens it
+- **THEN** the extension fetches the full template, prompts for a save location,
+  and links the new file
+
+### Requirement: Open or link a template from its Rewst URL
+
+The system SHALL accept a Rewst template URL, parse the organization, template,
+and base URL from it, and either open the template (reusing a link when present)
+or link an existing local file to it.
+
+#### Scenario: Open from URL
+
+- **GIVEN** a Rewst template URL
+- **WHEN** the user runs `Open Template from URL`
+- **THEN** the org/template/base are parsed and the template is opened with the
+  same reuse behavior as interactive open
+
+#### Scenario: Link a local file from URL
+
+- **GIVEN** a saved, unlinked local file and a Rewst template URL
+- **WHEN** the user runs `Link File to Template from URL`
+- **THEN** the file is linked to the parsed template and an immediate sync
+  reconciles local and remote
+
+### Requirement: Copy a linked template's id
+
+The system SHALL copy the linked template's id to the clipboard.
+
+#### Scenario: Copy id
+
+- **GIVEN** a linked file
+- **WHEN** the user runs `Copy Template ID`
+- **THEN** the template id is placed on the clipboard
+
+### Requirement: Open a template in the Rewst web app
+
+The system SHALL open the linked template in the Rewst web UI, constructing the
+URL from the organization's region base URL plus the org and template ids.
+
+#### Scenario: Open in Rewst
+
+- **GIVEN** a linked file whose org has a known region
+- **WHEN** the user runs `Open in Rewst`
+- **THEN** the browser opens the template's page in the correct regional Rewst
+  instance
+
+### Requirement: Bundle related templates
+
+The system SHALL group linked templates into bundles based on their reference
+graph — templates that reference other linked templates form dependency trees —
+and SHALL present those bundles in a tree view, refreshing as links change.
+
+#### Scenario: Templates that reference each other
+
+- **GIVEN** several linked templates where some reference others by id
+- **WHEN** bundles are built
+- **THEN** root templates (referencing others but unreferenced themselves) anchor
+  trees containing all reachable referenced templates
+- **AND** templates with no references in either direction appear as standalone
+
+#### Scenario: Duplicate bundle names
+
+- **GIVEN** two bundles whose root templates share a display name
+- **WHEN** the tree is rendered
+- **THEN** the names are disambiguated by appending part of the template id

--- a/openspec/specs/template-management/spec.md
+++ b/openspec/specs/template-management/spec.md
@@ -113,6 +113,25 @@ URL from the organization's region base URL plus the org and template ids.
 - **THEN** the browser opens the template's page in the correct regional Rewst
   instance
 
+#### Scenario: Region from active session
+
+- **GIVEN** the linked template belongs to an org managed by an active session
+- **WHEN** the user opens it in Rewst
+- **THEN** the URL uses that active session's region base URL
+
+#### Scenario: Region from known profile
+
+- **GIVEN** no active session manages the linked template's org
+- **AND** a known profile contains the org as a primary or managed org
+- **WHEN** the user opens it in Rewst
+- **THEN** the URL uses the known profile's region base URL
+
+#### Scenario: Fallback region
+
+- **GIVEN** no active session or known profile identifies the org's region
+- **WHEN** the user opens the linked template in Rewst
+- **THEN** the URL falls back to the default configured region
+
 ### Requirement: Bundle related templates
 
 The system SHALL group linked templates into bundles based on their reference
@@ -132,3 +151,65 @@ and SHALL present those bundles in a tree view, refreshing as links change.
 - **GIVEN** two bundles whose root templates share a display name
 - **WHEN** the tree is rendered
 - **THEN** the names are disambiguated by appending part of the template id
+
+#### Scenario: Shared referenced template
+
+- **GIVEN** two root templates both reference the same linked child template
+- **WHEN** bundles are built
+- **THEN** the shared child appears under each root bundle that reaches it
+
+#### Scenario: Cyclic references
+
+- **GIVEN** linked templates that reference each other in a cycle
+- **WHEN** bundles are built
+- **THEN** traversal terminates without duplicating nodes indefinitely
+- **AND** the cycle is represented once along the reachable path
+
+#### Scenario: Unknown references
+
+- **GIVEN** a linked template references an id that is not linked locally and not
+  present in cached metadata
+- **WHEN** bundles are built
+- **THEN** the unknown reference is ignored for bundle-tree structure
+
+#### Scenario: Legacy links missing reference metadata
+
+- **GIVEN** an older link whose referenced-template ids were not persisted
+- **WHEN** bundles are built
+- **THEN** references are re-derived from the local template body when possible
+
+### Requirement: Clone a template bundle through MCP
+
+The system SHALL provide an MCP-only write tool that clones a root template and
+its same-org referenced template graph into a target organization. The clone
+operation SHALL prompt once per target org/root template scope, rewrite
+references to newly created clone ids, deduplicate repeated dependencies, bound
+the traversal by depth and template count, and roll back created clones if a
+create or update step fails.
+
+#### Scenario: Clone a dependency chain
+
+- **GIVEN** a root template references another template in the same source org
+- **WHEN** the bundle clone tool is approved
+- **THEN** both templates are created in the target org
+- **AND** the root clone's body references the cloned dependency id
+
+#### Scenario: Shared dependency cloned once
+
+- **GIVEN** two templates in the bundle reference the same dependency
+- **WHEN** the bundle is cloned
+- **THEN** that dependency is created once
+- **AND** all cloned references point to the single new dependency id
+
+#### Scenario: Foreign-org reference
+
+- **GIVEN** the source template references a template owned by another org
+- **WHEN** the bundle is cloned
+- **THEN** the foreign template is not cloned
+- **AND** the result reports that the reference was skipped
+
+#### Scenario: Clone rollback
+
+- **GIVEN** some clone templates have already been created
+- **WHEN** a later create or update step fails
+- **THEN** the tool deletes the templates it created before returning the failure

--- a/openspec/specs/template-sync/spec.md
+++ b/openspec/specs/template-sync/spec.md
@@ -61,6 +61,9 @@ and choose exactly one action: **update-metadata**, **download-remote**,
 The system SHALL push a linked file on save when sync-on-save is in effect for
 that file, governed by the `rewst-buddy.syncOnSaveByDefault` setting and per-file
 toggles. Files for which sync-on-save is not in effect SHALL NOT sync on save.
+Per-file sync-on-save state SHALL be persisted in inclusion and exclusion lists
+so toggles survive reloads and can invert cleanly when the default setting
+changes.
 
 #### Scenario: Sync-on-save enabled for a file
 
@@ -74,11 +77,28 @@ toggles. Files for which sync-on-save is not in effect SHALL NOT sync on save.
 - **WHEN** the user saves it
 - **THEN** no automatic sync occurs
 
+#### Scenario: Per-file toggle persists
+
+- **GIVEN** `syncOnSaveByDefault` is disabled
+- **WHEN** a linked file is explicitly enabled for sync-on-save
+- **THEN** the file URI is stored in the sync inclusion list
+- **AND** future saves of that linked file sync until the toggle is disabled
+
+#### Scenario: Default enabled with one exclusion
+
+- **GIVEN** `syncOnSaveByDefault` is enabled
+- **WHEN** a linked file is explicitly disabled for sync-on-save
+- **THEN** the file URI is stored in the sync exclusion list
+- **AND** future saves of that linked file do not sync while other linked files do
+
 ### Requirement: Auto-fetch on open without clobbering local edits
 
 When `rewst-buddy.autoFetchOnOpen` is enabled, the system SHALL silently download
 a newer remote version on open **only** when the local file has no unsaved
 divergence, i.e. the local body still hashes to the link's stored `bodyHash`.
+Auto-fetch SHALL be independent of sync-on-save state, SHALL skip equal or older
+remote timestamps, and SHALL fail closed without overwriting local content when
+the remote fetch fails.
 
 #### Scenario: Remote is newer and local is untouched
 
@@ -92,6 +112,34 @@ divergence, i.e. the local body still hashes to the link's stored `bodyHash`.
 - **GIVEN** a linked file whose local body no longer matches its stored hash
 - **WHEN** the file is opened with a newer remote available
 - **THEN** auto-fetch does not overwrite the local file
+
+#### Scenario: Remote fetch fails
+
+- **GIVEN** a linked file with auto-fetch enabled
+- **WHEN** the remote template cannot be fetched
+- **THEN** the local file is left unchanged
+- **AND** no sync upload is attempted as part of the open event
+
+### Requirement: Normalize organizations during sync updates
+
+The system SHALL record the template's owning organization from the remote
+template metadata when refreshing, downloading, or uploading a link. It SHALL NOT
+trust stale legacy link org metadata when the template metadata identifies a
+different owning org.
+
+#### Scenario: Stale link org is corrected
+
+- **GIVEN** a link whose stored org is a parent or stale org
+- **AND** the remote template metadata identifies a sub-org
+- **WHEN** a sync refreshes metadata
+- **THEN** the link records the remote template's org id and name
+
+#### Scenario: Remote template belongs elsewhere
+
+- **GIVEN** a sync request for org A
+- **AND** the remote template metadata says the template belongs to org B
+- **WHEN** the sync would upload or download content
+- **THEN** the sync is rejected before changing either side
 
 ### Requirement: Resolve conflicts with explicit user choice
 
@@ -116,6 +164,42 @@ and SHALL abort the sync if the user dismisses the prompt.
 - **GIVEN** a conflict prompt
 - **WHEN** the user cancels
 - **THEN** no change is made and the sync is aborted
+
+### Requirement: Expose explicit sync tools
+
+The system SHALL expose MCP sync helpers that report link state and run syncs by
+explicit local path. `buddy_template_sync_status` SHALL be a read operation that
+maps the sync decision into user-facing states. `buddy_template_sync` SHALL allow
+automatic direction selection or explicit `upload` / `download` directions, with
+approval required before uploads to Rewst.
+
+#### Scenario: Sync status
+
+- **GIVEN** a linked file
+- **WHEN** `buddy_template_sync_status` is called for that file
+- **THEN** the result includes whether the file is linked, the template/org ids,
+  sync-on-save state, whether bodies match, and a recommended direction
+
+#### Scenario: Approved upload
+
+- **GIVEN** a linked file with local changes and unchanged remote metadata
+- **WHEN** `buddy_template_sync` selects or is given the `upload` direction
+- **THEN** the local file is saved if dirty
+- **AND** the upload occurs only after approval
+
+#### Scenario: Explicit empty upload
+
+- **GIVEN** a linked file whose local body is empty
+- **WHEN** `buddy_template_sync` is explicitly called with direction `upload`
+- **THEN** the approval prompt and result state that the remote template body will
+  be cleared
+
+#### Scenario: Download direction
+
+- **GIVEN** a linked file with remote content to take
+- **WHEN** `buddy_template_sync` is explicitly called with direction `download`
+- **THEN** the remote body replaces the local file without requiring a Rewst
+  mutation approval
 
 ### Requirement: Avoid false conflicts after upload
 

--- a/openspec/specs/template-sync/spec.md
+++ b/openspec/specs/template-sync/spec.md
@@ -9,7 +9,8 @@ decision logic, sync-on-save, auto-fetch-on-open, conflict handling, and
 background folder fetching.
 
 Source: `src/models/SyncManager.ts`, `src/models/syncDecision.ts`,
-`src/models/SyncOnSaveManager.ts`, `src/utils/getHash.ts`.
+`src/models/SyncOnSaveManager.ts`, `src/models/types.ts`,
+`src/capabilities/templateSyncCapabilities.ts`, `src/utils/getHash.ts`.
 
 ## Requirements
 
@@ -98,7 +99,16 @@ a newer remote version on open **only** when the local file has no unsaved
 divergence, i.e. the local body still hashes to the link's stored `bodyHash`.
 Auto-fetch SHALL be independent of sync-on-save state, SHALL skip equal or older
 remote timestamps, and SHALL fail closed without overwriting local content when
-the remote fetch fails.
+the remote fetch fails. "Newer" SHALL mean the remote `updatedAt` parses to an
+instant later than the link's last-known `updatedAt`; if either timestamp is
+missing, unparsable, or cannot prove the remote is newer, auto-fetch SHALL leave
+the local file unchanged.
+
+**Implementation status:** today the comparison is a strict string inequality
+between `remote.updatedAt` and the link's stored timestamp, not a parsed-instant
+comparison — any differing timestamp is treated as newer, and there is no
+missing/unparsable fallback. Adding real timestamp parsing as described above is
+tracked as follow-up work.
 
 #### Scenario: Remote is newer and local is untouched
 
@@ -120,17 +130,47 @@ the remote fetch fails.
 - **THEN** the local file is left unchanged
 - **AND** no sync upload is attempted as part of the open event
 
+#### Scenario: Remote is not provably newer
+
+- **GIVEN** a linked file whose local body still matches its stored hash
+- **AND** the remote timestamp is equal, older, missing, or unparsable relative
+  to the link's last-known timestamp
+- **WHEN** the file is opened
+- **THEN** auto-fetch does not replace the local file
+
 ### Requirement: Normalize organizations during sync updates
 
-The system SHALL record the template's owning organization from the remote
-template metadata when refreshing, downloading, or uploading a link. It SHALL NOT
-trust stale legacy link org metadata when the template metadata identifies a
-different owning org.
+The system SHALL record the template's owning organization from trusted remote
+template metadata when refreshing, downloading, or uploading a link. For every
+path that can change local or remote content or link metadata, including
+sync-on-save, auto-fetch-on-open, interactive sync, MCP sync, and metadata
+refresh, the system SHALL verify that the fetched remote template belongs to the
+expected organization before changing either side. The expected organization is
+the link's trusted template-owner metadata (`template.orgId` or
+`template.organization.id`) when present, otherwise the stored link organization.
+A legacy link that lacks trusted template-owner metadata MAY be corrected from a
+remote fetch only when the fetched template id matches the link, the resolving
+session manages the remote owner, and the caller did not supply a conflicting
+org id. MCP and URL-driven calls SHALL require any requested organization to
+match the trusted expected organization before content changes. If the remote
+organization is missing or mismatched, the sync SHALL fail closed before local
+or remote mutation. The system SHALL NOT trust stale legacy link org metadata
+when trusted template metadata identifies a different owning org and the remote
+fetch confirms that owner.
+
+**Implementation status:** today this guard is fully enforced only on the MCP
+sync path (`runSync`); sync-on-save, auto-fetch-on-open, interactive sync, and
+metadata refresh do not yet perform the verification step before changing local
+or remote content. Extending the guard to those paths is tracked as follow-up
+work.
 
 #### Scenario: Stale link org is corrected
 
 - **GIVEN** a link whose stored org is a parent or stale org
+- **AND** the link lacks trusted template-owner metadata
 - **AND** the remote template metadata identifies a sub-org
+- **AND** the resolving session manages that sub-org
+- **AND** the caller did not provide a conflicting org id
 - **WHEN** a sync refreshes metadata
 - **THEN** the link records the remote template's org id and name
 
@@ -138,7 +178,22 @@ different owning org.
 
 - **GIVEN** a sync request for org A
 - **AND** the remote template metadata says the template belongs to org B
-- **WHEN** the sync would upload or download content
+- **WHEN** the sync would upload, download, auto-fetch, or refresh metadata
+- **THEN** the sync is rejected before changing either side
+
+#### Scenario: Explicit org conflicts with legacy correction
+
+- **GIVEN** a legacy link has stored org A but no trusted template-owner metadata
+- **AND** the fetched remote template belongs to org B
+- **AND** the caller explicitly requested org A
+- **WHEN** the sync would change local content, remote content, or link metadata
+- **THEN** the sync is rejected rather than silently correcting the link to org B
+
+#### Scenario: Remote template organization is unknown
+
+- **GIVEN** a linked template with an expected organization
+- **AND** the fetched remote template omits owning organization metadata
+- **WHEN** the sync would change local content, remote content, or link metadata
 - **THEN** the sync is rejected before changing either side
 
 ### Requirement: Resolve conflicts with explicit user choice
@@ -171,7 +226,13 @@ The system SHALL expose MCP sync helpers that report link state and run syncs by
 explicit local path. `buddy_template_sync_status` SHALL be a read operation that
 maps the sync decision into user-facing states. `buddy_template_sync` SHALL allow
 automatic direction selection or explicit `upload` / `download` directions, with
-approval required before uploads to Rewst.
+approval required before uploads to Rewst. The `buddy_template_sync` tool SHALL
+be classified as write-tier for external MCP exposure in every direction
+because automatic sync can upload to Rewst and explicit download can overwrite a
+workspace file; every call SHALL require write tools to be enabled and the
+target org to pass the effective write allowlist. Download-only and
+metadata-only calls do not require Rewst mutation approval, but they remain
+subject to workspace target validation and sync organization guards.
 
 #### Scenario: Sync status
 
@@ -200,6 +261,15 @@ approval required before uploads to Rewst.
 - **WHEN** `buddy_template_sync` is explicitly called with direction `download`
 - **THEN** the remote body replaces the local file without requiring a Rewst
   mutation approval
+
+#### Scenario: MCP conflict returns data instead of a modal
+
+- **GIVEN** a linked file where local and remote both changed
+- **WHEN** `buddy_template_sync` is called with direction `auto`
+- **THEN** no modal is shown to the external MCP caller
+- **AND** no local or remote change is made
+- **AND** the result reports the conflict and asks the caller to choose
+  `upload` or `download`
 
 ### Requirement: Avoid false conflicts after upload
 

--- a/openspec/specs/template-sync/spec.md
+++ b/openspec/specs/template-sync/spec.md
@@ -1,0 +1,156 @@
+# Template Sync Specification
+
+## Purpose
+
+Once a local file is linked to a Rewst template, the extension keeps the two in
+step: pushing local edits up on save, pulling remote updates down on open, and
+detecting when local and remote have diverged. This capability covers the sync
+decision logic, sync-on-save, auto-fetch-on-open, conflict handling, and
+background folder fetching.
+
+Source: `src/models/SyncManager.ts`, `src/models/syncDecision.ts`,
+`src/models/SyncOnSaveManager.ts`, `src/utils/getHash.ts`.
+
+## Requirements
+
+### Requirement: Decide the sync action deterministically
+
+On each sync the system SHALL compare the local file against the remote template
+and choose exactly one action: **update-metadata**, **download-remote**,
+**upload-local**, or **conflict**. The decision SHALL be evaluated in this order:
+
+1. If the local body equals the remote body → **update-metadata**.
+2. Otherwise, if the local body is empty → **download-remote**.
+3. Otherwise, if the local last-known timestamp equals the remote timestamp →
+   **upload-local**.
+4. Otherwise → **conflict**.
+
+#### Scenario: Local matches remote
+
+- **GIVEN** a linked file whose text equals the remote template body
+- **WHEN** a sync runs
+- **THEN** the action is **update-metadata**: the link's `bodyHash` and
+  referenced template ids are refreshed and no body change is sent or applied
+
+#### Scenario: Local file is empty
+
+- **GIVEN** a linked file with empty content and a non-empty remote template
+- **WHEN** a sync runs
+- **THEN** the action is **download-remote**: the document is replaced with the
+  remote body and the file is saved
+
+#### Scenario: Local edited, remote unchanged since last sync
+
+- **GIVEN** a linked file edited locally
+- **AND** the remote template's timestamp still equals the link's last-known
+  timestamp
+- **WHEN** a sync runs
+- **THEN** the action is **upload-local**: the local body is pushed to Rewst and
+  the link is updated with the response metadata
+
+#### Scenario: Both sides changed
+
+- **GIVEN** a linked file edited locally
+- **AND** the remote template's timestamp differs from the link's last-known
+  timestamp
+- **WHEN** a sync runs
+- **THEN** the action is **conflict**
+
+### Requirement: Sync on save when enabled
+
+The system SHALL push a linked file on save when sync-on-save is in effect for
+that file, governed by the `rewst-buddy.syncOnSaveByDefault` setting and per-file
+toggles. Files for which sync-on-save is not in effect SHALL NOT sync on save.
+
+#### Scenario: Sync-on-save enabled for a file
+
+- **GIVEN** a linked file with sync-on-save active
+- **WHEN** the user saves it
+- **THEN** a sync runs for that file
+
+#### Scenario: Sync-on-save not active
+
+- **GIVEN** a linked file with sync-on-save off and the default disabled
+- **WHEN** the user saves it
+- **THEN** no automatic sync occurs
+
+### Requirement: Auto-fetch on open without clobbering local edits
+
+When `rewst-buddy.autoFetchOnOpen` is enabled, the system SHALL silently download
+a newer remote version on open **only** when the local file has no unsaved
+divergence, i.e. the local body still hashes to the link's stored `bodyHash`.
+
+#### Scenario: Remote is newer and local is untouched
+
+- **GIVEN** a linked file whose local body still matches its stored hash
+- **AND** the remote template is newer than the link's last-known timestamp
+- **WHEN** the file is opened
+- **THEN** the remote body is downloaded silently
+
+#### Scenario: Local has diverged
+
+- **GIVEN** a linked file whose local body no longer matches its stored hash
+- **WHEN** the file is opened with a newer remote available
+- **THEN** auto-fetch does not overwrite the local file
+
+### Requirement: Resolve conflicts with explicit user choice
+
+When the action is **conflict**, the system SHALL prompt the user with a modal
+offering to force-upload the local version or download the latest remote version,
+and SHALL abort the sync if the user dismisses the prompt.
+
+#### Scenario: User forces the local version
+
+- **GIVEN** a conflict prompt
+- **WHEN** the user chooses to force-override
+- **THEN** the local body is uploaded to Rewst
+
+#### Scenario: User takes the remote version
+
+- **GIVEN** a conflict prompt
+- **WHEN** the user chooses to download the latest
+- **THEN** the remote body replaces the local file
+
+#### Scenario: User dismisses
+
+- **GIVEN** a conflict prompt
+- **WHEN** the user cancels
+- **THEN** no change is made and the sync is aborted
+
+### Requirement: Avoid false conflicts after upload
+
+After a successful upload, the system SHALL update the link's last-known
+timestamp to the value returned by Rewst, so the next sync does not misread its
+own write as a remote change.
+
+#### Scenario: Two saves in a row
+
+- **GIVEN** a linked file just uploaded successfully
+- **WHEN** the user edits and saves again
+- **THEN** the second sync sees matching timestamps and uploads cleanly rather
+  than reporting a conflict
+
+### Requirement: Guard against concurrent syncs
+
+The system SHALL prevent overlapping syncs of the same file.
+
+#### Scenario: Rapid repeated saves
+
+- **GIVEN** a file already mid-sync
+- **WHEN** another sync is triggered for the same file before the first completes
+- **THEN** the second is suppressed until the first finishes
+
+### Requirement: Background folder fetch
+
+For folders linked to an organization, the system SHALL periodically fetch new
+templates from that org in the background and materialize them as linked local
+files, writing in batches to avoid UI stalls and reporting how many were
+fetched.
+
+#### Scenario: New templates appear in a linked org
+
+- **GIVEN** a folder linked to an org
+- **WHEN** the background fetch interval runs and the org has templates not yet
+  present locally
+- **THEN** the missing templates are written as local files, linked, and the user
+  is notified of the count fetched

--- a/src/capabilities/templateCloneCapabilities.test.ts
+++ b/src/capabilities/templateCloneCapabilities.test.ts
@@ -2,6 +2,7 @@ import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { createMockSession, initTestEnvironment } from '@test';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
+import { LinkManager } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
 import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
 import {
@@ -98,11 +99,13 @@ suite('Unit: templateCloneCapabilities', () => {
 		initTestEnvironment();
 		_resetApprovedMutationScopes();
 		_resetMcpMutationApproverForTesting();
+		LinkManager._resetForTesting();
 	});
 
 	teardown(() => {
 		_resetApprovedMutationScopes();
 		_resetMcpMutationApproverForTesting();
+		LinkManager._resetForTesting();
 	});
 
 	suite('rewriteReferences', () => {
@@ -201,9 +204,16 @@ suite('Unit: templateCloneCapabilities', () => {
 			assert.ok(!rootUpdate.body.includes(B), 'old id no longer present');
 		});
 
-		test('copies source contentType / language / context onto each clone', async () => {
+		test('copies source contentType / language / context / cloneOverrides / description onto each clone', async () => {
 			const remote = {
-				[A]: tmpl(A, { body: 'print(1)', contentType: 'powershell', language: 'python', context: { x: 1 } }),
+				[A]: tmpl(A, {
+					body: 'print(1)',
+					contentType: 'powershell',
+					language: 'python',
+					context: { x: 1 },
+					cloneOverrides: { y: 2 },
+					description: 'a real description',
+				}),
 			};
 			const { deps, calls } = makeCloneDeps(remote);
 			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
@@ -211,6 +221,17 @@ suite('Unit: templateCloneCapabilities', () => {
 			assert.strictEqual(update.language, 'python');
 			assert.strictEqual(update.contentType, 'powershell');
 			assert.deepStrictEqual(update.context, { x: 1 });
+			assert.deepStrictEqual(update.cloneOverrides, { y: 2 });
+			assert.strictEqual(update.description, 'a real description');
+		});
+
+		test('creates no local file or link (clone is remote-only)', async () => {
+			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
+			const { deps } = makeCloneDeps(remote);
+
+			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
+
+			assert.strictEqual(LinkManager.getAllTemplateLinks().length, 0, 'no local link was created');
 		});
 
 		test('handles a cycle without looping forever', async () => {
@@ -287,7 +308,10 @@ suite('Unit: templateCloneCapabilities', () => {
 			const remote = { [A]: tmpl(A, { body: refBody([B]) }), [B]: tmpl(B) };
 			const { deps, calls } = makeCloneDeps(remote);
 			await runBundleClone({ orgId: 'tgt-org', rootTemplateId: A }, makeCtx(), deps);
-			assert.ok(calls.create.every(c => c.orgId === 'tgt-org'), 'all creates target the requested org');
+			assert.ok(
+				calls.create.every(c => c.orgId === 'tgt-org'),
+				'all creates target the requested org',
+			);
 		});
 
 		test('fetches the root from a later session when the first cannot', async () => {
@@ -296,7 +320,10 @@ suite('Unit: templateCloneCapabilities', () => {
 			const base = deps.getTemplate;
 			const s1 = {} as unknown as Session;
 			const s2 = {
-				profile: { org: { id: 'tgt-org', name: 'Target' }, allManagedOrgs: [{ id: 'tgt-org', name: 'Target' }] },
+				profile: {
+					org: { id: 'tgt-org', name: 'Target' },
+					allManagedOrgs: [{ id: 'tgt-org', name: 'Target' }],
+				},
 			} as unknown as Session;
 			deps.getTemplate = async (s, id) => {
 				if (s === s1) throw new Error('first session cannot read it');
@@ -354,7 +381,15 @@ suite('Unit: templateCloneCapabilities', () => {
 	});
 
 	suite('defaultTemplateCloneDeps (production SDK glue)', () => {
-		const update = { id: 'x', body: 'b', contentType: 'text', language: 'jinja', context: null, cloneOverrides: null, description: null };
+		const update = {
+			id: 'x',
+			body: 'b',
+			contentType: 'text',
+			language: 'jinja',
+			context: null,
+			cloneOverrides: null,
+			description: null,
+		};
 
 		test('createTemplate returns the minted id', async () => {
 			const { session, wrapper } = createMockSession({ profile: { org: { id: 'tgt', name: 'T' } } });
@@ -366,7 +401,10 @@ suite('Unit: templateCloneCapabilities', () => {
 		test('createTemplate throws when the response has no template', async () => {
 			const { session, wrapper } = createMockSession();
 			wrapper.when('createTemplateMinimal', { data: { template: null } });
-			await assert.rejects(() => defaultTemplateCloneDeps.createTemplate(session, 'X', 'tgt'), /returned no template/);
+			await assert.rejects(
+				() => defaultTemplateCloneDeps.createTemplate(session, 'X', 'tgt'),
+				/returned no template/,
+			);
 		});
 
 		test('updateTemplate succeeds and throws on a missing template', async () => {
@@ -376,7 +414,10 @@ suite('Unit: templateCloneCapabilities', () => {
 
 			const bad = createMockSession();
 			bad.wrapper.when('updateTemplate', { data: { template: null } });
-			await assert.rejects(() => defaultTemplateCloneDeps.updateTemplate(bad.session, update), /returned no template/);
+			await assert.rejects(
+				() => defaultTemplateCloneDeps.updateTemplate(bad.session, update),
+				/returned no template/,
+			);
 		});
 
 		test('deleteTemplate succeeds and throws on a null result', async () => {
@@ -386,7 +427,10 @@ suite('Unit: templateCloneCapabilities', () => {
 
 			const bad = createMockSession();
 			bad.wrapper.when('deleteTemplate', { data: { deleteTemplate: null } });
-			await assert.rejects(() => defaultTemplateCloneDeps.deleteTemplate(bad.session, 'x'), /rollback delete failed/);
+			await assert.rejects(
+				() => defaultTemplateCloneDeps.deleteTemplate(bad.session, 'x'),
+				/rollback delete failed/,
+			);
 		});
 	});
 });

--- a/src/commands/folders/link/LinkFolder.test.ts
+++ b/src/commands/folders/link/LinkFolder.test.ts
@@ -1,4 +1,4 @@
-import { LinkManager } from '@models';
+import { LinkManager, SyncManager } from '@models';
 import { SessionManager } from '@sessions';
 import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import * as assert from 'assert';
@@ -78,5 +78,26 @@ suite('Unit: LinkFolder', () => {
 		await new LinkFolder().execute([folderUri]);
 
 		assert.strictEqual(LinkManager.getFolderLinks().length, 0);
+	});
+
+	test('still links the folder when fetching its templates fails', async () => {
+		const org = Fixtures.orgModel({ id: 'org-fetch-fail', name: 'Fetch Fail Org' });
+		const { session } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		SessionManager._setSessionsForTesting([session]);
+
+		stub(vscode.window, 'showQuickPick', (async (items: readonly { detail?: string }[]) =>
+			items.find(i => i.detail === 'Primary Organization')) as unknown as typeof vscode.window.showQuickPick);
+
+		let fetchCalled = false;
+		stub(SyncManager, 'fetchFolder', (async () => {
+			fetchCalled = true;
+			throw new Error('fetch failed');
+		}) as typeof SyncManager.fetchFolder);
+
+		await new LinkFolder().execute([folderUri]);
+
+		assert.ok(fetchCalled, 'the folder fetch was attempted');
+		const folderLink = LinkManager.getFolderLink(folderUri);
+		assert.strictEqual(folderLink.org.id, org.id, 'the folder link persists despite the fetch failure');
 	});
 });

--- a/src/commands/folders/link/LinkFolder.test.ts
+++ b/src/commands/folders/link/LinkFolder.test.ts
@@ -1,0 +1,82 @@
+import { LinkManager } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { LinkFolder } from './LinkFolder';
+
+const { suite, test, setup, teardown } = Mocha;
+
+suite('Unit: LinkFolder', () => {
+	let tmpDir: string;
+	let folderUri: vscode.Uri;
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-link-folder-'));
+		folderUri = vscode.Uri.file(tmpDir);
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('links the folder to the chosen org and fetches its templates', async () => {
+		const org = Fixtures.orgModel({ id: 'org-link-folder', name: 'Folder Org' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't1', name: 'Alpha', orgId: org.id })]),
+		});
+		wrapper.when('getTemplate', () => ({
+			data: Fixtures.getTemplateQuery({
+				id: 't1',
+				name: 'Alpha',
+				body: 'alpha-body',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		}));
+		SessionManager._setSessionsForTesting([session]);
+
+		stub(vscode.window, 'showQuickPick', (async (items: readonly { detail?: string }[]) =>
+			items.find(i => i.detail === 'Primary Organization')) as unknown as typeof vscode.window.showQuickPick);
+
+		await new LinkFolder().execute([folderUri]);
+
+		const folderLink = LinkManager.getFolderLink(folderUri);
+		assert.strictEqual(folderLink.org.id, org.id);
+
+		const templateLinks = LinkManager.getOrgTemplateLinks(org);
+		assert.strictEqual(templateLinks.length, 1);
+		const filePath = vscode.Uri.parse(templateLinks[0].uriString).fsPath;
+		assert.strictEqual(fs.readFileSync(filePath, 'utf8'), 'alpha-body');
+	});
+
+	test('does not link the folder when org selection is cancelled', async () => {
+		const org = Fixtures.orgModel({ id: 'org-cancel', name: 'Cancel Org' });
+		const { session } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		SessionManager._setSessionsForTesting([session]);
+
+		stub(vscode.window, 'showQuickPick', (async () => undefined) as unknown as typeof vscode.window.showQuickPick);
+
+		await new LinkFolder().execute([folderUri]);
+
+		assert.strictEqual(LinkManager.getFolderLinks().length, 0);
+	});
+});

--- a/src/commands/folders/sync/FetchFolder.test.ts
+++ b/src/commands/folders/sync/FetchFolder.test.ts
@@ -1,0 +1,66 @@
+import { FolderLink, LinkManager } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { FetchFolder } from './FetchFolder';
+
+const { suite, test, setup, teardown } = Mocha;
+
+suite('Unit: FetchFolder', () => {
+	let tmpDir: string;
+	let folderUri: vscode.Uri;
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-fetch-folder-'));
+		folderUri = vscode.Uri.file(tmpDir);
+	});
+
+	teardown(() => {
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	test('fetches missing templates into the previously linked folder', async () => {
+		const org = Fixtures.orgModel({ id: 'org-fetch-cmd', name: 'Fetch Cmd Org' });
+		const folderLink: FolderLink = { type: 'Folder', uriString: folderUri.toString(), org };
+		LinkManager.addLink(folderLink);
+
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't1', name: 'Solo', orgId: org.id })]),
+		});
+		wrapper.when('getTemplate', () => ({
+			data: Fixtures.getTemplateQuery({
+				id: 't1',
+				name: 'Solo',
+				body: 'solo-body',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		}));
+		SessionManager._setSessionsForTesting([session]);
+
+		await new FetchFolder().execute([folderUri]);
+
+		const links = LinkManager.getOrgTemplateLinks(org);
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(fs.readFileSync(vscode.Uri.parse(links[0].uriString).fsPath, 'utf8'), 'solo-body');
+	});
+
+	// Documents current behavior: getFolderLink() is resolved before the
+	// try/catch in FetchFolder.execute, so an unlinked folder rejects instead
+	// of being caught and surfaced via log.notifyError like a failed fetch is.
+	// See notesForReviewer.
+	test('rejects when run against a folder that was never linked', async () => {
+		await assert.rejects(() => new FetchFolder().execute([folderUri]), /Could not find link/);
+	});
+});

--- a/src/commands/server/StartServer.test.ts
+++ b/src/commands/server/StartServer.test.ts
@@ -1,0 +1,112 @@
+import { Server } from '@server';
+import { SessionManager } from '@sessions';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import net from 'net';
+import vscode from 'vscode';
+import { StartServer } from './StartServer';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/** Binds an ephemeral port, reads it, releases it — a free port to target. */
+function findFreePort(): Promise<number> {
+	return new Promise((resolve, reject) => {
+		const probe = net.createServer();
+		probe.once('error', reject);
+		probe.listen(0, '127.0.0.1', () => {
+			const address = probe.address();
+			const port = typeof address === 'object' && address ? address.port : 0;
+			probe.close(() => resolve(port));
+		});
+	});
+}
+
+async function setPort(port: number): Promise<void> {
+	const config = vscode.workspace.getConfiguration('rewst-buddy.server');
+	await config.update('port', port, vscode.ConfigurationTarget.Global);
+}
+
+/**
+ * `rewst-buddy.server.enabled` defaults on, and Server.ts auto-restarts on any
+ * `rewst-buddy.server.*` config change while enabled and not running. Forcing it
+ * off here keeps `setPort` below from racing a config-driven restart, so the
+ * manual-start path under test (which works regardless of `enabled`, per the
+ * "Manual start" spec scenario) is the only thing flipping the server's status.
+ */
+async function setEnabled(enabled: boolean | undefined): Promise<void> {
+	const config = vscode.workspace.getConfiguration('rewst-buddy.server');
+	await config.update('enabled', enabled, vscode.ConfigurationTarget.Global);
+}
+
+interface Restore {
+	restore(): void;
+}
+
+function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): Restore {
+	const original = obj[key];
+	Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+	return {
+		restore() {
+			Object.defineProperty(obj, key, { value: original, configurable: true, writable: true });
+		},
+	};
+}
+
+suite('Unit: StartServer command', () => {
+	let port = 0;
+	let infoMessages: string[] = [];
+	const restores: Restore[] = [];
+
+	setup(async () => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		// Activation may still have a background start() in flight (server.enabled
+		// defaults on); start() shares that in-flight bind rather than racing it, so
+		// awaiting it here settles activation before we stop for a clean, known state.
+		await Server.start();
+		await Server.stop();
+		await setEnabled(false);
+		port = await findFreePort();
+		await setPort(port);
+		infoMessages = [];
+		restores.push(
+			stub(vscode.window, 'showInformationMessage', (async (message: string) => {
+				infoMessages.push(message);
+				return undefined;
+			}) as unknown as typeof vscode.window.showInformationMessage),
+		);
+	});
+
+	teardown(async () => {
+		while (restores.length) restores.pop()!.restore();
+		await Server.stop();
+		await setPort(undefined as unknown as number); // clear override
+		await setEnabled(undefined); // clear override
+	});
+
+	test('starts the server when it is not already running', async () => {
+		assert.strictEqual(Server.getStatus(), false, 'precondition: server is not running');
+
+		await new StartServer().execute();
+
+		assert.strictEqual(Server.getStatus(), true, 'server is running after StartServer');
+		assert.ok(
+			infoMessages.some(message => message.includes('Server started')),
+			'reports the server started',
+		);
+	});
+
+	test('does nothing and reports already running when the server is already started', async () => {
+		await Server.start();
+		infoMessages = [];
+
+		await new StartServer().execute();
+
+		assert.strictEqual(Server.getStatus(), true);
+		assert.ok(
+			infoMessages.some(message => message.includes('already running')),
+			'reports the server was already running',
+		);
+	});
+});

--- a/src/commands/template/CopyTemplateID.test.ts
+++ b/src/commands/template/CopyTemplateID.test.ts
@@ -1,0 +1,93 @@
+import { LinkManager, TemplateLink } from '@models';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { CopyTemplateID } from './CopyTemplateID';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * CopyTemplateID drives the "Copy a linked template's id" requirement:
+ * resolve the file (context menu uri or active editor), look up its link,
+ * and write the template id to the clipboard.
+ */
+suite('Unit: CopyTemplateID', () => {
+	let tmpDir: string;
+
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-copy-id-'));
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeFile(name: string, content: string): vscode.Uri {
+		const filePath = path.join(tmpDir, name);
+		fs.writeFileSync(filePath, content);
+		return vscode.Uri.file(filePath);
+	}
+
+	function linkFile(uri: vscode.Uri, templateId: string): TemplateLink {
+		const link: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org: { id: 'org-1', name: 'Org One' },
+			template: { id: templateId, name: 'Linked Template', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(link);
+		return link;
+	}
+
+	test('copies the template id from a context-menu uri', async () => {
+		const uri = writeFile('context-menu.j2', 'body');
+		linkFile(uri, 'tpl-context-menu');
+
+		await new CopyTemplateID().execute([uri]);
+
+		assert.strictEqual(await vscode.env.clipboard.readText(), 'tpl-context-menu');
+	});
+
+	test('copies the template id from the active editor when no uri arg is given', async () => {
+		const uri = writeFile('active-editor.j2', 'body');
+		linkFile(uri, 'tpl-active-editor');
+
+		// Stub activeTextEditor directly rather than relying on showTextDocument to
+		// actually grant focus -- unreliable in a headless Extension Host,
+		// especially as part of a large suite (see OpenInRewst.test.ts for the
+		// same pattern).
+		const document = await vscode.workspace.openTextDocument(uri);
+		const original = vscode.window.activeTextEditor;
+		Object.defineProperty(vscode.window, 'activeTextEditor', {
+			value: { document },
+			configurable: true,
+		});
+
+		try {
+			await new CopyTemplateID().execute();
+			assert.strictEqual(await vscode.env.clipboard.readText(), 'tpl-active-editor');
+		} finally {
+			Object.defineProperty(vscode.window, 'activeTextEditor', {
+				value: original,
+				configurable: true,
+			});
+		}
+	});
+
+	test('does not throw and leaves the clipboard untouched when the file is not linked', async () => {
+		const uri = writeFile('unlinked.j2', 'body');
+		await vscode.env.clipboard.writeText('unchanged');
+
+		await new CopyTemplateID().execute([uri]);
+
+		assert.strictEqual(await vscode.env.clipboard.readText(), 'unchanged');
+	});
+});

--- a/src/commands/template/CreateTemplate.test.ts
+++ b/src/commands/template/CreateTemplate.test.ts
@@ -1,0 +1,150 @@
+import { LinkManager, TemplateLink } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import { getHash } from '@utils';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { CreateTemplate } from './CreateTemplate';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * CreateTemplate drives the "Create a template from a local file" flow:
+ * refuse-if-linked, pickOrganization (session -> primary/other org QuickPicks),
+ * a name InputBox defaulting to the file's base name, then createTemplateMinimal
+ * + a new local link. These tests stub vscode.window.showQuickPick/showInputBox
+ * using the Object.defineProperty stub()/restore() pattern from
+ * src/utils/openTemplateById.test.ts and use real saved files on disk, since
+ * ensureSavedDocument() opens documents via the real vscode.workspace API.
+ */
+interface OrgQuickPickItem {
+	arguments: unknown[];
+}
+
+suite('Unit: CreateTemplate', () => {
+	let tmpDir: string;
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	function stubPrimaryOrgQuickPick(): void {
+		stub(vscode.window, 'showQuickPick', (async (items: readonly OrgQuickPickItem[]) =>
+			items.find(i => 'arguments' in i)) as unknown as typeof vscode.window.showQuickPick);
+	}
+
+	function stubInputBox(value: string | undefined): void {
+		stub(vscode.window, 'showInputBox', (async () => value) as unknown as typeof vscode.window.showInputBox);
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-create-template-'));
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeFile(name: string, content: string): vscode.Uri {
+		const filePath = path.join(tmpDir, name);
+		fs.writeFileSync(filePath, content);
+		return vscode.Uri.file(filePath);
+	}
+
+	test('creates the template in Rewst from the file body and links the file', async () => {
+		const body = '// new template body';
+		const uri = writeFile('my-template.j2', body);
+
+		const org = Fixtures.orgModel({ id: 'org-create', name: 'Create Org' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		const createdId = 'tpl-created';
+		wrapper.when('createTemplateMinimal', vars => ({
+			data: Fixtures.createTemplateMinimalMutation({
+				id: createdId,
+				name: vars.name,
+				orgId: vars.orgId,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		}));
+
+		SessionManager._setSessionsForTesting([session]);
+		stubPrimaryOrgQuickPick();
+		stubInputBox('my-template'); // defaults to file base name, but confirm explicit value works too
+
+		await new CreateTemplate().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), true);
+		const link = LinkManager.getTemplateLink(uri);
+		assert.strictEqual(link.template.id, createdId);
+		assert.strictEqual(link.bodyHash, getHash(body));
+		assert.strictEqual(link.org.id, org.id);
+
+		const calls = wrapper.getCallsFor('createTemplateMinimal');
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].variables.name, 'my-template');
+		assert.strictEqual(calls[0].variables.orgId, org.id);
+		assert.strictEqual(calls[0].variables.body, body);
+	});
+
+	test('refuses to create a template when the file is already linked', async () => {
+		const uri = writeFile('already-linked.j2', 'body');
+		const existingLink: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org: { id: 'org-1', name: 'Org One' },
+			template: { id: 'tpl-existing', name: 'Existing', updatedAt: '', orgId: 'org-1' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(existingLink);
+
+		const org = Fixtures.orgModel({ id: 'org-1', name: 'Org One' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		SessionManager._setSessionsForTesting([session]);
+
+		await assert.rejects(() => new CreateTemplate().execute([uri]), /Already linked/);
+
+		assert.strictEqual(wrapper.getCallsFor('createTemplateMinimal').length, 0, 'no template should be created');
+	});
+
+	test('does nothing when the user cancels org selection', async () => {
+		const uri = writeFile('cancel-org.j2', 'body');
+		const org = Fixtures.orgModel({ id: 'org-2', name: 'Org Two' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		SessionManager._setSessionsForTesting([session]);
+
+		stub(vscode.window, 'showQuickPick', (async () => undefined) as unknown as typeof vscode.window.showQuickPick);
+
+		await new CreateTemplate().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), false);
+		assert.strictEqual(wrapper.getCallsFor('createTemplateMinimal').length, 0);
+	});
+
+	test('does nothing when the user cancels the name prompt', async () => {
+		const uri = writeFile('cancel-name.j2', 'body');
+		const org = Fixtures.orgModel({ id: 'org-3', name: 'Org Three' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		SessionManager._setSessionsForTesting([session]);
+
+		stubPrimaryOrgQuickPick();
+		stubInputBox(undefined);
+
+		await new CreateTemplate().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), false);
+		assert.strictEqual(wrapper.getCallsFor('createTemplateMinimal').length, 0);
+	});
+});

--- a/src/commands/template/DeleteTemplate.test.ts
+++ b/src/commands/template/DeleteTemplate.test.ts
@@ -1,0 +1,116 @@
+import { LinkManager, TemplateLink } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { DeleteTemplate } from './DeleteTemplate';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * DeleteTemplate drives the "Delete a template with confirmation" flow: a
+ * modal warning confirmation, then deleteTemplate over the SDK, then removal
+ * of the local link. This test stubs vscode.window.showWarningMessage using
+ * the Object.defineProperty stub()/restore() pattern from
+ * src/utils/openTemplateById.test.ts.
+ */
+suite('Unit: DeleteTemplate', () => {
+	let tmpDir: string;
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	function stubConfirm(response: 'Delete' | undefined): void {
+		stub(
+			vscode.window,
+			'showWarningMessage',
+			(async () => response) as unknown as typeof vscode.window.showWarningMessage,
+		);
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-delete-template-'));
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeFile(name: string, content: string): vscode.Uri {
+		const filePath = path.join(tmpDir, name);
+		fs.writeFileSync(filePath, content);
+		return vscode.Uri.file(filePath);
+	}
+
+	function linkFile(uri: vscode.Uri, org: { id: string; name: string }, templateId: string): TemplateLink {
+		const link: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org,
+			template: {
+				id: templateId,
+				name: 'Doomed Template',
+				updatedAt: '',
+				orgId: org.id,
+				organization: org,
+			} as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(link);
+		return link;
+	}
+
+	test('deletes the template in Rewst and removes the local link when the user confirms', async () => {
+		const uri = writeFile('confirm.j2', 'body');
+		const org = Fixtures.orgModel({ id: 'org-del', name: 'Delete Org' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		const templateId = 'tpl-to-delete';
+		linkFile(uri, org, templateId);
+
+		wrapper.when('deleteTemplate', { data: { __typename: 'Mutation', deleteTemplate: templateId } });
+		SessionManager._setSessionsForTesting([session]);
+		stubConfirm('Delete');
+
+		await new DeleteTemplate().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), false, 'link should be removed after a successful delete');
+		const calls = wrapper.getCallsFor('deleteTemplate');
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].variables.id, templateId);
+	});
+
+	test('deletes nothing and keeps the link when the user dismisses the confirmation', async () => {
+		const uri = writeFile('cancel.j2', 'body');
+		const org = Fixtures.orgModel({ id: 'org-del-2', name: 'Delete Org Two' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		const templateId = 'tpl-keep';
+		linkFile(uri, org, templateId);
+
+		SessionManager._setSessionsForTesting([session]);
+		stubConfirm(undefined);
+
+		await new DeleteTemplate().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), true, 'link should remain when the user cancels');
+		assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 0, 'no delete call should be made');
+	});
+
+	test('throws when the file has no template link', async () => {
+		const uri = writeFile('unlinked.j2', 'body');
+		await assert.rejects(() => new DeleteTemplate().execute([uri]), /no template linked/);
+	});
+});

--- a/src/commands/template/OpenTemplateFromURL.test.ts
+++ b/src/commands/template/OpenTemplateFromURL.test.ts
@@ -1,0 +1,105 @@
+import { LinkManager, TemplateLink } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { OpenTemplateFromURL } from './OpenTemplateFromURL';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * OpenTemplateFromURL drives the "Open or link a template from its Rewst
+ * URL" flow for opening: parse the URL, reuse an existing local link if one
+ * exists, otherwise resolve a session and fetch+link the template. These
+ * tests only exercise the primary-org-match path of session resolution (see
+ * the template-management spec's managed-sub-org implementation-status
+ * note); the mock session's default region loginUrl is
+ * http://localhost:9999/login, so URLs below use that host.
+ */
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const TEMPLATE_ID = '22222222-2222-4222-8222-222222222222';
+const templateURL = `http://localhost:9999/organizations/${ORG_ID}/templates/${TEMPLATE_ID}`;
+
+suite('Unit: OpenTemplateFromURL', () => {
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	function stubURLInput(value: string | undefined): void {
+		stub(vscode.window, 'showInputBox', (async () => value) as unknown as typeof vscode.window.showInputBox);
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+	});
+
+	test('reuses an existing local link instead of fetching a duplicate', async () => {
+		const uri = vscode.Uri.file('/ws/already-open.j2');
+		const link: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org: { id: ORG_ID, name: 'Org One' },
+			template: { id: TEMPLATE_ID, name: 'Existing', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(link);
+		stubURLInput(templateURL);
+
+		const opened: string[] = [];
+		stub(vscode.commands, 'executeCommand', (async (command: string, openUri?: vscode.Uri) => {
+			if (command === 'vscode.open' && openUri) opened.push(openUri.toString());
+			return undefined;
+		}) as typeof vscode.commands.executeCommand);
+
+		await new OpenTemplateFromURL().execute();
+
+		assert.deepStrictEqual(opened, [uri.toString()]);
+	});
+
+	test('fetches the full template, prompts a save location, and links a new file when no link exists', async () => {
+		const org = Fixtures.orgModel({ id: ORG_ID, name: 'Org One' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		wrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: TEMPLATE_ID,
+				orgId: ORG_ID,
+				organization: Fixtures.org({ id: ORG_ID, name: 'Org One' }),
+				body: 'fetched body',
+			}),
+		});
+		SessionManager._setSessionsForTesting([session]);
+		stubURLInput(templateURL);
+
+		const fixedUri = vscode.Uri.file('/ws/new-from-url.j2');
+		stub(vscode.workspace, 'saveAs', (async () => fixedUri) as typeof vscode.workspace.saveAs);
+
+		await new OpenTemplateFromURL().execute();
+
+		assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 1);
+		assert.strictEqual(LinkManager.isLinked(fixedUri), true);
+		const link = LinkManager.getTemplateLink(fixedUri);
+		assert.strictEqual(link.template.id, TEMPLATE_ID);
+		assert.strictEqual(link.org.id, ORG_ID);
+
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+	});
+
+	test('does nothing when the user cancels the URL prompt', async () => {
+		stubURLInput(undefined);
+
+		await assert.rejects(() => new OpenTemplateFromURL().execute(), /not a string/);
+	});
+});

--- a/src/commands/template/OpenTemplateFromURL.test.ts
+++ b/src/commands/template/OpenTemplateFromURL.test.ts
@@ -40,10 +40,14 @@ suite('Unit: OpenTemplateFromURL', () => {
 		LinkManager._resetForTesting();
 	});
 
-	teardown(() => {
+	teardown(async () => {
 		while (restores.length) restores.pop()!();
 		SessionManager._resetForTesting();
 		LinkManager._resetForTesting();
+		// Runs after restores, so this hits the real command even for tests that
+		// stubbed executeCommand — disposes any untitled editor a test opened,
+		// even if an assertion failed before the test reached its own cleanup.
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
 	});
 
 	test('reuses an existing local link instead of fetching a duplicate', async () => {
@@ -93,8 +97,6 @@ suite('Unit: OpenTemplateFromURL', () => {
 		const link = LinkManager.getTemplateLink(fixedUri);
 		assert.strictEqual(link.template.id, TEMPLATE_ID);
 		assert.strictEqual(link.org.id, ORG_ID);
-
-		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
 	});
 
 	test('does nothing when the user cancels the URL prompt', async () => {

--- a/src/commands/template/OpenTemplateInteractive.test.ts
+++ b/src/commands/template/OpenTemplateInteractive.test.ts
@@ -1,0 +1,138 @@
+import { LinkManager, TemplateLink } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { OpenTemplateInteractive } from './OpenTemplateInteractive';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * OpenTemplateInteractive drives the "Open a template, reusing an existing
+ * link" requirement interactively: pickTemplate (session -> org -> template
+ * QuickPicks), then reuse an existing local link or fetch+link a new file.
+ * These tests stub vscode.window.showQuickPick using the
+ * Object.defineProperty stub()/restore() pattern from
+ * src/utils/openTemplateById.test.ts.
+ */
+interface OrgQuickPickItem {
+	arguments: unknown[];
+}
+interface TemplateQuickPickItem {
+	template: { id: string };
+}
+
+suite('Unit: OpenTemplateInteractive', () => {
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	function stubPickFlow(pickTemplateId?: string): void {
+		stub(vscode.window, 'showQuickPick', (async (items: readonly (OrgQuickPickItem | TemplateQuickPickItem)[]) => {
+			const orgItem = items.find((i): i is OrgQuickPickItem => 'arguments' in i);
+			if (orgItem) return orgItem; // always pick "Primary Organization"
+			if (!pickTemplateId) return undefined; // simulate the user cancelling template selection
+			return items.find((i): i is TemplateQuickPickItem => 'template' in i && i.template.id === pickTemplateId);
+		}) as unknown as typeof vscode.window.showQuickPick);
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+	});
+
+	teardown(async () => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+	});
+
+	test('opens the existing local file instead of fetching a duplicate', async () => {
+		const org = Fixtures.orgModel({ id: 'org-open', name: 'Open Org' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		const templateId = 'tpl-already-open';
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({ id: templateId, name: 'Already Open', orgId: org.id }),
+			]),
+		});
+		SessionManager._setSessionsForTesting([session]);
+
+		const uri = vscode.Uri.file('/ws/already-open.j2');
+		const existingLink: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org: { id: org.id, name: org.name },
+			template: { id: templateId, name: 'Already Open', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(existingLink);
+
+		stubPickFlow(templateId);
+
+		const opened: string[] = [];
+		stub(vscode.commands, 'executeCommand', (async (command: string, openUri?: vscode.Uri) => {
+			if (command === 'vscode.open' && openUri) opened.push(openUri.toString());
+			return undefined;
+		}) as typeof vscode.commands.executeCommand);
+
+		await new OpenTemplateInteractive().execute();
+
+		assert.deepStrictEqual(opened, [uri.toString()]);
+		assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 0, 'must not fetch the full template');
+	});
+
+	test('fetches the full template, prompts a save location, and links a new file when no link exists', async () => {
+		const org = Fixtures.orgModel({ id: 'org-fetch', name: 'Fetch Org' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		const templateId = 'tpl-new';
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({ id: templateId, name: 'New Template', orgId: org.id }),
+			]),
+		});
+		wrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: templateId,
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+				body: 'fetched body',
+			}),
+		});
+		SessionManager._setSessionsForTesting([session]);
+		stubPickFlow(templateId);
+
+		const fixedUri = vscode.Uri.file('/ws/interactive-new.j2');
+		stub(vscode.workspace, 'saveAs', (async () => fixedUri) as typeof vscode.workspace.saveAs);
+
+		await new OpenTemplateInteractive().execute();
+
+		assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 1);
+		assert.strictEqual(LinkManager.isLinked(fixedUri), true);
+		const link = LinkManager.getTemplateLink(fixedUri);
+		assert.strictEqual(link.template.id, templateId);
+	});
+
+	test('does nothing when the user cancels template selection', async () => {
+		const org = Fixtures.orgModel({ id: 'org-cancel', name: 'Cancel Org' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({ id: 'tpl-x', name: 'Some Template', orgId: org.id }),
+			]),
+		});
+		SessionManager._setSessionsForTesting([session]);
+		stubPickFlow(undefined);
+
+		await new OpenTemplateInteractive().execute();
+
+		assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 0);
+	});
+});

--- a/src/commands/template/link/LinkTemplateFromURL.test.ts
+++ b/src/commands/template/link/LinkTemplateFromURL.test.ts
@@ -107,4 +107,20 @@ suite('Unit: LinkTemplateFromURL', () => {
 
 		await assert.rejects(() => new LinkTemplateFromURL().execute([uri]), /Already linked/);
 	});
+
+	test('rejects before linking when the URL prompt is cancelled', async () => {
+		const uri = writeFile('cancelled.j2', 'body');
+		stubURLInput(undefined);
+
+		await assert.rejects(() => new LinkTemplateFromURL().execute([uri]), /not a string/);
+		assert.strictEqual(LinkManager.isLinked(uri), false, 'no link is created when the URL is missing');
+	});
+
+	test('rejects before linking when the URL is malformed', async () => {
+		const uri = writeFile('malformed.j2', 'body');
+		stubURLInput('not-a-valid-template-url');
+
+		await assert.rejects(() => new LinkTemplateFromURL().execute([uri]));
+		assert.strictEqual(LinkManager.isLinked(uri), false, 'no link is created when the URL cannot be parsed');
+	});
 });

--- a/src/commands/template/link/LinkTemplateFromURL.test.ts
+++ b/src/commands/template/link/LinkTemplateFromURL.test.ts
@@ -1,0 +1,110 @@
+import { LinkManager, TemplateLink } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import { getHash } from '@utils';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { LinkTemplateFromURL } from './LinkTemplateFromURL';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * LinkTemplateFromURL drives the "Link a local file from URL" scenario of
+ * the "Open or link a template from its Rewst URL" requirement: refuse if
+ * already linked, parse the URL, resolve a session, fetch the template, link
+ * the file, then sync. This test only exercises the primary-org-match path
+ * of session resolution (see the template-management spec's
+ * managed-sub-org implementation-status note); the mock session's default
+ * region loginUrl is http://localhost:9999/login, so the URL below uses
+ * that host.
+ */
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const TEMPLATE_ID = '22222222-2222-4222-8222-222222222222';
+const templateURL = `http://localhost:9999/organizations/${ORG_ID}/templates/${TEMPLATE_ID}`;
+
+suite('Unit: LinkTemplateFromURL', () => {
+	let tmpDir: string;
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	function stubURLInput(value: string | undefined): void {
+		stub(vscode.window, 'showInputBox', (async () => value) as unknown as typeof vscode.window.showInputBox);
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-link-from-url-'));
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeFile(name: string, content: string): vscode.Uri {
+		const filePath = path.join(tmpDir, name);
+		fs.writeFileSync(filePath, content);
+		return vscode.Uri.file(filePath);
+	}
+
+	test('links the open file to the parsed template and syncs', async () => {
+		const body = '// local body to link';
+		const uri = writeFile('to-link.j2', body);
+
+		const org = Fixtures.orgModel({ id: ORG_ID, name: 'Org One' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		wrapper.when('getTemplate', () => ({
+			data: Fixtures.getTemplateQuery({
+				id: TEMPLATE_ID,
+				orgId: ORG_ID,
+				organization: Fixtures.org({ id: ORG_ID, name: 'Org One' }),
+				body,
+			}),
+		}));
+		SessionManager._setSessionsForTesting([session]);
+		stubURLInput(templateURL);
+
+		await new LinkTemplateFromURL().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), true);
+		const link = LinkManager.getTemplateLink(uri);
+		assert.strictEqual(link.template.id, TEMPLATE_ID);
+		assert.strictEqual(link.org.id, ORG_ID);
+		assert.strictEqual(link.bodyHash, getHash(body), 'bodyHash reflects the local file content at link time');
+
+		assert.strictEqual(
+			wrapper.getCallsFor('getTemplate').length,
+			2,
+			'one fetch while linking, one fetch from the follow-up sync',
+		);
+	});
+
+	test('refuses before parsing the URL when the file is already linked', async () => {
+		const uri = writeFile('already-linked.j2', 'body');
+		const existingLink: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org: { id: 'org-existing', name: 'Existing Org' },
+			template: { id: 'tpl-existing', name: 'Existing', updatedAt: '', orgId: 'org-existing' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(existingLink);
+
+		stubURLInput(templateURL);
+
+		await assert.rejects(() => new LinkTemplateFromURL().execute([uri]), /Already linked/);
+	});
+});

--- a/src/commands/template/link/LinkTemplateInteractive.test.ts
+++ b/src/commands/template/link/LinkTemplateInteractive.test.ts
@@ -1,0 +1,144 @@
+import { LinkManager, TemplateLink } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import { getHash } from '@utils';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { LinkTemplateInteractive } from './LinkTemplateInteractive';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * LinkTemplateInteractive drives the full "Link File to Template" user flow:
+ * refuse-if-linked, pickTemplate (session -> org -> template QuickPicks),
+ * fetch the template, record the link, then sync. These tests stub
+ * vscode.window.showQuickPick using the Object.defineProperty stub()/restore()
+ * pattern from src/utils/openTemplateById.test.ts and use real saved files on
+ * disk, since ensureSavedDocument() opens documents via vscode.workspace
+ * (real, not mocked, in this test host).
+ */
+interface OrgQuickPickItem {
+	arguments: unknown[];
+}
+interface TemplateQuickPickItem {
+	template: { id: string };
+}
+
+suite('Unit: LinkTemplateInteractive', () => {
+	let tmpDir: string;
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	function stubQuickPick(pickTemplateId?: string): void {
+		stub(vscode.window, 'showQuickPick', (async (items: readonly (OrgQuickPickItem | TemplateQuickPickItem)[]) => {
+			const orgItem = items.find((i): i is OrgQuickPickItem => 'arguments' in i);
+			if (orgItem) return orgItem; // always pick "Primary Organization"
+			if (!pickTemplateId) return undefined; // simulate the user cancelling template selection
+			return items.find((i): i is TemplateQuickPickItem => 'template' in i && i.template.id === pickTemplateId);
+		}) as unknown as typeof vscode.window.showQuickPick);
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-link-interactive-'));
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeFile(name: string, content: string): vscode.Uri {
+		const filePath = path.join(tmpDir, name);
+		fs.writeFileSync(filePath, content);
+		return vscode.Uri.file(filePath);
+	}
+
+	test('refuses before template selection when the file is already linked', async () => {
+		const uri = writeFile('already-linked.j2', 'body');
+		const existingLink: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org: { id: 'org-1', name: 'Org One' },
+			template: { id: 'tpl-existing', name: 'Existing', updatedAt: '', orgId: 'org-1' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(existingLink);
+
+		const org = Fixtures.orgModel({ id: 'org-1', name: 'Org One' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		SessionManager._setSessionsForTesting([session]);
+
+		await assert.rejects(() => new LinkTemplateInteractive().execute([uri]), /Already linked/);
+
+		assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 0, 'template selection must not have started');
+	});
+
+	test('user links an open file: records template metadata, org, bodyHash and syncs', async () => {
+		const body = '// shared body content';
+		const uri = writeFile('new-link.j2', body);
+
+		const org = Fixtures.orgModel({ id: 'org-2', name: 'Org Two' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+
+		const templateId = 'tpl-target';
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({ id: templateId, name: 'Target Template', orgId: org.id }),
+			]),
+		});
+		wrapper.when('getTemplate', () => ({
+			data: Fixtures.getTemplateQuery({
+				id: templateId,
+				name: 'Target Template',
+				body,
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		}));
+
+		SessionManager._setSessionsForTesting([session]);
+		stubQuickPick(templateId);
+
+		await new LinkTemplateInteractive().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), true);
+		const link = LinkManager.getTemplateLink(uri);
+		assert.strictEqual(link.template.id, templateId);
+		assert.strictEqual(link.bodyHash, getHash(body), 'bodyHash reflects the file content at link time');
+		assert.strictEqual(link.org.id, org.id);
+		assert.deepStrictEqual(link.referencedTemplateIds, []);
+
+		assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 1);
+		assert.strictEqual(
+			wrapper.getCallsFor('getTemplate').length,
+			2,
+			'one fetch while linking, one fetch from the follow-up sync',
+		);
+	});
+
+	test('does nothing when the user cancels template selection', async () => {
+		const uri = writeFile('cancel.j2', 'body');
+		const org = Fixtures.orgModel({ id: 'org-3', name: 'Org Three' });
+		const { session } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		SessionManager._setSessionsForTesting([session]);
+		stubQuickPick(undefined);
+
+		await new LinkTemplateInteractive().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), false);
+	});
+});

--- a/src/commands/template/link/UnlinkAllTemplates.test.ts
+++ b/src/commands/template/link/UnlinkAllTemplates.test.ts
@@ -1,0 +1,81 @@
+import { FolderLink, LinkManager, TemplateLink } from '@models';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { UnlinkAllTemplates } from './UnlinkAllTemplates';
+
+const { suite, test, setup, teardown } = Mocha;
+
+suite('Unit: UnlinkAllTemplates', () => {
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	function seedLinks(): { tplLink: TemplateLink; folderLink: FolderLink } {
+		const tplLink: TemplateLink = {
+			uriString: vscode.Uri.file('/test/a.j2').toString(),
+			org: { id: 'org-1', name: 'Org' },
+			type: 'Template',
+			template: { id: 'tpl-1', name: 'Tpl', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		const folderLink: FolderLink = {
+			uriString: vscode.Uri.file('/test/folder').toString(),
+			org: { id: 'org-1', name: 'Org' },
+			type: 'Folder',
+		};
+		LinkManager.addLink(tplLink);
+		LinkManager.addLink(folderLink);
+		return { tplLink, folderLink };
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		LinkManager._resetForTesting();
+	});
+
+	test('clears all template links when the user confirms', async () => {
+		const { tplLink, folderLink } = seedLinks();
+		stub(
+			vscode.window,
+			'showInformationMessage',
+			(async () => 'Clear Links') as unknown as typeof vscode.window.showInformationMessage,
+		);
+
+		await new UnlinkAllTemplates().execute();
+
+		assert.strictEqual(LinkManager.isLinked(vscode.Uri.parse(tplLink.uriString)), false);
+		assert.strictEqual(
+			LinkManager.isLinked(vscode.Uri.parse(folderLink.uriString)),
+			true,
+			'folder links are untouched',
+		);
+	});
+
+	test('leaves links untouched when the user dismisses the confirmation', async () => {
+		const { tplLink } = seedLinks();
+		stub(
+			vscode.window,
+			'showInformationMessage',
+			(async () => undefined) as unknown as typeof vscode.window.showInformationMessage,
+		);
+
+		await new UnlinkAllTemplates().execute();
+
+		assert.strictEqual(
+			LinkManager.isLinked(vscode.Uri.parse(tplLink.uriString)),
+			true,
+			'link should remain when the confirmation is dismissed',
+		);
+	});
+});

--- a/src/commands/template/link/UnlinkTemplate.test.ts
+++ b/src/commands/template/link/UnlinkTemplate.test.ts
@@ -1,0 +1,64 @@
+import { LinkManager, TemplateLink } from '@models';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { UnlinkTemplate } from './UnlinkTemplate';
+
+const { suite, test, setup, teardown } = Mocha;
+
+suite('Unit: UnlinkTemplate', () => {
+	let tmpDir: string;
+
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-unlink-'));
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function writeFile(name: string): vscode.Uri {
+		const filePath = path.join(tmpDir, name);
+		fs.writeFileSync(filePath, 'content');
+		return vscode.Uri.file(filePath);
+	}
+
+	test('removes the link for the given file while leaving other links intact', async () => {
+		const uri = writeFile('linked.j2');
+		const otherUri = vscode.Uri.file('/test/other.j2');
+
+		const link: TemplateLink = {
+			uriString: uri.toString(),
+			org: { id: 'org-1', name: 'Org' },
+			type: 'Template',
+			template: { id: 'tpl-1', name: 'Tpl', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		const otherLink: TemplateLink = {
+			uriString: otherUri.toString(),
+			org: { id: 'org-1', name: 'Org' },
+			type: 'Template',
+			template: { id: 'tpl-2', name: 'Tpl2', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(link);
+		LinkManager.addLink(otherLink);
+
+		await new UnlinkTemplate().execute([uri]);
+
+		assert.strictEqual(LinkManager.isLinked(uri), false);
+		assert.strictEqual(LinkManager.isLinked(otherUri), true, 'unrelated link should remain');
+	});
+
+	test('throws when the file has no template link', async () => {
+		const uri = writeFile('unlinked.j2');
+		await assert.rejects(() => new UnlinkTemplate().execute([uri]), /no template link to clear/);
+	});
+});

--- a/src/commands/template/sync/DisableSyncOnSave.test.ts
+++ b/src/commands/template/sync/DisableSyncOnSave.test.ts
@@ -1,0 +1,73 @@
+import { LinkManager, SyncOnSaveManager, TemplateLink } from '@models';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { DisableSyncOnSave } from './DisableSyncOnSave';
+
+const { suite, test, setup, teardown } = Mocha;
+
+suite('Unit: DisableSyncOnSave', () => {
+	let tmpDir: string;
+
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-disable-sync-'));
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function linkedFile(name: string): vscode.Uri {
+		const filePath = path.join(tmpDir, name);
+		fs.writeFileSync(filePath, 'content');
+		const uri = vscode.Uri.file(filePath);
+		const link: TemplateLink = {
+			uriString: uri.toString(),
+			org: { id: 'org-1', name: 'Org' },
+			type: 'Template',
+			template: { id: 'tpl-1', name: 'Tpl', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(link);
+		return uri;
+	}
+
+	test('turns sync-on-save off for a linked file that was enabled', async () => {
+		const uri = linkedFile('a.j2');
+		SyncOnSaveManager.enableSync(uri);
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true);
+
+		await new DisableSyncOnSave().execute([uri]);
+
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false);
+	});
+
+	test('is a no-op when sync-on-save is not enabled', async () => {
+		const uri = linkedFile('b.j2');
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false);
+
+		await new DisableSyncOnSave().execute([uri]);
+
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false, 'remains disabled');
+	});
+
+	test('with the default enabled, disabling a file excludes only that file', async () => {
+		SyncOnSaveManager.syncByDefault = true;
+		const uri = linkedFile('c.j2');
+		const other = linkedFile('d.j2');
+
+		await new DisableSyncOnSave().execute([uri]);
+
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false);
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(other), true, 'unrelated linked file still syncs');
+	});
+});

--- a/src/commands/template/sync/EnableSyncOnSave.test.ts
+++ b/src/commands/template/sync/EnableSyncOnSave.test.ts
@@ -58,4 +58,14 @@ suite('Unit: EnableSyncOnSave', () => {
 
 		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true, 'remains enabled');
 	});
+
+	test('enabling one linked file does not affect another linked file', async () => {
+		const uri = linkedFile('a.j2');
+		const other = linkedFile('b.j2');
+
+		await new EnableSyncOnSave().execute([uri]);
+
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true, 'the targeted file becomes synced');
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(other), false, 'the untouched file stays unsynced');
+	});
 });

--- a/src/commands/template/sync/EnableSyncOnSave.test.ts
+++ b/src/commands/template/sync/EnableSyncOnSave.test.ts
@@ -1,0 +1,61 @@
+import { LinkManager, SyncOnSaveManager, TemplateLink } from '@models';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
+import vscode from 'vscode';
+import { EnableSyncOnSave } from './EnableSyncOnSave';
+
+const { suite, test, setup, teardown } = Mocha;
+
+suite('Unit: EnableSyncOnSave', () => {
+	let tmpDir: string;
+
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-enable-sync-'));
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function linkedFile(name: string): vscode.Uri {
+		const filePath = path.join(tmpDir, name);
+		fs.writeFileSync(filePath, 'content');
+		const uri = vscode.Uri.file(filePath);
+		const link: TemplateLink = {
+			uriString: uri.toString(),
+			org: { id: 'org-1', name: 'Org' },
+			type: 'Template',
+			template: { id: 'tpl-1', name: 'Tpl', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(link);
+		return uri;
+	}
+
+	test('turns sync-on-save on for a linked file', async () => {
+		const uri = linkedFile('a.j2');
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false);
+
+		await new EnableSyncOnSave().execute([uri]);
+
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true);
+	});
+
+	test('is a no-op when sync-on-save is already enabled', async () => {
+		const uri = linkedFile('b.j2');
+		SyncOnSaveManager.enableSync(uri);
+
+		await new EnableSyncOnSave().execute([uri]);
+
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true, 'remains enabled');
+	});
+});

--- a/src/models/LinkManager.test.ts
+++ b/src/models/LinkManager.test.ts
@@ -1,5 +1,8 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
 import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
 import vscode from 'vscode';
 import { LinkManager, TemplateLink, FolderLink, Link } from '@models';
 import { initTestEnvironment } from '@test';
@@ -518,6 +521,76 @@ suite('Unit: LinkManager', () => {
 			LinkManager._handleDeleteForTesting({ files: [unlinkedUri] });
 
 			assert.strictEqual(LinkManager.isLinked(linkedUri), true, 'Existing link should remain');
+		});
+	});
+
+	// handleRename's single-file branch is already covered indirectly via
+	// moveLink() (see 'org index' suite below); this covers the directory
+	// branch, which must relink every descendant under the new folder path.
+	// vscode.workspace.fs.stat in this test host is real, so the *new* path
+	// needs to actually exist on disk for the directory check to pass — the
+	// old path does not (handleRename never stats it).
+	suite('handleRename() directory branch', () => {
+		let newDirPath: string;
+
+		setup(() => {
+			newDirPath = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-rename-'));
+		});
+
+		teardown(() => {
+			fs.rmSync(newDirPath, { recursive: true, force: true });
+		});
+
+		test('renaming a folder relinks every descendant link under the new path', async () => {
+			const oldDirUri = vscode.Uri.file('/test/old-project');
+			const newDirUri = vscode.Uri.file(newDirPath);
+
+			const child1Old = vscode.Uri.file('/test/old-project/file1.txt');
+			const child2Old = vscode.Uri.file('/test/old-project/sub/file2.txt');
+			const outsideUri = vscode.Uri.file('/test/other/file3.txt');
+
+			const makeLink = (uri: vscode.Uri, id: string): TemplateLink => ({
+				uriString: uri.toString(),
+				org: { id: 'org-1', name: 'Test Org' },
+				type: 'Template',
+				template: { id, name: `Template ${id}`, updatedAt: '' } as any,
+				bodyHash: `hash-${id}`,
+			});
+
+			LinkManager.addLink(makeLink(child1Old, 't1'));
+			LinkManager.addLink(makeLink(child2Old, 't2'));
+			LinkManager.addLink(makeLink(outsideUri, 't3'));
+
+			await (LinkManager as any)['handleRename']({ files: [{ oldUri: oldDirUri, newUri: newDirUri }] });
+
+			const child1New = vscode.Uri.joinPath(newDirUri, 'file1.txt');
+			const child2New = vscode.Uri.joinPath(newDirUri, 'sub', 'file2.txt');
+
+			assert.strictEqual(LinkManager.isLinked(child1Old), false, 'old child path no longer linked');
+			assert.strictEqual(LinkManager.isLinked(child2Old), false, 'old nested child path no longer linked');
+			assert.strictEqual(LinkManager.isLinked(child1New), true, 'child relinked under the new folder path');
+			assert.strictEqual(
+				LinkManager.isLinked(child2New),
+				true,
+				'nested child relinked under the new folder path',
+			);
+			assert.strictEqual(LinkManager.isLinked(outsideUri), true, 'unrelated link is untouched');
+
+			const movedLink1 = LinkManager.getTemplateLink(child1New);
+			assert.strictEqual(movedLink1.bodyHash, 'hash-t1', 'link data is preserved across the move');
+			assert.strictEqual(
+				LinkManager.getTemplateLinkFromId('t1')[0]?.uriString,
+				child1New.toString(),
+				'reverse index follows the move',
+			);
+
+			const movedLink2 = LinkManager.getTemplateLink(child2New);
+			assert.strictEqual(movedLink2.bodyHash, 'hash-t2', 'nested link data is preserved across the move');
+			assert.strictEqual(
+				LinkManager.getTemplateLinkFromId('t2')[0]?.uriString,
+				child2New.toString(),
+				'nested reverse index follows the move',
+			);
 		});
 	});
 

--- a/src/models/LinkManager.test.ts
+++ b/src/models/LinkManager.test.ts
@@ -561,7 +561,7 @@ suite('Unit: LinkManager', () => {
 			LinkManager.addLink(makeLink(child2Old, 't2'));
 			LinkManager.addLink(makeLink(outsideUri, 't3'));
 
-			await (LinkManager as any)['handleRename']({ files: [{ oldUri: oldDirUri, newUri: newDirUri }] });
+			await LinkManager._handleRenameForTesting({ files: [{ oldUri: oldDirUri, newUri: newDirUri }] });
 
 			const child1New = vscode.Uri.joinPath(newDirUri, 'file1.txt');
 			const child2New = vscode.Uri.joinPath(newDirUri, 'sub', 'file2.txt');

--- a/src/models/LinkManager.ts
+++ b/src/models/LinkManager.ts
@@ -67,6 +67,10 @@ export const LinkManager = new (class _ implements vscode.Disposable {
 		return this.handleDelete(e);
 	}
 
+	_handleRenameForTesting(e: vscode.FileRenameEvent): Promise<void> {
+		return this.handleRename(e);
+	}
+
 	private async handleRename(e: vscode.FileRenameEvent): Promise<void> {
 		log.trace('LinkManager.handleRename: processing', { fileCount: e.files.length });
 

--- a/src/models/SyncManager.test.ts
+++ b/src/models/SyncManager.test.ts
@@ -1,9 +1,12 @@
-import { LinkManager, SyncOnSaveManager, TemplateLink } from '@models';
+import { FolderLink, LinkManager, Org, SyncOnSaveManager, TemplateLink } from '@models';
 import { SessionManager } from '@sessions';
 import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import { getHash } from '@utils';
 import * as assert from 'assert';
+import * as fs from 'fs';
 import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
 import vscode from 'vscode';
 import { SyncManager, orgFromTemplate } from './SyncManager';
 
@@ -47,6 +50,16 @@ function createMockDocument(options: { uri: vscode.Uri; content: string }): vsco
 		validateRange: (range: vscode.Range) => range,
 		validatePosition: (pos: vscode.Position) => pos,
 	} as vscode.TextDocument;
+}
+
+/**
+ * Stub a vscode.* method for the duration of a test and return a restore
+ * function. Mirrors the pattern in src/utils/openTemplateById.test.ts.
+ */
+function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): () => void {
+	const original = obj[key];
+	Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+	return () => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true });
 }
 
 suite('Unit: SyncManager.checkAutoFetch', () => {
@@ -459,5 +472,600 @@ suite('Unit: SyncManager.checkAutoFetch', () => {
 			1,
 			'getTemplate should be called when remote may be newer',
 		);
+	});
+});
+
+// fetchFolder is the mechanism behind "Link Folder to Organization" + "Fetch
+// Folder": it materializes an org's remote templates as linked local files.
+// vscode.workspace.fs in this test host is real (not mocked), so these tests
+// write to a throwaway temp directory on disk.
+suite('Unit: SyncManager.fetchFolder', () => {
+	let tmpDir: string;
+	let folderUri: vscode.Uri;
+	let org: Org;
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+		tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-fetchFolder-'));
+		folderUri = vscode.Uri.file(tmpDir);
+		org = { id: 'org-fetch', name: 'Fetch Org' };
+	});
+
+	teardown(() => {
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+		fs.rmSync(tmpDir, { recursive: true, force: true });
+	});
+
+	function setUpSession(templates: { id: string; name: string }[]) {
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery(
+				templates.map(t =>
+					Fixtures.template({
+						id: t.id,
+						name: t.name,
+						orgId: org.id,
+						organization: Fixtures.org({ id: org.id, name: org.name }),
+					}),
+				),
+			),
+		});
+		SessionManager._setSessionsForTesting([session]);
+		return { session, wrapper };
+	}
+
+	const folderLink = (): FolderLink => ({ type: 'Folder', uriString: folderUri.toString(), org });
+
+	test('links and fetches: missing org templates are materialized as linked local files', async () => {
+		const { wrapper } = setUpSession([
+			{ id: 't1', name: 'Alpha' },
+			{ id: 't2', name: 'Beta' },
+		]);
+		wrapper.when('getTemplate', vars => ({
+			data: Fixtures.getTemplateQuery({
+				id: vars.id,
+				name: vars.id === 't1' ? 'Alpha' : 'Beta',
+				body: `body-${vars.id}`,
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		}));
+
+		await SyncManager.fetchFolder(folderLink());
+
+		const links = LinkManager.getOrgTemplateLinks(org);
+		assert.strictEqual(links.length, 2, 'both remote templates are linked');
+		const byId = new Map(links.map(l => [l.template.id, l]));
+		assert.ok(byId.has('t1') && byId.has('t2'));
+
+		for (const [id, link] of byId) {
+			const filePath = vscode.Uri.parse(link.uriString).fsPath;
+			assert.ok(fs.existsSync(filePath), `file for ${id} should exist on disk`);
+			assert.strictEqual(fs.readFileSync(filePath, 'utf8'), `body-${id}`);
+			assert.strictEqual(link.bodyHash, getHash(`body-${id}`));
+		}
+	});
+
+	test('skips already-linked templates and only fetches the missing ones', async () => {
+		const { wrapper } = setUpSession([
+			{ id: 't1', name: 'Alpha' },
+			{ id: 't2', name: 'Beta' },
+		]);
+		// t1 is already linked locally (e.g. from a previous fetch)
+		const existingLink: TemplateLink = {
+			type: 'Template',
+			uriString: vscode.Uri.joinPath(folderUri, 'Alpha-existing.txt').toString(),
+			org,
+			template: {
+				id: 't1',
+				name: 'Alpha',
+				updatedAt: '',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			} as any,
+			bodyHash: 'existing-hash',
+		};
+		LinkManager.addLink(existingLink);
+
+		wrapper.when('getTemplate', vars => ({
+			data: Fixtures.getTemplateQuery({
+				id: vars.id,
+				name: 'Beta',
+				body: 'beta-body',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		}));
+
+		await SyncManager.fetchFolder(folderLink());
+
+		assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 1, 'only the missing template is fetched');
+		assert.strictEqual(wrapper.getCallsFor('getTemplate')[0].variables.id, 't2');
+
+		const links = LinkManager.getOrgTemplateLinks(org);
+		assert.strictEqual(links.length, 2, 'existing link kept, new link added');
+		assert.ok(links.some(l => l.template.id === 't2'));
+	});
+
+	test('reports successful and failed counts when one template cannot be fetched', async () => {
+		const { wrapper } = setUpSession([
+			{ id: 't1', name: 'Alpha' },
+			{ id: 't2', name: 'Beta' },
+			{ id: 't3', name: 'Gamma' },
+		]);
+		wrapper.when('getTemplate', vars => {
+			if (vars.id === 't2') return { error: Fixtures.networkError('boom') };
+			return {
+				data: Fixtures.getTemplateQuery({
+					id: vars.id,
+					name: vars.id,
+					body: `${vars.id}-body`,
+					orgId: org.id,
+					organization: Fixtures.org({ id: org.id, name: org.name }),
+				}),
+			};
+		});
+
+		const messages: string[] = [];
+		const originalShowInformationMessage = vscode.window.showInformationMessage;
+		Object.defineProperty(vscode.window, 'showInformationMessage', {
+			value: (async (msg: string) => {
+				messages.push(msg);
+				return undefined;
+			}) as typeof vscode.window.showInformationMessage,
+			configurable: true,
+			writable: true,
+		});
+
+		try {
+			await SyncManager.fetchFolder(folderLink());
+		} finally {
+			Object.defineProperty(vscode.window, 'showInformationMessage', {
+				value: originalShowInformationMessage,
+				configurable: true,
+				writable: true,
+			});
+		}
+
+		const links = LinkManager.getOrgTemplateLinks(org);
+		assert.strictEqual(links.length, 2, 'the failed template is not linked');
+		assert.ok(!links.some(l => l.template.id === 't2'));
+		assert.ok(
+			messages.includes('Fetched 2/3 templates into the folder'),
+			`expected a partial-failure message, got: ${messages.join(' | ')}`,
+		);
+	});
+
+	test('sanitizes unsafe characters and de-duplicates colliding filenames', async () => {
+		fs.writeFileSync(path.join(tmpDir, 'Pre.txt'), 'do-not-overwrite');
+
+		const { wrapper } = setUpSession([
+			{ id: 't1', name: 'Dup' },
+			{ id: 't2', name: 'Dup' },
+			{ id: 't3', name: 'Weird:Name/Test' },
+			{ id: 't4', name: 'Pre.txt' },
+		]);
+		wrapper.when('getTemplate', vars => ({
+			data: Fixtures.getTemplateQuery({
+				id: vars.id,
+				name: vars.id,
+				body: `${vars.id}-body`,
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		}));
+
+		await SyncManager.fetchFolder(folderLink());
+
+		const links = LinkManager.getOrgTemplateLinks(org);
+		assert.strictEqual(links.length, 4);
+
+		const basenames = links.map(l => path.basename(vscode.Uri.parse(l.uriString).fsPath)).sort();
+		assert.deepStrictEqual(
+			basenames,
+			['Dup', 'Dup(1)', 'Pre(1).txt', 'Weird_Name_Test'].sort(),
+			'sanitized + de-duplicated filenames',
+		);
+
+		// A pre-existing unrelated file that was never part of this fetch is untouched.
+		assert.strictEqual(
+			fs.readFileSync(path.join(tmpDir, 'Pre.txt'), 'utf8'),
+			'do-not-overwrite',
+			'pre-existing file left untouched',
+		);
+	});
+});
+
+// Spec: template-sync "Resolve conflicts with explicit user choice". The
+// 'conflict' action is only reachable through the public syncTemplate() entry
+// point (computeSyncDecision -> syncTemplateInternal -> handleConflict), which
+// no prior test exercised. These stub the modal vscode.window.showInformationMessage
+// uses to drive each of its three outcomes.
+suite('Unit: SyncManager.syncTemplate (conflict resolution)', () => {
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	teardown(() => {
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	function setUpConflict() {
+		const uri = vscode.Uri.file('/test/conflict-file.txt');
+		const localContent = '// locally edited content';
+		const templateId = 'template-conflict';
+		const org = Fixtures.orgModel({ id: 'org-conflict', name: 'Conflict Org' });
+
+		const link: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org,
+			template: { id: templateId, name: 'Conflict Template', updatedAt: 'local-ts' } as any,
+			bodyHash: getHash('// some prior synced content'),
+		};
+		LinkManager.addLink(link);
+
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		wrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: templateId,
+				name: 'Conflict Template',
+				body: '// remote content, different from local',
+				updatedAt: 'remote-ts', // differs from the link's local-ts -> conflict
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+		SessionManager._setSessionsForTesting([session]);
+
+		const doc = createMockDocument({ uri, content: localContent });
+		return { uri, doc, wrapper, templateId, org };
+	}
+
+	test('user forces the local version: the local body is uploaded to Rewst', async () => {
+		const { doc, wrapper, templateId, org } = setUpConflict();
+		let modalMessage = '';
+		const restore = stub(vscode.window, 'showInformationMessage', (async (message: string) => {
+			modalMessage = message;
+			return 'Force Override';
+		}) as unknown as typeof vscode.window.showInformationMessage);
+		wrapper.when('updateTemplateBody', {
+			data: Fixtures.updateTemplateBodyMutation({
+				id: templateId,
+				name: 'Conflict Template',
+				updatedAt: 'uploaded-ts',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+
+		try {
+			await SyncManager.syncTemplate(doc);
+		} finally {
+			restore();
+		}
+
+		assert.match(modalMessage, /out of sync/);
+		assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 1, 'force override uploads local body');
+		assert.strictEqual(wrapper.getCallsFor('updateTemplateBody')[0].variables.body, '// locally edited content');
+		assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 1, 'no extra download happens');
+
+		const link = LinkManager.getTemplateLink(doc.uri);
+		assert.strictEqual(link.template.updatedAt, 'uploaded-ts', 'link reflects the upload response');
+	});
+
+	test('user takes the remote version: the remote body replaces the local file', async () => {
+		const { doc, wrapper } = setUpConflict();
+		const restore = stub(
+			vscode.window,
+			'showInformationMessage',
+			(async () => 'Download Latest') as unknown as typeof vscode.window.showInformationMessage,
+		);
+
+		try {
+			await SyncManager.syncTemplate(doc);
+		} catch {
+			// expected: vscode.workspace.save of an unopened mock document fails here,
+			// same as the existing applyTemplateToDocument tests above.
+		} finally {
+			restore();
+		}
+
+		assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 0, 'no upload happens on download');
+
+		const link = LinkManager.getTemplateLink(doc.uri);
+		assert.strictEqual(link.template.updatedAt, 'remote-ts', 'link now reflects the downloaded remote template');
+		assert.strictEqual(link.bodyHash, getHash('// remote content, different from local'));
+	});
+
+	test('user dismisses the prompt: the sync aborts and nothing changes', async () => {
+		const { doc, wrapper } = setUpConflict();
+		const restore = stub(
+			vscode.window,
+			'showInformationMessage',
+			(async () => undefined) as unknown as typeof vscode.window.showInformationMessage,
+		);
+
+		try {
+			await assert.rejects(() => SyncManager.syncTemplate(doc));
+		} finally {
+			restore();
+		}
+
+		assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 0, 'no upload on cancel');
+		const link = LinkManager.getTemplateLink(doc.uri);
+		assert.strictEqual(link.template.updatedAt, 'local-ts', 'link is untouched after cancel');
+	});
+});
+
+// Spec: template-sync "Guard against concurrent syncs". The syncingUris Set
+// guard inside the public syncTemplate() entry point was never exercised by a
+// prior test. Calling syncTemplate() twice back-to-back (without awaiting in
+// between) relies on JS run-to-completion: the first call's synchronous prefix
+// adds the uri to the guard Set before yielding at its first await, so the
+// second call's synchronous guard check is guaranteed to see it.
+suite('Unit: SyncManager.syncTemplate (concurrency guard)', () => {
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	teardown(() => {
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	test('a second sync started before the first finishes is suppressed, not raced', async () => {
+		const uri = vscode.Uri.file('/test/concurrent-file.txt');
+		const content = '// edited content';
+		const templateId = 'template-concurrent';
+		const updatedAt = 'ts-1';
+		const org = Fixtures.orgModel({ id: 'org-concurrent', name: 'Concurrent Org' });
+
+		const link: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org,
+			template: { id: templateId, name: 'Concurrent Template', updatedAt } as any,
+			bodyHash: getHash('// some prior synced content'),
+		};
+		LinkManager.addLink(link);
+
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		// Remote timestamp matches the link (no remote change) but the body differs
+		// from local -> upload-local, a clean action with no vscode editor interaction.
+		wrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: templateId,
+				name: 'Concurrent Template',
+				body: '// remote body',
+				updatedAt,
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+		wrapper.when('updateTemplateBody', {
+			data: Fixtures.updateTemplateBodyMutation({
+				id: templateId,
+				name: 'Concurrent Template',
+				updatedAt: 'ts-2',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+		SessionManager._setSessionsForTesting([session]);
+
+		const doc = createMockDocument({ uri, content });
+
+		await Promise.all([SyncManager.syncTemplate(doc), SyncManager.syncTemplate(doc)]);
+
+		assert.strictEqual(
+			wrapper.getCallsFor('getTemplate').length,
+			1,
+			'only the first sync fetches the remote template',
+		);
+		assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 1, 'only the first sync uploads');
+	});
+});
+
+// Spec: template-sync "Avoid false conflicts after upload". SyncManager.ts:196
+// (link.template = response.template inside updateTemplateBody) is the actual
+// mechanism; this exercises it through two real syncTemplate() calls in a row
+// rather than mocking the upload/decision step away.
+suite('Unit: SyncManager.syncTemplate (avoid false conflicts after upload)', () => {
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	teardown(() => {
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	test('a second save right after a successful upload uploads cleanly instead of reporting a conflict', async () => {
+		const uri = vscode.Uri.file('/test/two-saves-file.txt');
+		const templateId = 'template-two-saves';
+		const org = Fixtures.orgModel({ id: 'org-two-saves', name: 'Two Saves Org' });
+
+		const link: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org,
+			template: { id: templateId, name: 'Two Saves Template', updatedAt: 'ts-1' } as any,
+			bodyHash: getHash('// original content'),
+		};
+		LinkManager.addLink(link);
+
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+
+		// First sync: remote is still at ts-1 (matches the link) -> upload-local.
+		wrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: templateId,
+				name: 'Two Saves Template',
+				body: '// original content',
+				updatedAt: 'ts-1',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+		wrapper.when('updateTemplateBody', {
+			data: Fixtures.updateTemplateBodyMutation({
+				id: templateId,
+				name: 'Two Saves Template',
+				updatedAt: 'ts-2',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+		SessionManager._setSessionsForTesting([session]);
+
+		const firstDoc = createMockDocument({ uri, content: '// edit one' });
+		await SyncManager.syncTemplate(firstDoc);
+
+		assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 1, 'first save uploads');
+		const afterFirst = LinkManager.getTemplateLink(uri);
+		assert.strictEqual(afterFirst.template.updatedAt, 'ts-2', 'link records the timestamp Rewst returned');
+
+		// Second sync: remote now reflects what was just uploaded (ts-2, body = edit
+		// one). Without recording the upload response timestamp, the link would still
+		// read 'ts-1' here and this would misread as a conflict instead of a clean upload.
+		wrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: templateId,
+				name: 'Two Saves Template',
+				body: '// edit one',
+				updatedAt: 'ts-2',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+
+		const secondDoc = createMockDocument({ uri, content: '// edit two' });
+		await SyncManager.syncTemplate(secondDoc);
+
+		assert.strictEqual(
+			wrapper.getCallsFor('updateTemplateBody').length,
+			2,
+			'second save uploads cleanly, not a conflict',
+		);
+	});
+});
+
+// Spec: template-sync "Background folder fetch". fetchAllFolders is the
+// periodic ALL-folders background job (distinct from the single-folder,
+// user-triggered fetchFolder covered above). isActive is flipped directly via
+// bracket access, matching the existing private-method access pattern in this
+// file, so these tests exercise fetchAllFolders' own loop/gate without
+// depending on the real SessionManager-driven activation lifecycle.
+suite('Unit: SyncManager.fetchAllFolders', () => {
+	let tmpDirA: string;
+	let tmpDirB: string;
+	let folderUriA: vscode.Uri;
+	let folderUriB: vscode.Uri;
+	let orgA: Org;
+	let orgB: Org;
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+		tmpDirA = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-fetchAllFolders-a-'));
+		tmpDirB = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-fetchAllFolders-b-'));
+		folderUriA = vscode.Uri.file(tmpDirA);
+		folderUriB = vscode.Uri.file(tmpDirB);
+		orgA = { id: 'org-bg-a', name: 'Org A' };
+		orgB = { id: 'org-bg-b', name: 'Org B' };
+	});
+
+	teardown(() => {
+		(SyncManager as any)['isActive'] = false;
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+		fs.rmSync(tmpDirA, { recursive: true, force: true });
+		fs.rmSync(tmpDirB, { recursive: true, force: true });
+	});
+
+	test('does nothing when the manager is inactive', async () => {
+		(SyncManager as any)['isActive'] = false;
+
+		const { session, wrapper } = createMockSession({ profile: { org: orgA, allManagedOrgs: [orgA] } });
+		SessionManager._setSessionsForTesting([session]);
+		LinkManager.addLink({ type: 'Folder', uriString: folderUriA.toString(), org: orgA });
+
+		await SyncManager.fetchAllFolders();
+
+		assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 0, 'no folder is fetched while inactive');
+	});
+
+	test('fetches missing templates for every linked folder and links them locally', async () => {
+		const { session, wrapper } = createMockSession({
+			profile: { org: orgA, allManagedOrgs: [orgA, orgB] },
+		});
+		wrapper.when('listTemplates', vars => ({
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({
+					id: vars.orgId === orgA.id ? 'a1' : 'b1',
+					name: vars.orgId === orgA.id ? 'Alpha' : 'Bravo',
+					orgId: vars.orgId,
+					organization: Fixtures.org({
+						id: vars.orgId,
+						name: vars.orgId === orgA.id ? orgA.name : orgB.name,
+					}),
+				}),
+			]),
+		}));
+		wrapper.when('getTemplate', vars => {
+			const isA = vars.id === 'a1';
+			return {
+				data: Fixtures.getTemplateQuery({
+					id: vars.id,
+					name: isA ? 'Alpha' : 'Bravo',
+					body: `${vars.id}-body`,
+					orgId: isA ? orgA.id : orgB.id,
+					organization: Fixtures.org({ id: isA ? orgA.id : orgB.id, name: isA ? orgA.name : orgB.name }),
+				}),
+			};
+		});
+		SessionManager._setSessionsForTesting([session]);
+
+		LinkManager.addLink({ type: 'Folder', uriString: folderUriA.toString(), org: orgA });
+		LinkManager.addLink({ type: 'Folder', uriString: folderUriB.toString(), org: orgB });
+
+		(SyncManager as any)['isActive'] = true;
+		await SyncManager.fetchAllFolders();
+
+		assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 2, 'both linked folders are fetched');
+
+		const linksA = LinkManager.getOrgTemplateLinks(orgA);
+		const linksB = LinkManager.getOrgTemplateLinks(orgB);
+		assert.strictEqual(linksA.length, 1, 'org A got its missing template linked');
+		assert.strictEqual(linksB.length, 1, 'org B got its missing template linked');
+
+		const fileA = vscode.Uri.parse(linksA[0].uriString).fsPath;
+		const fileB = vscode.Uri.parse(linksB[0].uriString).fsPath;
+		assert.ok(fs.existsSync(fileA), 'org A template written to disk');
+		assert.ok(fs.existsSync(fileB), 'org B template written to disk');
+		assert.strictEqual(fs.readFileSync(fileA, 'utf8'), 'a1-body');
+		assert.strictEqual(fs.readFileSync(fileB, 'utf8'), 'b1-body');
 	});
 });

--- a/src/models/SyncOnSaveManager.test.ts
+++ b/src/models/SyncOnSaveManager.test.ts
@@ -1,0 +1,102 @@
+import { context } from '@global';
+import { LinkManager, SyncOnSaveManager, TemplateLink } from '@models';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+
+const { suite, test, setup, teardown } = Mocha;
+
+// Spec: template-sync "Sync on save when enabled". SyncManager.handleSave only
+// consults SyncOnSaveManager.isUriSynced; these tests exercise the real
+// toggle/persistence logic instead of stubbing isSyncOnSaveEnabled as a constant
+// (as templateSyncCapabilities.test.ts does for its own unrelated purposes).
+suite('Unit: SyncOnSaveManager', () => {
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+		SyncOnSaveManager._resetForTesting();
+	});
+
+	function linkedUri(filePath: string): vscode.Uri {
+		const uri = vscode.Uri.file(filePath);
+		const link: TemplateLink = {
+			uriString: uri.toString(),
+			org: { id: 'org-1', name: 'Org' },
+			type: 'Template',
+			template: { id: 'tpl-1', name: 'Tpl', updatedAt: '' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(link);
+		return uri;
+	}
+
+	test('defaults to inclusion mode: a linked file not explicitly enabled does not sync', () => {
+		const uri = linkedUri('/test/a.j2');
+		assert.strictEqual(SyncOnSaveManager.syncByDefault, false, 'reset state defaults to off');
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false);
+	});
+
+	test('an unlinked file never syncs, even if explicitly enabled', () => {
+		const uri = vscode.Uri.file('/test/unlinked.j2');
+		SyncOnSaveManager.enableSync(uri);
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false);
+	});
+
+	test('enableSync turns a linked file on and stores it in the inclusion list', () => {
+		const uri = linkedUri('/test/include.j2');
+
+		SyncOnSaveManager.enableSync(uri);
+
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true);
+		const persisted = context.globalState.get<string[]>(SyncOnSaveManager.inclusionsKey, []);
+		assert.ok(persisted?.includes(uri.toString()), 'inclusion is persisted to globalState');
+	});
+
+	test('per-file toggle persists across repeated checks until explicitly disabled', () => {
+		const uri = linkedUri('/test/persist.j2');
+
+		SyncOnSaveManager.enableSync(uri);
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true, 'enabled after toggle');
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true, 'stays enabled across repeated saves');
+
+		SyncOnSaveManager.disableSync(uri);
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false);
+
+		const persisted = context.globalState.get<string[]>(SyncOnSaveManager.inclusionsKey, []);
+		assert.ok(!persisted?.includes(uri.toString()), 'no longer in the inclusion list once disabled');
+	});
+
+	test('default enabled with one exclusion: the excluded file does not sync while other linked files do', () => {
+		SyncOnSaveManager.syncByDefault = true;
+		const excluded = linkedUri('/test/excluded.j2');
+		const other = linkedUri('/test/other.j2');
+
+		SyncOnSaveManager.disableSync(excluded);
+
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(excluded), false);
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(other), true, 'other linked files still sync by default');
+
+		const persistedExclusions = context.globalState.get<string[]>(SyncOnSaveManager.exclusionsKey, []);
+		assert.ok(persistedExclusions?.includes(excluded.toString()), 'exclusion is persisted to globalState');
+	});
+
+	test('enableSync clears a prior exclusion; disableSync clears a prior inclusion', () => {
+		const uri = linkedUri('/test/flip.j2');
+
+		SyncOnSaveManager.disableSync(uri);
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), false);
+
+		SyncOnSaveManager.enableSync(uri);
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true);
+
+		// Switching the default to exclusion-mode should not resurrect the old exclusion.
+		SyncOnSaveManager.syncByDefault = true;
+		assert.strictEqual(SyncOnSaveManager.isUriSynced(uri), true);
+	});
+});

--- a/src/models/TemplateBundleManager.test.ts
+++ b/src/models/TemplateBundleManager.test.ts
@@ -1,7 +1,11 @@
 import * as assert from 'assert';
+import * as fs from 'fs';
 import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
 import { initTestEnvironment } from '@test';
 import { LinkManager, TemplateBundleManager, TemplateLink } from '@models';
+import vscode from 'vscode';
 
 const { suite, test, setup, teardown } = Mocha;
 
@@ -320,6 +324,58 @@ suite('Unit: TemplateBundleManager', () => {
 			assert.ok(allMemberIds.includes(b));
 			assert.ok(allMemberIds.includes(c));
 			assert.ok(allMemberIds.includes(d));
+		});
+	});
+
+	suite('legacy links missing reference metadata', () => {
+		test('re-derives referencedTemplateIds from the local file body when undefined', async () => {
+			const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-bundle-backfill-'));
+			try {
+				const [a, b] = [uuid(), uuid()];
+				const filePath = path.join(tmpDir, `${a}.jinja`);
+				fs.writeFileSync(filePath, `{{ template('${b}') }}`);
+				const uri = vscode.Uri.file(filePath);
+
+				const legacyLink: TemplateLink = {
+					uriString: uri.toString(),
+					org: { id: 'org-1', name: 'Test Org' },
+					type: 'Template',
+					template: { id: a, name: 'Root', updatedAt: '' } as any,
+					bodyHash: 'hash',
+					referencedTemplateIds: undefined,
+				};
+				LinkManager.addLink(legacyLink);
+				LinkManager.addLink(makeLink(b, 'Child'));
+
+				await TemplateBundleManager.buildBundles();
+
+				assert.deepStrictEqual(bundleIds(), [[a, b].sort()]);
+				const stored = LinkManager.getTemplateLink(uri);
+				assert.deepStrictEqual(stored.referencedTemplateIds, [b], 'backfilled from the file on disk');
+			} finally {
+				fs.rmSync(tmpDir, { recursive: true, force: true });
+			}
+		});
+
+		test('backfills to an empty array when the local file cannot be read', async () => {
+			const a = uuid();
+			const missingUri = vscode.Uri.file(path.join(os.tmpdir(), `rewst-buddy-missing-${a}.jinja`));
+
+			const legacyLink: TemplateLink = {
+				uriString: missingUri.toString(),
+				org: { id: 'org-1', name: 'Test Org' },
+				type: 'Template',
+				template: { id: a, name: 'Unreadable', updatedAt: '' } as any,
+				bodyHash: 'hash',
+				referencedTemplateIds: undefined,
+			};
+			LinkManager.addLink(legacyLink);
+
+			await TemplateBundleManager.buildBundles();
+
+			const stored = LinkManager.getTemplateLink(missingUri);
+			assert.deepStrictEqual(stored.referencedTemplateIds, []);
+			assert.deepStrictEqual(standaloneIds(), [a]);
 		});
 	});
 

--- a/src/providers/TemplateDefinitionProvider.test.ts
+++ b/src/providers/TemplateDefinitionProvider.test.ts
@@ -1,0 +1,149 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { initTestEnvironment, createMockSession, Fixtures } from '@test';
+import { LinkManager, TemplateLink, TemplateMetadataStore } from '@models';
+import { SessionManager } from '@sessions';
+import { TemplateDefinitionProvider } from './TemplateDefinitionProvider';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * Covers the Ctrl+Click side of the language-navigation spec: jump straight to a
+ * linked file, fetch-save-link-and-open a cached-but-unlinked template in the
+ * background, and the fast "not a linked file" bail-out. TemplateDefinitionProvider
+ * had zero coverage before this file.
+ */
+const LINKED_TEMPLATE_ID = '11111111-1111-1111-1111-111111111111';
+const CACHED_TEMPLATE_ID = '22222222-2222-2222-2222-222222222222';
+
+function templateLink(uri: vscode.Uri, templateId: string, orgId: string, orgName: string, name: string): TemplateLink {
+	return {
+		uriString: uri.toString(),
+		org: { id: orgId, name: orgName },
+		type: 'Template',
+		template: { id: templateId, name, updatedAt: '' } as TemplateLink['template'],
+		bodyHash: 'hash',
+	};
+}
+
+async function openDoc(content: string): Promise<vscode.TextDocument> {
+	return vscode.workspace.openTextDocument({ language: 'plaintext', content });
+}
+
+suite('Unit: TemplateDefinitionProvider', () => {
+	const provider = new TemplateDefinitionProvider();
+	const position = new vscode.Position(0, 5); // inside "template(" on a single-reference line
+	const token = new vscode.CancellationTokenSource().token;
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		SessionManager._resetForTesting();
+		TemplateMetadataStore._resetForTesting();
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		TemplateMetadataStore._resetForTesting();
+		LinkManager._resetForTesting();
+		SessionManager._resetForTesting();
+	});
+
+	test('returns immediately with no work when the document is not a linked template', async () => {
+		const doc = await openDoc(`template('${LINKED_TEMPLATE_ID}')`);
+		// Deliberately no LinkManager.addLink for this document's own uri.
+		const result = provider.provideDefinition(doc, position, token);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('navigates straight to the local file when the referenced template is linked', async () => {
+		const doc = await openDoc(`template('${LINKED_TEMPLATE_ID}')`);
+		// The file under the cursor must itself be linked for the provider to do any work.
+		LinkManager.addLink(templateLink(doc.uri, 'host-template', 'host-org', 'Host Org', 'Host Template'));
+		const targetUri = vscode.Uri.file('/ws/other.j2');
+		LinkManager.addLink(templateLink(targetUri, LINKED_TEMPLATE_ID, 'org-linked', 'Linked Org', 'Linked Template'));
+
+		const result = provider.provideDefinition(doc, position, token);
+		assert.ok(Array.isArray(result), 'expected a LocationLink array');
+		const [locationLink] = result as vscode.LocationLink[];
+		assert.strictEqual(locationLink.targetUri.toString(), targetUri.toString());
+	});
+
+	test('fetches, saves, and links a cached-but-unlinked template in the background, opening it', async () => {
+		const cacheOrg = Fixtures.orgModel({ id: 'cache-org', name: 'Cache Org' });
+		const doc = await openDoc(`template('${CACHED_TEMPLATE_ID}')`);
+		// Link the editor's own file to a different template in the same org so the
+		// org counts as "linked" and its templates load with priority (no deferred wait).
+		LinkManager.addLink(templateLink(doc.uri, 'anchor-template', cacheOrg.id, cacheOrg.name, 'Anchor Template'));
+
+		const { session, wrapper } = createMockSession({ profile: { org: cacheOrg, allManagedOrgs: [cacheOrg] } });
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({ id: 'anchor-template', name: 'Anchor Template', orgId: cacheOrg.id }),
+				Fixtures.template({ id: CACHED_TEMPLATE_ID, name: 'Cached Template', orgId: cacheOrg.id }),
+			]),
+		});
+
+		SessionManager._setSessionsForTesting([session]);
+		TemplateMetadataStore.init();
+		await new Promise(resolve => setTimeout(resolve, 100));
+
+		// Sanity check: the referenced template is cached but not itself linked.
+		assert.strictEqual(LinkManager.getTemplateLinkFromId(CACHED_TEMPLATE_ID).length, 0);
+
+		wrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: CACHED_TEMPLATE_ID,
+				name: 'Cached Template',
+				orgId: cacheOrg.id,
+				organization: Fixtures.org({ id: cacheOrg.id, name: cacheOrg.name }),
+			}),
+		});
+
+		// Stub the vscode primitives createAndLinkNewTemplate drives, so the
+		// background flow runs without a real "Save As" dialog or network call.
+		const newFileUri = vscode.Uri.file('/ws/new-cached-template.j2');
+		const shownDocs: string[] = [];
+
+		stub(
+			vscode.workspace,
+			'openTextDocument',
+			(async (uri: vscode.Uri) =>
+				({ uri }) as vscode.TextDocument) as unknown as typeof vscode.workspace.openTextDocument,
+		);
+		stub(vscode.window, 'showTextDocument', (async (untitledDoc: vscode.TextDocument) => {
+			shownDocs.push(untitledDoc.uri.toString());
+			return {
+				document: untitledDoc,
+				edit: async (callback: (editBuilder: vscode.TextEditorEdit) => void) => {
+					callback({ insert: () => undefined } as unknown as vscode.TextEditorEdit);
+					return true;
+				},
+			} as unknown as vscode.TextEditor;
+		}) as unknown as typeof vscode.window.showTextDocument);
+		stub(vscode.workspace, 'saveAs', (async () => newFileUri) as typeof vscode.workspace.saveAs);
+
+		const result = provider.provideDefinition(doc, position, token);
+		assert.strictEqual(result, undefined, 'the fetch-and-link happens in the background, not synchronously');
+
+		await new Promise(resolve => setTimeout(resolve, 150));
+
+		const getTemplateCalls = wrapper.getCallsFor('getTemplate');
+		assert.strictEqual(getTemplateCalls.length, 1, 'the template was fetched');
+		assert.strictEqual(getTemplateCalls[0].variables.id, CACHED_TEMPLATE_ID);
+
+		const newLinks = LinkManager.getTemplateLinkFromId(CACHED_TEMPLATE_ID);
+		assert.strictEqual(newLinks.length, 1, 'the fetched template gets linked to the newly saved file');
+		assert.strictEqual(newLinks[0].uriString, newFileUri.toString());
+
+		assert.ok(shownDocs.length > 0, 'the new file was opened in an editor');
+	});
+});

--- a/src/providers/TemplateDefinitionProvider.test.ts
+++ b/src/providers/TemplateDefinitionProvider.test.ts
@@ -4,9 +4,19 @@ import vscode from 'vscode';
 import { initTestEnvironment, createMockSession, Fixtures } from '@test';
 import { LinkManager, TemplateLink, TemplateMetadataStore } from '@models';
 import { SessionManager } from '@sessions';
+import { log } from '@utils';
 import { TemplateDefinitionProvider } from './TemplateDefinitionProvider';
 
 const { suite, test, setup, teardown } = Mocha;
+
+/** Poll `predicate` until it is true or the timeout elapses, instead of waiting a fixed delay. */
+async function waitFor(predicate: () => boolean, timeoutMs = 2000, stepMs = 10): Promise<void> {
+	const deadline = Date.now() + timeoutMs;
+	while (!predicate()) {
+		if (Date.now() >= deadline) throw new Error('waitFor: condition not met before timeout');
+		await new Promise(resolve => setTimeout(resolve, stepMs));
+	}
+}
 
 /**
  * Covers the Ctrl+Click side of the language-navigation spec: jump straight to a
@@ -94,7 +104,7 @@ suite('Unit: TemplateDefinitionProvider', () => {
 
 		SessionManager._setSessionsForTesting([session]);
 		TemplateMetadataStore.init();
-		await new Promise(resolve => setTimeout(resolve, 100));
+		await waitFor(() => TemplateMetadataStore.getTemplateMetadata(CACHED_TEMPLATE_ID) !== undefined);
 
 		// Sanity check: the referenced template is cached but not itself linked.
 		assert.strictEqual(LinkManager.getTemplateLinkFromId(CACHED_TEMPLATE_ID).length, 0);
@@ -134,7 +144,7 @@ suite('Unit: TemplateDefinitionProvider', () => {
 		const result = provider.provideDefinition(doc, position, token);
 		assert.strictEqual(result, undefined, 'the fetch-and-link happens in the background, not synchronously');
 
-		await new Promise(resolve => setTimeout(resolve, 150));
+		await waitFor(() => LinkManager.getTemplateLinkFromId(CACHED_TEMPLATE_ID).length === 1);
 
 		const getTemplateCalls = wrapper.getCallsFor('getTemplate');
 		assert.strictEqual(getTemplateCalls.length, 1, 'the template was fetched');
@@ -145,5 +155,59 @@ suite('Unit: TemplateDefinitionProvider', () => {
 		assert.strictEqual(newLinks[0].uriString, newFileUri.toString());
 
 		assert.ok(shownDocs.length > 0, 'the new file was opened in an editor');
+	});
+
+	test('reports an error and creates no link when the background fetch of a cached template fails', async () => {
+		const cacheOrg = Fixtures.orgModel({ id: 'cache-org', name: 'Cache Org' });
+		const doc = await openDoc(`template('${CACHED_TEMPLATE_ID}')`);
+		LinkManager.addLink(templateLink(doc.uri, 'anchor-template', cacheOrg.id, cacheOrg.name, 'Anchor Template'));
+
+		const { session, wrapper } = createMockSession({ profile: { org: cacheOrg, allManagedOrgs: [cacheOrg] } });
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({ id: 'anchor-template', name: 'Anchor Template', orgId: cacheOrg.id }),
+				Fixtures.template({ id: CACHED_TEMPLATE_ID, name: 'Cached Template', orgId: cacheOrg.id }),
+			]),
+		});
+		wrapper.when('getTemplate', { error: new Error('fetch exploded') });
+		SessionManager._setSessionsForTesting([session]);
+		TemplateMetadataStore.init();
+		await waitFor(() => TemplateMetadataStore.getTemplateMetadata(CACHED_TEMPLATE_ID) !== undefined);
+
+		const errors: string[] = [];
+		stub(log, 'notifyError', ((message: string) => {
+			errors.push(message);
+			return new Error(message);
+		}) as typeof log.notifyError);
+
+		const result = provider.provideDefinition(doc, position, token);
+		assert.strictEqual(result, undefined);
+
+		await waitFor(() => errors.length > 0);
+		assert.ok(
+			errors.some(m => m.includes('Failed to open template')),
+			'the fetch failure is surfaced via notifyError',
+		);
+		assert.strictEqual(
+			LinkManager.getTemplateLinkFromId(CACHED_TEMPLATE_ID).length,
+			0,
+			'no link is created when the fetch fails',
+		);
+	});
+
+	test('returns undefined with no side effects when the referenced template is neither linked nor cached', async () => {
+		const doc = await openDoc(`template('${CACHED_TEMPLATE_ID}')`);
+		// The host file is linked, but nothing knows about the referenced id: no
+		// local link and no metadata-store entry, so there is nothing to open.
+		LinkManager.addLink(templateLink(doc.uri, 'host-template', 'host-org', 'Host Org', 'Host Template'));
+
+		const result = provider.provideDefinition(doc, position, token);
+
+		assert.strictEqual(result, undefined);
+		assert.strictEqual(
+			LinkManager.getTemplateLinkFromId(CACHED_TEMPLATE_ID).length,
+			0,
+			'no background fetch-and-link happened',
+		);
 	});
 });

--- a/src/providers/TemplateHoverProvider.test.ts
+++ b/src/providers/TemplateHoverProvider.test.ts
@@ -1,0 +1,124 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { initTestEnvironment, createMockSession, Fixtures } from '@test';
+import { LinkManager, TemplateLink, TemplateMetadataStore } from '@models';
+import { SessionManager } from '@sessions';
+import { TemplateHoverProvider } from './TemplateHoverProvider';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * Covers the hover side of the language-navigation spec: link-then-cache-then-
+ * unknown precedence, and the fast "not a linked file" bail-out. TemplateHoverProvider
+ * had zero coverage before this file.
+ */
+const LINKED_TEMPLATE_ID = '11111111-1111-1111-1111-111111111111';
+const CACHED_TEMPLATE_ID = '22222222-2222-2222-2222-222222222222';
+const UNKNOWN_TEMPLATE_ID = '33333333-3333-3333-3333-333333333333';
+
+function templateLink(uri: vscode.Uri, templateId: string, orgId: string, orgName: string, name: string): TemplateLink {
+	return {
+		uriString: uri.toString(),
+		org: { id: orgId, name: orgName },
+		type: 'Template',
+		template: { id: templateId, name, updatedAt: '' } as TemplateLink['template'],
+		bodyHash: 'hash',
+	};
+}
+
+async function openDoc(content: string): Promise<vscode.TextDocument> {
+	return vscode.workspace.openTextDocument({ language: 'plaintext', content });
+}
+
+function markdownText(hover: vscode.Hover): string {
+	return hover.contents.map(c => (typeof c === 'string' ? c : (c as vscode.MarkdownString).value)).join('\n');
+}
+
+suite('Unit: TemplateHoverProvider', () => {
+	const provider = new TemplateHoverProvider();
+	const position = new vscode.Position(0, 5); // inside "template(" on a single-reference line
+	const token = new vscode.CancellationTokenSource().token;
+
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+		SessionManager._resetForTesting();
+		TemplateMetadataStore._resetForTesting();
+	});
+
+	teardown(() => {
+		TemplateMetadataStore._resetForTesting();
+		LinkManager._resetForTesting();
+		SessionManager._resetForTesting();
+	});
+
+	test('returns immediately with no work when the document is not a linked template', async () => {
+		const doc = await openDoc(`template('${LINKED_TEMPLATE_ID}')`);
+		// Deliberately no LinkManager.addLink for this document's own uri.
+		const result = provider.provideHover(doc, position, token);
+		assert.strictEqual(result, undefined);
+	});
+
+	test('shows the name and org from the link when the referenced template is linked locally', async () => {
+		const doc = await openDoc(`template('${LINKED_TEMPLATE_ID}')`);
+		// The file under the cursor must itself be linked for the provider to do any work.
+		LinkManager.addLink(templateLink(doc.uri, 'host-template', 'host-org', 'Host Org', 'Host Template'));
+		// The referenced template is linked to a different local file.
+		LinkManager.addLink(
+			templateLink(
+				vscode.Uri.file('/ws/other.j2'),
+				LINKED_TEMPLATE_ID,
+				'org-linked',
+				'Linked Org',
+				'Linked Template',
+			),
+		);
+
+		const result = provider.provideHover(doc, position, token);
+		assert.ok(result instanceof vscode.Hover, 'expected a Hover result');
+		const text = markdownText(result as vscode.Hover);
+		assert.ok(text.includes('Linked Template'), 'shows the linked template name');
+		assert.ok(text.includes('Linked Org'), 'shows the linked template org');
+	});
+
+	test('shows the name and org from cached metadata when the referenced template is only cached', async () => {
+		const cacheOrg = Fixtures.orgModel({ id: 'cache-org', name: 'Cache Org' });
+		const doc = await openDoc(`template('${CACHED_TEMPLATE_ID}')`);
+		// Link the editor's own file to a different template in the same org so the
+		// org counts as "linked" and its templates load with priority (no deferred wait).
+		LinkManager.addLink(templateLink(doc.uri, 'anchor-template', cacheOrg.id, cacheOrg.name, 'Anchor Template'));
+
+		const { session, wrapper } = createMockSession({ profile: { org: cacheOrg, allManagedOrgs: [cacheOrg] } });
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({ id: 'anchor-template', name: 'Anchor Template', orgId: cacheOrg.id }),
+				Fixtures.template({ id: CACHED_TEMPLATE_ID, name: 'Cached Template', orgId: cacheOrg.id }),
+			]),
+		});
+
+		SessionManager._setSessionsForTesting([session]);
+		TemplateMetadataStore.init();
+		await new Promise(resolve => setTimeout(resolve, 100));
+
+		// Sanity check: the referenced template is cached but not itself linked.
+		assert.strictEqual(LinkManager.getTemplateLinkFromId(CACHED_TEMPLATE_ID).length, 0);
+
+		const result = provider.provideHover(doc, position, token);
+		assert.ok(result instanceof vscode.Hover, 'expected a Hover result');
+		const text = markdownText(result as vscode.Hover);
+		assert.ok(text.includes('Cached Template'), 'shows the cached template name');
+		assert.ok(text.includes('Cache Org'), 'shows the cached template org');
+	});
+
+	test('shows the id and marks the template unknown when neither linked nor cached', async () => {
+		const doc = await openDoc(`template('${UNKNOWN_TEMPLATE_ID}')`);
+		LinkManager.addLink(templateLink(doc.uri, 'host-template', 'host-org', 'Host Org', 'Host Template'));
+
+		const result = provider.provideHover(doc, position, token);
+		assert.ok(result instanceof vscode.Hover, 'expected a Hover result');
+		const text = markdownText(result as vscode.Hover);
+		assert.ok(text.includes(UNKNOWN_TEMPLATE_ID), 'shows the raw template id');
+		assert.ok(/unknown/i.test(text), 'marks the template as unknown');
+	});
+});

--- a/src/server/Server.test.ts
+++ b/src/server/Server.test.ts
@@ -1,4 +1,5 @@
 import * as assert from 'assert';
+import http from 'http';
 import * as Mocha from 'mocha';
 import net from 'net';
 import vscode from 'vscode';
@@ -24,6 +25,23 @@ function findFreePort(): Promise<number> {
 async function setPort(port: number): Promise<void> {
 	const config = vscode.workspace.getConfiguration('rewst-buddy.server');
 	await config.update('port', port, vscode.ConfigurationTarget.Global);
+}
+
+async function setHost(host: string | undefined): Promise<void> {
+	const config = vscode.workspace.getConfiguration('rewst-buddy.server');
+	await config.update('host', host, vscode.ConfigurationTarget.Global);
+}
+
+/**
+ * `rewst-buddy.server.enabled` defaults on, and Server.ts's own config listener
+ * auto-restarts on any `rewst-buddy.server.*` change while enabled and not
+ * running. Forcing it off keeps `setPort`/`setHost` below from racing that
+ * auto-restart, so the explicit `Server.start()` call under test is the only
+ * thing that binds.
+ */
+async function setEnabled(enabled: boolean | undefined): Promise<void> {
+	const config = vscode.workspace.getConfiguration('rewst-buddy.server');
+	await config.update('enabled', enabled, vscode.ConfigurationTarget.Global);
 }
 
 /**
@@ -65,5 +83,250 @@ suite('Unit: Server concurrent start', () => {
 		} finally {
 			sub.dispose();
 		}
+	});
+});
+
+interface Restore {
+	restore(): void;
+}
+
+function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): Restore {
+	const original = obj[key];
+	Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+	return {
+		restore() {
+			Object.defineProperty(obj, key, { value: original, configurable: true, writable: true });
+		},
+	};
+}
+
+/**
+ * Closes the "Run a localhost-only server when enabled" gap: a non-loopback
+ * `rewst-buddy.server.host` must be refused before bind() ever calls listen().
+ */
+suite('Unit: Server host validation', () => {
+	const restores: Restore[] = [];
+	let errorMessages: string[] = [];
+
+	setup(async () => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		await Server.start(); // settle any in-flight activation bind first
+		await Server.stop();
+		await setEnabled(false); // avoid the config listener auto-restarting mid-setup below
+		errorMessages = [];
+		restores.push(
+			stub(vscode.window, 'showErrorMessage', (async (message: string) => {
+				errorMessages.push(message);
+				return undefined;
+			}) as unknown as typeof vscode.window.showErrorMessage),
+		);
+	});
+
+	teardown(async () => {
+		while (restores.length) restores.pop()!.restore();
+		await Server.stop();
+		await setPort(undefined as unknown as number); // clear override
+		await setHost(undefined); // clear override
+		await setEnabled(undefined); // clear override
+	});
+
+	test('refuses to bind a non-loopback host and does not flip isRunning', async () => {
+		const port = await findFreePort();
+		await setPort(port);
+		await setHost('0.0.0.0');
+
+		const started = await Server.start();
+
+		assert.strictEqual(started, false, 'start() should refuse a non-loopback host');
+		assert.strictEqual(Server.getStatus(), false, 'server should not be marked running');
+		assert.ok(
+			errorMessages.some(message => message.toLowerCase().includes('localhost')),
+			'user is notified that only localhost bindings are allowed',
+		);
+	});
+
+	test('refuses an unresolvable hostname', async () => {
+		const port = await findFreePort();
+		await setPort(port);
+		await setHost('attacker.example');
+
+		const started = await Server.start();
+
+		assert.strictEqual(started, false);
+		assert.strictEqual(Server.getStatus(), false);
+	});
+});
+
+interface RawHttpResponse {
+	statusCode: number;
+	headers: Record<string, string>;
+	body: string;
+}
+
+/** Sends a real HTTP request via Node's http.request, overriding the Host/Origin headers a browser or proxy could send. */
+function rawRequest(options: {
+	port: number;
+	method: string;
+	headers?: Record<string, string>;
+	body?: string;
+}): Promise<RawHttpResponse> {
+	return new Promise((resolve, reject) => {
+		const req = http.request(
+			{ host: '127.0.0.1', port: options.port, method: options.method, path: '/', headers: options.headers },
+			res => {
+				const chunks: Buffer[] = [];
+				res.on('data', (chunk: Buffer) => chunks.push(chunk));
+				res.on('end', () => {
+					const headers: Record<string, string> = {};
+					for (const [key, value] of Object.entries(res.headers)) {
+						if (typeof value === 'string') headers[key] = value;
+					}
+					resolve({
+						statusCode: res.statusCode ?? 0,
+						headers,
+						body: Buffer.concat(chunks).toString('utf-8'),
+					});
+				});
+			},
+		);
+		req.on('error', reject);
+		if (options.body) req.write(options.body);
+		req.end();
+	});
+}
+
+/**
+ * Sends a hand-crafted HTTP request over a raw socket. Used only for shapes
+ * Node's http.request can't produce on its own — e.g. a request with no Host
+ * header at all (Node always injects one unless told otherwise).
+ */
+function rawSocketRequest(options: {
+	port: number;
+	requestLine: string;
+	headerLines?: string[];
+	body?: string;
+}): Promise<RawHttpResponse> {
+	return new Promise((resolve, reject) => {
+		const body = options.body ?? '';
+		const headerLines = [...(options.headerLines ?? []), 'Connection: close'];
+		if (body) headerLines.push(`Content-Length: ${Buffer.byteLength(body)}`);
+		const raw = [options.requestLine, ...headerLines, '', body].join('\r\n');
+
+		const socket = net.createConnection({ host: '127.0.0.1', port: options.port }, () => {
+			socket.write(raw);
+		});
+
+		let data = '';
+		socket.on('data', (chunk: Buffer) => {
+			data += chunk.toString('utf-8');
+		});
+		socket.on('end', () => {
+			const [headPart, ...rest] = data.split('\r\n\r\n');
+			const headLines = headPart.split('\r\n');
+			const statusCode = Number(headLines[0].split(' ')[1]);
+			const headers: Record<string, string> = {};
+			for (const line of headLines.slice(1)) {
+				const idx = line.indexOf(':');
+				if (idx === -1) continue;
+				headers[line.slice(0, idx).trim().toLowerCase()] = line.slice(idx + 1).trim();
+			}
+			resolve({ statusCode, headers, body: rest.join('\r\n\r\n') });
+		});
+		socket.on('error', reject);
+	});
+}
+
+/**
+ * Closes the "Reject non-local HTTP requests" gap for the session-ingestion and
+ * template-open routes. Exercises the spec's four scenarios against a real,
+ * bound Server instance over real HTTP/TCP — the /mcp route's own allowedHosts
+ * mechanism is untouched and out of scope here.
+ */
+suite('Unit: Server request guard (Host/CORS)', () => {
+	let port = 0;
+	const restores: Restore[] = [];
+
+	setup(async () => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		await Server.start(); // settle any in-flight activation bind first
+		await Server.stop();
+		await setEnabled(false); // keep the config listener from racing the explicit start() below
+		port = await findFreePort();
+		await setPort(port);
+		await setHost(undefined); // default loopback host
+		await Server.start();
+	});
+
+	teardown(async () => {
+		while (restores.length) restores.pop()!.restore();
+		await Server.stop();
+		await setPort(undefined as unknown as number);
+		await setHost(undefined);
+		await setEnabled(undefined);
+	});
+
+	test('rejects a non-local Host header before any action runs', async () => {
+		const createSessionCalls: unknown[] = [];
+		restores.push(
+			stub(SessionManager, 'createSession', (async (...args: unknown[]) => {
+				createSessionCalls.push(args);
+				throw new Error('should not have been called');
+			}) as typeof SessionManager.createSession),
+		);
+
+		const res = await rawRequest({
+			port,
+			method: 'POST',
+			headers: { Host: 'attacker.example', 'Content-Type': 'application/json' },
+			body: JSON.stringify({ action: 'addSession', cookies: 'cookie=value' }),
+		});
+
+		assert.strictEqual(res.statusCode, 400);
+		assert.strictEqual(createSessionCalls.length, 0, 'no credential/action handling ran for a spoofed Host');
+	});
+
+	test('rejects a request with no Host header before reading the request body', async () => {
+		const res = await rawSocketRequest({ port, requestLine: 'GET / HTTP/1.0' });
+
+		assert.strictEqual(res.statusCode, 400);
+	});
+
+	test('rejects a request with a malformed Host header', async () => {
+		const res = await rawSocketRequest({
+			port,
+			requestLine: 'POST / HTTP/1.1',
+			headerLines: ['Host: foo:bar:baz', 'Content-Type: application/json'],
+			body: JSON.stringify({ action: 'addSession', cookies: 'cookie=value' }),
+		});
+
+		assert.strictEqual(res.statusCode, 400);
+	});
+
+	test('rejects a browser request whose Origin is a non-loopback web origin', async () => {
+		const res = await rawRequest({
+			port,
+			method: 'POST',
+			headers: {
+				Host: `127.0.0.1:${port}`,
+				Origin: 'http://attacker.example',
+				'Content-Type': 'application/json',
+			},
+			body: JSON.stringify({ action: 'addSession', cookies: 'cookie=value' }),
+		});
+
+		assert.strictEqual(res.statusCode, 400);
+	});
+
+	test('a local preflight names the allowed origin instead of a wildcard', async () => {
+		const res = await rawRequest({
+			port,
+			method: 'OPTIONS',
+			headers: { Host: `127.0.0.1:${port}`, Origin: 'http://localhost:5500' },
+		});
+
+		assert.notStrictEqual(res.headers['access-control-allow-origin'], '*');
+		assert.strictEqual(res.headers['access-control-allow-origin'], 'http://localhost:5500');
 	});
 });

--- a/src/server/Server.ts
+++ b/src/server/Server.ts
@@ -3,8 +3,9 @@ import http, { IncomingMessage, ServerResponse } from 'http';
 import vscode from 'vscode';
 import { handleMcpHttp } from '../mcp/mcpServer';
 import { readMcpSettings } from '../mcp/settings';
-import { getServerConfig } from './config';
+import { getServerConfig, isLoopbackHost } from './config';
 import { handleAddSession, handleOpenTemplate, validateRequest } from './handlers';
+import { evaluateRequestGuard, requestGuardInputFromRequest } from './requestGuard';
 import { BrowserRequest, Response, ServerConfig } from './types';
 
 export const Server = new (class _ implements vscode.Disposable {
@@ -104,6 +105,14 @@ export const Server = new (class _ implements vscode.Disposable {
 		const config = getServerConfig();
 		log.debug('Server.start: config', { host: config.host, port: config.port });
 
+		if (!isLoopbackHost(config.host)) {
+			log.notifyError(
+				`Refusing to start the Rewst Buddy server: '${config.host}' is not a loopback host. ` +
+					`Only localhost bindings are allowed (rewst-buddy.server.host).`,
+			);
+			return false;
+		}
+
 		try {
 			this.server = http.createServer(this.handleRequest.bind(this));
 
@@ -162,7 +171,25 @@ export const Server = new (class _ implements vscode.Disposable {
 		}
 
 		res.setHeader('Content-Type', 'application/json');
-		res.setHeader('Access-Control-Allow-Origin', '*');
+
+		// Localhost-only control plane: reject before reading any body or
+		// setting any CORS header, so a non-loopback Host/forwarded-host/web
+		// origin can't ingest credentials or trigger actions. See the
+		// credential-server spec's "Reject non-local HTTP requests" requirement.
+		const guard = evaluateRequestGuard(requestGuardInputFromRequest(req));
+		if (!guard.allowed) {
+			log.warn('Server.handleRequest: rejected by request guard', { reason: guard.reason });
+			this.sendResponse(res, 400, { success: false, error: 'Request rejected: not a local request' });
+			return;
+		}
+
+		// Echo the caller's own Origin back instead of a wildcard, and only ever
+		// after the guard above has validated it. No Origin header (e.g. the
+		// browser extension's background/service-worker context) means no
+		// browser is enforcing CORS for this response, so it's fine to omit.
+		if (guard.allowedOrigin) {
+			res.setHeader('Access-Control-Allow-Origin', guard.allowedOrigin);
+		}
 		res.setHeader('Access-Control-Allow-Methods', 'POST, OPTIONS');
 		res.setHeader('Access-Control-Allow-Headers', 'Content-Type');
 

--- a/src/server/config.test.ts
+++ b/src/server/config.test.ts
@@ -2,7 +2,7 @@ import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { SessionManager } from '@sessions';
 import { initTestEnvironment } from '@test';
-import { formatHostPort } from './config';
+import { formatHostPort, isLoopbackHost } from './config';
 
 const { suite, test, setup } = Mocha;
 
@@ -29,5 +29,48 @@ suite('Unit: formatHostPort', () => {
 	test('trims surrounding whitespace', () => {
 		assert.strictEqual(formatHostPort('  ::1  ', 27121), '[::1]:27121');
 		assert.strictEqual(formatHostPort(' 127.0.0.1 ', 27121), '127.0.0.1:27121');
+	});
+});
+
+suite('Unit: isLoopbackHost', () => {
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+	});
+
+	test('accepts every documented loopback form', () => {
+		assert.strictEqual(isLoopbackHost('127.0.0.1'), true);
+		assert.strictEqual(isLoopbackHost('localhost'), true);
+		assert.strictEqual(isLoopbackHost('::1'), true);
+		assert.strictEqual(isLoopbackHost('[::1]'), true);
+	});
+
+	test('is case-insensitive', () => {
+		assert.strictEqual(isLoopbackHost('LOCALHOST'), true);
+		assert.strictEqual(isLoopbackHost('LocalHost'), true);
+	});
+
+	test('trims surrounding whitespace', () => {
+		assert.strictEqual(isLoopbackHost('  127.0.0.1  '), true);
+		assert.strictEqual(isLoopbackHost(' localhost '), true);
+		assert.strictEqual(isLoopbackHost(' ::1 '), true);
+	});
+
+	test('rejects wildcard binds', () => {
+		assert.strictEqual(isLoopbackHost('0.0.0.0'), false);
+		assert.strictEqual(isLoopbackHost('::'), false);
+		assert.strictEqual(isLoopbackHost('[::]'), false);
+	});
+
+	test('rejects LAN, public, and arbitrary hostnames', () => {
+		assert.strictEqual(isLoopbackHost('192.168.1.10'), false);
+		assert.strictEqual(isLoopbackHost('10.0.0.5'), false);
+		assert.strictEqual(isLoopbackHost('8.8.8.8'), false);
+		assert.strictEqual(isLoopbackHost('example.com'), false);
+	});
+
+	test('rejects an empty host', () => {
+		assert.strictEqual(isLoopbackHost(''), false);
+		assert.strictEqual(isLoopbackHost('   '), false);
 	});
 });

--- a/src/server/config.ts
+++ b/src/server/config.ts
@@ -20,3 +20,15 @@ export function formatHostPort(host: string, port: number): string {
 	const needsBrackets = trimmed.includes(':') && !trimmed.startsWith('[');
 	return needsBrackets ? `[${trimmed}]:${port}` : `${trimmed}:${port}`;
 }
+
+const LOOPBACK_HOSTS = new Set(['127.0.0.1', 'localhost', '::1', '[::1]']);
+
+/**
+ * True only for the loopback host forms `rewst-buddy.server.host` is allowed to
+ * take (`127.0.0.1`, `localhost`, `::1`, `[::1]`, case-insensitive, surrounding
+ * whitespace trimmed). Anything else — wildcards (`0.0.0.0`, `::`), LAN/public
+ * addresses, or an arbitrary hostname — is not loopback and must not be bound.
+ */
+export function isLoopbackHost(host: string): boolean {
+	return LOOPBACK_HOSTS.has(host.trim().toLowerCase());
+}

--- a/src/server/handlers.test.ts
+++ b/src/server/handlers.test.ts
@@ -1,0 +1,283 @@
+import { LinkManager, SyncManager, TemplateLink } from '@models';
+import { SessionManager } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import { ServerResponse } from 'http';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { handleAddSession, handleOpenTemplate, validateRequest } from './handlers';
+import { AddSessionRequest, OpenTemplateRequest, Response } from './types';
+
+const { suite, test, setup, teardown } = Mocha;
+
+interface Restore {
+	restore(): void;
+}
+
+/** Replaces one method on a (real) object/singleton and returns a restore handle. */
+function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): Restore {
+	const original = obj[key];
+	Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+	return {
+		restore() {
+			Object.defineProperty(obj, key, { value: original, configurable: true, writable: true });
+		},
+	};
+}
+
+/** Records every sendResponse call so handler tests can assert on status/body without a real socket. */
+function createSendResponseSpy() {
+	const calls: { statusCode: number; body: Response }[] = [];
+	const sendResponse = (_res: ServerResponse, statusCode: number, body: Response) => {
+		calls.push({ statusCode, body });
+	};
+	return { calls, sendResponse };
+}
+
+const fakeRes = {} as ServerResponse;
+
+suite('Unit: validateRequest', () => {
+	setup(() => {
+		initTestEnvironment();
+	});
+
+	test('rejects a non-object request', () => {
+		assert.ok(validateRequest(null));
+		assert.ok(validateRequest('not json'));
+		assert.ok(validateRequest(42));
+	});
+
+	test('rejects a request missing action', () => {
+		const error = validateRequest({});
+		assert.ok(error);
+		assert.match(error!, /action/);
+	});
+
+	test('rejects addSession missing cookies', () => {
+		const error = validateRequest({ action: 'addSession' });
+		assert.ok(error);
+		assert.match(error!, /cookies/);
+	});
+
+	test('rejects addSession with empty cookies', () => {
+		const error = validateRequest({ action: 'addSession', cookies: '' });
+		assert.ok(error);
+		assert.match(error!, /[Cc]ookies/);
+	});
+
+	test('rejects openTemplate missing orgId', () => {
+		const error = validateRequest({ action: 'openTemplate', templateId: 'tpl-1' });
+		assert.ok(error);
+		assert.match(error!, /orgId/);
+	});
+
+	test('rejects openTemplate missing templateId', () => {
+		const error = validateRequest({ action: 'openTemplate', orgId: 'org-1' });
+		assert.ok(error);
+		assert.match(error!, /templateId/);
+	});
+
+	test('accepts a valid addSession request', () => {
+		assert.strictEqual(validateRequest({ action: 'addSession', cookies: 'cookie=value' }), null);
+	});
+
+	test('accepts a valid openTemplate request', () => {
+		assert.strictEqual(validateRequest({ action: 'openTemplate', orgId: 'org-1', templateId: 'tpl-1' }), null);
+	});
+});
+
+suite('Unit: handleAddSession', () => {
+	const restores: Restore[] = [];
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!.restore();
+		SessionManager._resetForTesting();
+	});
+
+	function request(cookies = 'cookie=value'): AddSessionRequest {
+		return { action: 'addSession', cookies };
+	}
+
+	test('reports success with the session label when the session validates', async () => {
+		const fakeSession = { validate: async () => true, profile: { label: 'My Session' } };
+		restores.push(
+			stub(SessionManager, 'createSession', (async () => fakeSession) as typeof SessionManager.createSession),
+		);
+
+		const { calls, sendResponse } = createSendResponseSpy();
+		await handleAddSession(request(), fakeRes, sendResponse);
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].statusCode, 200);
+		assert.strictEqual(calls[0].body.success, true);
+		assert.strictEqual((calls[0].body as { sessionLabel?: string }).sessionLabel, 'My Session');
+	});
+
+	test('reports a validation failure as 400 when the session created but did not validate', async () => {
+		const fakeSession = { validate: async () => false, profile: { label: 'My Session' } };
+		restores.push(
+			stub(SessionManager, 'createSession', (async () => fakeSession) as typeof SessionManager.createSession),
+		);
+
+		const { calls, sendResponse } = createSendResponseSpy();
+		await handleAddSession(request(), fakeRes, sendResponse);
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].statusCode, 400);
+		assert.strictEqual(calls[0].body.success, false);
+	});
+
+	test('reports a thrown error as 500 with the error message', async () => {
+		restores.push(
+			stub(SessionManager, 'createSession', (async () => {
+				throw new Error('boom');
+			}) as typeof SessionManager.createSession),
+		);
+
+		const { calls, sendResponse } = createSendResponseSpy();
+		await handleAddSession(request(), fakeRes, sendResponse);
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].statusCode, 500);
+		assert.strictEqual(calls[0].body.success, false);
+		assert.match((calls[0].body as { error: string }).error, /boom/);
+	});
+});
+
+suite('Unit: handleOpenTemplate', () => {
+	const restores: Restore[] = [];
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+	});
+
+	teardown(async () => {
+		while (restores.length) restores.pop()!.restore();
+		SessionManager._resetForTesting();
+		LinkManager._resetForTesting();
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+	});
+
+	function request(orgId: string, templateId: string): OpenTemplateRequest {
+		return { action: 'openTemplate', orgId, templateId };
+	}
+
+	test('refreshes and syncs an already-linked template', async () => {
+		const org = Fixtures.orgModel({ id: 'org-1', name: 'Test Org' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		const remoteTemplate = Fixtures.fullTemplate({
+			id: 'tpl-1',
+			orgId: 'org-1',
+			organization: Fixtures.org({ id: 'org-1', name: 'Test Org' }),
+		});
+		wrapper.when('getTemplate', { data: Fixtures.getTemplateQuery(remoteTemplate) });
+		SessionManager._setSessionsForTesting([session]);
+
+		const uri = vscode.Uri.file('/ws/existing.j2');
+		const existingTemplateLink: TemplateLink = {
+			type: 'Template',
+			uriString: uri.toString(),
+			org,
+			template: { id: 'tpl-1', name: 'Existing Template', updatedAt: '2024-01-01T00:00:00Z' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(existingTemplateLink);
+
+		const fakeDoc = { uri, getText: () => 'old content' } as unknown as vscode.TextDocument;
+		restores.push(
+			stub(
+				vscode.workspace,
+				'openTextDocument',
+				(async () => fakeDoc) as typeof vscode.workspace.openTextDocument,
+			),
+		);
+
+		const applyCalls: unknown[][] = [];
+		restores.push(
+			stub(SyncManager, 'applyTemplateToDocument', (async (...args: unknown[]) => {
+				applyCalls.push(args);
+			}) as typeof SyncManager.applyTemplateToDocument),
+		);
+
+		const { calls, sendResponse } = createSendResponseSpy();
+		await handleOpenTemplate(request('org-1', 'tpl-1'), fakeRes, sendResponse);
+
+		assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 1, 'fetches the remote template to sync');
+		assert.strictEqual(applyCalls.length, 1, 'applies the remote template to the linked document');
+		assert.strictEqual(applyCalls[0][0], fakeDoc);
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].statusCode, 200);
+		assert.strictEqual(calls[0].body.success, true);
+	});
+
+	test('fetches and links a brand-new template when no link exists', async () => {
+		const org = Fixtures.orgModel({ id: 'org-2', name: 'Org Two' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		const remoteTemplate = Fixtures.fullTemplate({
+			id: 'tpl-2',
+			orgId: 'org-2',
+			organization: Fixtures.org({ id: 'org-2', name: 'Org Two' }),
+		});
+		wrapper.when('getTemplate', { data: Fixtures.getTemplateQuery(remoteTemplate) });
+		SessionManager._setSessionsForTesting([session]);
+
+		const fixedUri = vscode.Uri.file('/ws/new-template.j2');
+		restores.push(stub(vscode.workspace, 'saveAs', (async () => fixedUri) as typeof vscode.workspace.saveAs));
+
+		const { calls, sendResponse } = createSendResponseSpy();
+		await handleOpenTemplate(request('org-2', 'tpl-2'), fakeRes, sendResponse);
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].statusCode, 200);
+		assert.strictEqual(calls[0].body.success, true);
+
+		const links = LinkManager.getTemplateLinkFromId('tpl-2');
+		assert.strictEqual(links.length, 1);
+		assert.strictEqual(links[0].uriString, fixedUri.toString());
+	});
+
+	test('reports success:false when the user cancels the save dialog', async () => {
+		const org = Fixtures.orgModel({ id: 'org-3', name: 'Org Three' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		const remoteTemplate = Fixtures.fullTemplate({
+			id: 'tpl-3',
+			orgId: 'org-3',
+			organization: Fixtures.org({ id: 'org-3', name: 'Org Three' }),
+		});
+		wrapper.when('getTemplate', { data: Fixtures.getTemplateQuery(remoteTemplate) });
+		SessionManager._setSessionsForTesting([session]);
+
+		restores.push(stub(vscode.workspace, 'saveAs', (async () => undefined) as typeof vscode.workspace.saveAs));
+
+		const { calls, sendResponse } = createSendResponseSpy();
+		await handleOpenTemplate(request('org-3', 'tpl-3'), fakeRes, sendResponse);
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].statusCode, 200);
+		assert.strictEqual(calls[0].body.success, false);
+		assert.strictEqual((calls[0].body as { error: string }).error, 'User cancelled save operation');
+		assert.deepStrictEqual(LinkManager.getTemplateLinkFromId('tpl-3'), []);
+	});
+
+	test('reports a thrown error as 500', async () => {
+		const org = Fixtures.orgModel({ id: 'org-4', name: 'Org Four' });
+		const { session, wrapper } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+		wrapper.when('getTemplate', { error: Fixtures.networkError('boom') });
+		SessionManager._setSessionsForTesting([session]);
+
+		const { calls, sendResponse } = createSendResponseSpy();
+		await handleOpenTemplate(request('org-4', 'tpl-4'), fakeRes, sendResponse);
+
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].statusCode, 500);
+		assert.strictEqual(calls[0].body.success, false);
+		assert.match((calls[0].body as { error: string }).error, /boom/);
+	});
+});

--- a/src/server/requestGuard.test.ts
+++ b/src/server/requestGuard.test.ts
@@ -96,6 +96,14 @@ suite('Unit: requestGuard', () => {
 			}
 		});
 
+		test('rejects opaque and malformed origins', () => {
+			for (const origin of ['null', 'blob:https://attacker.example/asset', 'not a url']) {
+				const result = evaluateRequestGuard(input({ headers: { host: '127.0.0.1:27121', origin } }));
+				assert.strictEqual(result.allowed, false, origin);
+				assert.strictEqual(result.allowedOrigin, undefined, origin);
+			}
+		});
+
 		test('allows and echoes back a loopback http(s) origin', () => {
 			for (const origin of ['http://localhost:5500', 'https://127.0.0.1:9999', 'http://[::1]:5500']) {
 				const result = evaluateRequestGuard(input({ headers: { host: '127.0.0.1:27121', origin } }));

--- a/src/server/requestGuard.test.ts
+++ b/src/server/requestGuard.test.ts
@@ -1,0 +1,124 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import { evaluateRequestGuard, RequestGuardInput } from './requestGuard';
+
+const { suite, test, setup } = Mocha;
+
+function input(overrides: Partial<RequestGuardInput> = {}): RequestGuardInput {
+	return {
+		remoteAddress: '127.0.0.1',
+		headers: { host: '127.0.0.1:27121' },
+		...overrides,
+	};
+}
+
+suite('Unit: requestGuard', () => {
+	setup(() => {
+		initTestEnvironment();
+	});
+
+	suite('remote address', () => {
+		test('allows a loopback remote address', () => {
+			for (const remoteAddress of ['127.0.0.1', '::1', '::ffff:127.0.0.1']) {
+				const result = evaluateRequestGuard(input({ remoteAddress }));
+				assert.strictEqual(result.allowed, true, remoteAddress);
+			}
+		});
+
+		test('rejects a non-loopback remote address before reading any body', () => {
+			const result = evaluateRequestGuard(input({ remoteAddress: '203.0.113.5' }));
+			assert.strictEqual(result.allowed, false);
+		});
+
+		test('rejects a missing remote address', () => {
+			const result = evaluateRequestGuard(input({ remoteAddress: undefined }));
+			assert.strictEqual(result.allowed, false);
+		});
+	});
+
+	suite('Host header', () => {
+		test('allows loopback host forms', () => {
+			for (const host of ['127.0.0.1:27121', 'localhost:27121', '[::1]:27121', 'localhost', '127.0.0.1']) {
+				const result = evaluateRequestGuard(input({ headers: { host } }));
+				assert.strictEqual(result.allowed, true, host);
+			}
+		});
+
+		test('is case-insensitive', () => {
+			const result = evaluateRequestGuard(input({ headers: { host: 'LOCALHOST:27121' } }));
+			assert.strictEqual(result.allowed, true);
+		});
+
+		test('rejects a non-local Host header', () => {
+			const result = evaluateRequestGuard(input({ headers: { host: 'attacker.example' } }));
+			assert.strictEqual(result.allowed, false);
+		});
+
+		test('rejects a missing Host header', () => {
+			const result = evaluateRequestGuard(input({ headers: {} }));
+			assert.strictEqual(result.allowed, false);
+		});
+
+		test('rejects a malformed Host header', () => {
+			const result = evaluateRequestGuard(input({ headers: { host: 'foo:bar:baz' } }));
+			assert.strictEqual(result.allowed, false);
+		});
+	});
+
+	suite('X-Forwarded-Host', () => {
+		test('rejects a non-loopback forwarded host even when Host is loopback', () => {
+			const result = evaluateRequestGuard(
+				input({ headers: { host: '127.0.0.1:27121', 'x-forwarded-host': 'attacker.example' } }),
+			);
+			assert.strictEqual(result.allowed, false);
+		});
+
+		test('allows a loopback forwarded host', () => {
+			const result = evaluateRequestGuard(
+				input({ headers: { host: '127.0.0.1:27121', 'x-forwarded-host': 'localhost:27121' } }),
+			);
+			assert.strictEqual(result.allowed, true);
+		});
+	});
+
+	suite('Origin header', () => {
+		test('allows a request with no Origin header and omits an echoed origin', () => {
+			const result = evaluateRequestGuard(input({ headers: { host: '127.0.0.1:27121' } }));
+			assert.strictEqual(result.allowed, true);
+			assert.strictEqual(result.allowedOrigin, undefined);
+		});
+
+		test('rejects a non-loopback http(s) web origin', () => {
+			for (const origin of ['http://attacker.example', 'https://attacker.example']) {
+				const result = evaluateRequestGuard(input({ headers: { host: '127.0.0.1:27121', origin } }));
+				assert.strictEqual(result.allowed, false, origin);
+			}
+		});
+
+		test('allows and echoes back a loopback http(s) origin', () => {
+			for (const origin of ['http://localhost:5500', 'https://127.0.0.1:9999', 'http://[::1]:5500']) {
+				const result = evaluateRequestGuard(input({ headers: { host: '127.0.0.1:27121', origin } }));
+				assert.strictEqual(result.allowed, true, origin);
+				assert.strictEqual(result.allowedOrigin, origin, origin);
+			}
+		});
+
+		test('allows and echoes back a browser-extension origin', () => {
+			for (const origin of ['chrome-extension://abcdefghijklmnop', 'moz-extension://12345678-1234-1234-1234']) {
+				const result = evaluateRequestGuard(input({ headers: { host: '127.0.0.1:27121', origin } }));
+				assert.strictEqual(result.allowed, true, origin);
+				assert.strictEqual(result.allowedOrigin, origin, origin);
+			}
+		});
+	});
+
+	test('allows a fully local preflight-shaped request', () => {
+		const result = evaluateRequestGuard({
+			remoteAddress: '127.0.0.1',
+			headers: { host: 'localhost:27121', origin: 'http://localhost:5500' },
+		});
+		assert.strictEqual(result.allowed, true);
+		assert.strictEqual(result.allowedOrigin, 'http://localhost:5500');
+	});
+});

--- a/src/server/requestGuard.ts
+++ b/src/server/requestGuard.ts
@@ -30,6 +30,7 @@ export interface RequestGuardResult {
 
 const LOOPBACK_REMOTE_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
 const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '::1']);
+const ALLOWED_EXTENSION_ORIGIN_PROTOCOLS = new Set(['chrome-extension:', 'moz-extension:']);
 
 function isLoopbackRemoteAddress(address: string | undefined): boolean {
 	return !!address && LOOPBACK_REMOTE_ADDRESSES.has(address.toLowerCase());
@@ -89,22 +90,23 @@ export function evaluateRequestGuard(input: RequestGuardInput): RequestGuardResu
 
 	const originHeader = input.headers.origin;
 	if (originHeader) {
-		let originUrl: URL | undefined;
+		let originUrl: URL;
 		try {
 			originUrl = new URL(originHeader);
 		} catch {
-			originUrl = undefined;
+			return { allowed: false, reason: `malformed Origin header: ${originHeader}` };
 		}
-		const isWebOrigin = originUrl?.protocol === 'http:' || originUrl?.protocol === 'https:';
-		// Web origins must be loopback to be allowed; a browser-extension scheme
-		// (chrome-extension:, moz-extension:) or anything else unparseable/opaque
-		// is allowed through — only an http(s) origin naming a remote host is the
-		// actual threat this guard defends against (the browser sets Host
-		// correctly regardless, so Host alone can't catch a cross-origin fetch()).
-		// `URL.host` carries the IPv6-bracketed form that hostnameOf() expects
-		// (`.hostname` strips the brackets, which our bracket-aware parser wants).
-		if (isWebOrigin && !isLoopbackHostname(hostnameOf(originUrl!.host))) {
-			return { allowed: false, reason: `non-loopback web origin: ${originHeader}` };
+		const isWebOrigin = originUrl.protocol === 'http:' || originUrl.protocol === 'https:';
+		const isAllowedExtensionOrigin = ALLOWED_EXTENSION_ORIGIN_PROTOCOLS.has(originUrl.protocol);
+		// Web origins must be loopback to be allowed. `URL.host` carries the
+		// IPv6-bracketed form that hostnameOf() expects (`.hostname` strips the
+		// brackets, which our bracket-aware parser wants).
+		if (isWebOrigin) {
+			if (!isLoopbackHostname(hostnameOf(originUrl.host))) {
+				return { allowed: false, reason: `non-loopback web origin: ${originHeader}` };
+			}
+		} else if (!isAllowedExtensionOrigin) {
+			return { allowed: false, reason: `disallowed Origin scheme: ${originHeader}` };
 		}
 	}
 

--- a/src/server/requestGuard.ts
+++ b/src/server/requestGuard.ts
@@ -1,0 +1,129 @@
+import { IncomingMessage } from 'http';
+
+/**
+ * The subset of an HTTP request the guard needs to decide loopback-only
+ * access. Kept as plain data (rather than `IncomingMessage`) so the decision
+ * logic is unit-testable without constructing a real socket — see
+ * `requestGuardInputFromRequest` for the adapter that builds this from a real
+ * request.
+ */
+export interface RequestGuardInput {
+	remoteAddress: string | undefined;
+	headers: {
+		host?: string;
+		'x-forwarded-host'?: string;
+		origin?: string;
+	};
+}
+
+export interface RequestGuardResult {
+	allowed: boolean;
+	/** Set only when `allowed` is false, for logging. */
+	reason?: string;
+	/**
+	 * The Origin header value to echo back as `Access-Control-Allow-Origin` when
+	 * `allowed` is true and the request sent one. Undefined when there was no
+	 * Origin header (no browser is enforcing CORS for that request anyway).
+	 */
+	allowedOrigin?: string;
+}
+
+const LOOPBACK_REMOTE_ADDRESSES = new Set(['127.0.0.1', '::1', '::ffff:127.0.0.1']);
+const LOOPBACK_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '::1']);
+
+function isLoopbackRemoteAddress(address: string | undefined): boolean {
+	return !!address && LOOPBACK_REMOTE_ADDRESSES.has(address.toLowerCase());
+}
+
+/**
+ * Strips a port suffix and IPv6 brackets from a `Host`-style header value,
+ * returning the bare hostname. Returns undefined for a value that can't be
+ * unambiguously parsed (treated as malformed/non-loopback by callers).
+ */
+function hostnameOf(headerValue: string): string | undefined {
+	const trimmed = headerValue.trim();
+	if (!trimmed) return undefined;
+
+	const bracketMatch = trimmed.match(/^\[([^\]]+)\](?::\d+)?$/);
+	if (bracketMatch) return bracketMatch[1].toLowerCase();
+
+	const colonCount = (trimmed.match(/:/g) ?? []).length;
+	if (colonCount === 0) return trimmed.toLowerCase();
+	if (colonCount === 1) {
+		const [host, port] = trimmed.split(':');
+		return /^\d+$/.test(port) ? host.toLowerCase() : undefined;
+	}
+	// Multiple colons with no brackets: an unbracketed IPv6 literal (or just
+	// malformed) — either way we can't safely split host from port.
+	return undefined;
+}
+
+function isLoopbackHostname(hostname: string | undefined): boolean {
+	return !!hostname && LOOPBACK_HOSTNAMES.has(hostname);
+}
+
+/**
+ * Decides whether a non-MCP request (session ingestion, template-open) may be
+ * served at all. Every check runs before any credential or action handling, so
+ * a rejection happens before the request body is ever read. See the
+ * credential-server spec's "Reject non-local HTTP requests" requirement.
+ */
+export function evaluateRequestGuard(input: RequestGuardInput): RequestGuardResult {
+	if (!isLoopbackRemoteAddress(input.remoteAddress)) {
+		return { allowed: false, reason: `non-loopback remote address: ${input.remoteAddress ?? '(none)'}` };
+	}
+
+	const hostHeader = input.headers.host;
+	if (!hostHeader) {
+		return { allowed: false, reason: 'missing Host header' };
+	}
+	const hostname = hostnameOf(hostHeader);
+	if (!isLoopbackHostname(hostname)) {
+		return { allowed: false, reason: `non-loopback or malformed Host header: ${hostHeader}` };
+	}
+
+	const forwardedHost = input.headers['x-forwarded-host'];
+	if (forwardedHost && !isLoopbackHostname(hostnameOf(forwardedHost))) {
+		return { allowed: false, reason: `non-loopback X-Forwarded-Host: ${forwardedHost}` };
+	}
+
+	const originHeader = input.headers.origin;
+	if (originHeader) {
+		let originUrl: URL | undefined;
+		try {
+			originUrl = new URL(originHeader);
+		} catch {
+			originUrl = undefined;
+		}
+		const isWebOrigin = originUrl?.protocol === 'http:' || originUrl?.protocol === 'https:';
+		// Web origins must be loopback to be allowed; a browser-extension scheme
+		// (chrome-extension:, moz-extension:) or anything else unparseable/opaque
+		// is allowed through — only an http(s) origin naming a remote host is the
+		// actual threat this guard defends against (the browser sets Host
+		// correctly regardless, so Host alone can't catch a cross-origin fetch()).
+		// `URL.host` carries the IPv6-bracketed form that hostnameOf() expects
+		// (`.hostname` strips the brackets, which our bracket-aware parser wants).
+		if (isWebOrigin && !isLoopbackHostname(hostnameOf(originUrl!.host))) {
+			return { allowed: false, reason: `non-loopback web origin: ${originHeader}` };
+		}
+	}
+
+	return { allowed: true, allowedOrigin: originHeader };
+}
+
+/** node lowercases header names; a repeated header arrives as an array. */
+function firstHeader(value: string | string[] | undefined): string | undefined {
+	return Array.isArray(value) ? value[0] : value;
+}
+
+/** Adapts a real Node `IncomingMessage` into the guard's plain input shape. */
+export function requestGuardInputFromRequest(req: IncomingMessage): RequestGuardInput {
+	return {
+		remoteAddress: req.socket.remoteAddress,
+		headers: {
+			host: firstHeader(req.headers.host),
+			'x-forwarded-host': firstHeader(req.headers['x-forwarded-host']),
+			origin: firstHeader(req.headers.origin),
+		},
+	};
+}

--- a/src/sessions/Session.test.ts
+++ b/src/sessions/Session.test.ts
@@ -2,7 +2,8 @@ import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { createServer, type Server } from 'http';
 import type { AddressInfo } from 'net';
-import { initTestEnvironment } from '@test';
+import vscode from 'vscode';
+import { initTestEnvironment, createMockSession } from '@test';
 import SessionProfile from './SessionProfile';
 import Session from './Session';
 
@@ -80,5 +81,134 @@ suite('Unit: Session', () => {
 		assert.strictEqual(receivedCookie, expectedCookie);
 		assert.match(receivedBody?.query ?? '', /query Check/);
 		assert.deepStrictEqual(receivedBody?.variables, { id: 'n-1' });
+	});
+
+	/** A local GraphQL-shaped server that answers every POST with a fixed `User` response, ignoring the query body. */
+	function userServer(user: unknown): Server {
+		return createServer((request, response) => {
+			let body = '';
+			request.on('data', chunk => {
+				body += String(chunk);
+			});
+			request.on('end', () => {
+				response.writeHead(200, { 'content-type': 'application/json' });
+				response.end(JSON.stringify({ data: { user } }));
+			});
+		});
+	}
+
+	suite('newSdk()', () => {
+		teardown(async () => {
+			await vscode.workspace
+				.getConfiguration('rewst-buddy')
+				.update('regions', undefined, vscode.ConfigurationTarget.Global);
+		});
+
+		test('probes configured regions in order and binds to the first that accepts the cookie', async () => {
+			const rejecting = userServer(null);
+			const accepting = userServer({
+				id: 'user-1',
+				username: 'eu-user',
+				organization: { id: 'org-eu', name: 'EU Org' },
+				allManagedOrgs: [{ id: 'org-eu', name: 'EU Org' }],
+			});
+			servers.push(rejecting, accepting);
+			const rejectingPort = await listen(rejecting);
+			const acceptingPort = await listen(accepting);
+
+			await vscode.workspace.getConfiguration('rewst-buddy').update(
+				'regions',
+				[
+					{
+						name: 'North America',
+						cookieName: 'appSession',
+						graphqlUrl: `http://127.0.0.1:${rejectingPort}/graphql`,
+						loginUrl: `http://127.0.0.1:${rejectingPort}`,
+					},
+					{
+						name: 'Europe',
+						cookieName: 'appSession',
+						graphqlUrl: `http://127.0.0.1:${acceptingPort}/graphql`,
+						loginUrl: `http://127.0.0.1:${acceptingPort}`,
+					},
+				],
+				vscode.ConfigurationTarget.Global,
+			);
+
+			const [, regionConfig] = await Session.newSdk('cookie-only-valid-in-europe');
+
+			assert.strictEqual(regionConfig.name, 'Europe');
+		});
+	});
+
+	suite('validate()', () => {
+		test('caches a successful validation for 24 hours, skipping re-validation on the next call', async () => {
+			const { session, wrapper } = createMockSession();
+
+			const first = await session.validate();
+			assert.strictEqual(first, true);
+			assert.strictEqual(wrapper.getCallsFor('User').length, 1);
+
+			const second = await session.validate();
+			assert.strictEqual(second, true);
+			assert.strictEqual(wrapper.getCallsFor('User').length, 1, 'cache hit should not re-query');
+		});
+	});
+
+	suite('refreshToken()', () => {
+		test('replaces the stored secret and the in-memory session with the refreshed cookie', async () => {
+			const orgId = 'org-refresh';
+			const oldCookie = 'appSession=old-cookie';
+			const newCookie = 'appSession=new-cookie';
+			let receivedLoginCookie = '';
+			let receivedGraphqlCookie = '';
+
+			const server = createServer((request, response) => {
+				if (request.method === 'GET') {
+					receivedLoginCookie = request.headers.cookie ?? '';
+					response.writeHead(200, { 'set-cookie': newCookie });
+					response.end();
+					return;
+				}
+
+				let body = '';
+				request.on('data', chunk => {
+					body += String(chunk);
+				});
+				request.on('end', () => {
+					receivedGraphqlCookie = request.headers.cookie ?? '';
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(JSON.stringify({ data: { user: { id: 'user-1' } } }));
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const context = initTestEnvironment();
+			await context.secrets.store(orgId, oldCookie);
+
+			const profile: SessionProfile = {
+				region: {
+					name: 'Local Test',
+					cookieName: 'appSession',
+					graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+					loginUrl: `http://127.0.0.1:${port}`,
+				},
+				org: { id: orgId, name: 'Refresh Org' },
+				allManagedOrgs: [{ id: orgId, name: 'Refresh Org' }],
+				label: 'Refresh Session',
+				user: { id: 'user-1' } as SessionProfile['user'],
+			};
+
+			const session = new Session(undefined, profile);
+			assert.strictEqual(session.sdk, undefined);
+
+			await session.refreshToken();
+
+			assert.strictEqual(receivedLoginCookie, oldCookie);
+			assert.strictEqual(await context.secrets.get(orgId), newCookie);
+			assert.notStrictEqual(session.sdk, undefined, 'refreshToken should replace the in-memory SDK');
+			assert.strictEqual(receivedGraphqlCookie, newCookie);
+		});
 	});
 });

--- a/src/sessions/Session.test.ts
+++ b/src/sessions/Session.test.ts
@@ -139,6 +139,38 @@ suite('Unit: Session', () => {
 
 			assert.strictEqual(regionConfig.name, 'Europe');
 		});
+
+		test('rejects when no configured region accepts the cookie', async () => {
+			const rejectingA = userServer(null);
+			const rejectingB = userServer(null);
+			servers.push(rejectingA, rejectingB);
+			const portA = await listen(rejectingA);
+			const portB = await listen(rejectingB);
+
+			await vscode.workspace.getConfiguration('rewst-buddy').update(
+				'regions',
+				[
+					{
+						name: 'North America',
+						cookieName: 'appSession',
+						graphqlUrl: `http://127.0.0.1:${portA}/graphql`,
+						loginUrl: `http://127.0.0.1:${portA}`,
+					},
+					{
+						name: 'Europe',
+						cookieName: 'appSession',
+						graphqlUrl: `http://127.0.0.1:${portB}/graphql`,
+						loginUrl: `http://127.0.0.1:${portB}`,
+					},
+				],
+				vscode.ConfigurationTarget.Global,
+			);
+
+			await assert.rejects(
+				() => Session.newSdk('cookie-rejected-everywhere'),
+				/could not initialize with any region/,
+			);
+		});
 	});
 
 	suite('validate()', () => {
@@ -152,6 +184,29 @@ suite('Unit: Session', () => {
 			const second = await session.validate();
 			assert.strictEqual(second, true);
 			assert.strictEqual(wrapper.getCallsFor('User').length, 1, 'cache hit should not re-query');
+		});
+
+		test('returns false without querying User when the session has no SDK', async () => {
+			const { session, wrapper } = createMockSession();
+			session.sdk = undefined;
+
+			const result = await session.validate();
+
+			assert.strictEqual(result, false);
+			assert.strictEqual(wrapper.getCallsFor('User').length, 0, 'User is not looked up without an SDK');
+		});
+
+		test('does not cache a failed validation, re-querying on the next call', async () => {
+			const { session, wrapper } = createMockSession();
+			wrapper.when('User', { data: { user: null } });
+
+			const first = await session.validate();
+			assert.strictEqual(first, false);
+			assert.strictEqual(wrapper.getCallsFor('User').length, 1);
+
+			const second = await session.validate();
+			assert.strictEqual(second, false);
+			assert.strictEqual(wrapper.getCallsFor('User').length, 2, 'a failed validation is re-run, not cached');
 		});
 	});
 
@@ -209,6 +264,92 @@ suite('Unit: Session', () => {
 			assert.strictEqual(await context.secrets.get(orgId), newCookie);
 			assert.notStrictEqual(session.sdk, undefined, 'refreshToken should replace the in-memory SDK');
 			assert.strictEqual(receivedGraphqlCookie, newCookie);
+		});
+
+		function refreshProfile(orgId: string, port: number): SessionProfile {
+			return {
+				region: {
+					name: 'Local Test',
+					cookieName: 'appSession',
+					graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+					loginUrl: `http://127.0.0.1:${port}`,
+				},
+				org: { id: orgId, name: 'Refresh Org' },
+				allManagedOrgs: [{ id: orgId, name: 'Refresh Org' }],
+				label: 'Refresh Session',
+				user: { id: 'user-1' } as SessionProfile['user'],
+			};
+		}
+
+		test('throws and leaves state untouched when the login response is not ok', async () => {
+			const orgId = 'org-refresh-not-ok';
+			const oldCookie = 'appSession=old-cookie';
+			const server = createServer((_request, response) => {
+				response.writeHead(500);
+				response.end();
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const context = initTestEnvironment();
+			await context.secrets.store(orgId, oldCookie);
+			const session = new Session(undefined, refreshProfile(orgId, port));
+
+			await assert.rejects(() => session.refreshToken(), /status 500/);
+			assert.strictEqual(await context.secrets.get(orgId), oldCookie, 'stored secret is unchanged');
+			assert.strictEqual(session.sdk, undefined, 'in-memory SDK is not set');
+		});
+
+		test('throws when the login response has no set-cookie header', async () => {
+			const orgId = 'org-refresh-no-cookie';
+			const oldCookie = 'appSession=old-cookie';
+			const server = createServer((_request, response) => {
+				response.writeHead(200);
+				response.end();
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const context = initTestEnvironment();
+			await context.secrets.store(orgId, oldCookie);
+			const session = new Session(undefined, refreshProfile(orgId, port));
+
+			await assert.rejects(() => session.refreshToken(), /missing set-cookie header/);
+			assert.strictEqual(await context.secrets.get(orgId), oldCookie, 'stored secret is unchanged');
+		});
+
+		test('throws when the refreshed cookie fails SDK validation', async () => {
+			const orgId = 'org-refresh-invalid';
+			const oldCookie = 'appSession=old-cookie';
+			const server = createServer((request, response) => {
+				if (request.method === 'GET') {
+					response.writeHead(200, { 'set-cookie': 'appSession=new-cookie' });
+					response.end();
+					return;
+				}
+				let body = '';
+				request.on('data', chunk => {
+					body += String(chunk);
+				});
+				request.on('end', () => {
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(JSON.stringify({ data: { user: null } }));
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const context = initTestEnvironment();
+			await context.secrets.store(orgId, oldCookie);
+			const session = new Session(undefined, refreshProfile(orgId, port));
+
+			await assert.rejects(() => session.refreshToken(), /new SDK validation failed/);
+			assert.strictEqual(
+				await context.secrets.get(orgId),
+				oldCookie,
+				'secret is not overwritten on validation failure',
+			);
+			assert.strictEqual(session.sdk, undefined, 'in-memory SDK is not set on validation failure');
 		});
 	});
 });

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -337,5 +337,33 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
 			assert.throws(() => SessionManager.getSessionForOrg('org-clear-primary'));
 		});
+
+		test('deletes secrets for profiles saved only in SessionProfiles', async () => {
+			const savedOnlyProfile: SessionProfile = {
+				region: {
+					name: 'Local Test',
+					cookieName: 'appSession',
+					graphqlUrl: 'http://127.0.0.1/graphql',
+					loginUrl: 'http://127.0.0.1',
+				},
+				org: { id: 'org-saved-primary', name: 'Saved Primary' },
+				allManagedOrgs: [
+					{ id: 'org-saved-primary', name: 'Saved Primary' },
+					{ id: 'org-saved-managed', name: 'Saved Managed' },
+				],
+				label: 'saved-user (Saved Primary)',
+				user: { id: 'saved-user' } as SessionProfile['user'],
+			};
+			await context.globalState.update('SessionProfiles', [savedOnlyProfile]);
+			await context.secrets.store('org-saved-primary', 'cookie-primary');
+			await context.secrets.store('org-saved-managed', 'cookie-managed');
+
+			await SessionManager.clearProfiles();
+
+			assert.strictEqual(await context.secrets.get('org-saved-primary'), undefined);
+			assert.strictEqual(await context.secrets.get('org-saved-managed'), undefined);
+			assert.deepStrictEqual(context.globalState.get('SessionProfiles'), []);
+			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+		});
 	});
 });

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -1,9 +1,67 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import vscode from 'vscode';
+import { context } from '@global';
 import { SessionManager, Session } from '@sessions';
 import { initTestEnvironment, createMockSession, Fixtures } from '@test';
+import SessionProfile from './SessionProfile';
 
 const { suite, test, setup, teardown } = Mocha;
+
+function listen(server: Server): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			server.off('error', reject);
+			resolve((server.address() as AddressInfo).port);
+		});
+	});
+}
+
+function close(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close(error => (error ? reject(error) : resolve()));
+	});
+}
+
+interface MockUser {
+	id: string;
+	username: string;
+	organization: { id: string; name: string };
+	allManagedOrgs: { id: string; name: string }[];
+}
+
+/** A local GraphQL-shaped server that answers every POST with a fixed `User` response, ignoring the query body. */
+function createUserServer(user: MockUser | null): Server {
+	return createServer((request, response) => {
+		let body = '';
+		request.on('data', chunk => {
+			body += String(chunk);
+		});
+		request.on('end', () => {
+			response.writeHead(200, { 'content-type': 'application/json' });
+			response.end(JSON.stringify({ data: { user } }));
+		});
+	});
+}
+
+function stubShowInputBox(impl: () => Promise<string | undefined>): () => void {
+	const original = vscode.window.showInputBox;
+	Object.defineProperty(vscode.window, 'showInputBox', {
+		value: impl,
+		configurable: true,
+		writable: true,
+	});
+	return () => {
+		Object.defineProperty(vscode.window, 'showInputBox', {
+			value: original,
+			configurable: true,
+			writable: true,
+		});
+	};
+}
 
 interface SessionSaver {
 	saveSession(session: Session): Promise<void>;
@@ -121,6 +179,163 @@ suite('Unit: SessionManager', () => {
 
 			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
 			assert.strictEqual(SessionManager.getProfileForOrg('org-x'), undefined);
+		});
+	});
+
+	suite('createSession()', () => {
+		let servers: Server[] = [];
+
+		setup(() => {
+			servers = [];
+		});
+
+		teardown(async () => {
+			await Promise.all(servers.map(server => close(server)));
+			await vscode.workspace
+				.getConfiguration('rewst-buddy')
+				.update('regions', undefined, vscode.ConfigurationTarget.Global);
+		});
+
+		test('valid cookie produces a session whose profile.label is "{username} ({orgName})"', async () => {
+			const server = createUserServer({
+				id: 'user-1',
+				username: 'jdoe',
+				organization: { id: 'org-create', name: 'Acme Co' },
+				allManagedOrgs: [{ id: 'org-create', name: 'Acme Co' }],
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			await vscode.workspace.getConfiguration('rewst-buddy').update(
+				'regions',
+				[
+					{
+						name: 'Local Test',
+						cookieName: 'appSession',
+						graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+						loginUrl: `http://127.0.0.1:${port}`,
+					},
+				],
+				vscode.ConfigurationTarget.Global,
+			);
+
+			// newSdk tries the "{cookieName}={token}" variant first, so a raw token
+			// (rather than a pre-formatted cookie) deterministically resolves to
+			// that variant on this always-accepting mock server.
+			const session = await SessionManager.createSession('raw-test-token');
+
+			assert.strictEqual(session.profile.label, 'jdoe (Acme Co)');
+			assert.strictEqual(SessionManager.getSessionForOrg('org-create'), session);
+			assert.strictEqual(await context.secrets.get('org-create'), 'appSession=raw-test-token');
+		});
+
+		test('empty input is rejected and no session is created', async () => {
+			const unstub = stubShowInputBox(async () => '');
+
+			try {
+				await assert.rejects(() => SessionManager.createSession());
+			} finally {
+				unstub();
+			}
+
+			assert.strictEqual(SessionManager.getActiveSessions().length, 0);
+		});
+	});
+
+	suite('loadSessions()', () => {
+		let servers: Server[] = [];
+
+		setup(() => {
+			servers = [];
+		});
+
+		teardown(async () => {
+			await Promise.all(servers.map(server => close(server)));
+			await vscode.workspace
+				.getConfiguration('rewst-buddy')
+				.update('regions', undefined, vscode.ConfigurationTarget.Global);
+		});
+
+		test('restores sessions from saved profiles and secrets on activation, without prompting', async () => {
+			const server = createUserServer({
+				id: 'user-1',
+				username: 'restored-user',
+				organization: { id: 'org-restore', name: 'Restored Org' },
+				allManagedOrgs: [{ id: 'org-restore', name: 'Restored Org' }],
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const region = {
+				name: 'Local Test',
+				cookieName: 'appSession',
+				graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+				loginUrl: `http://127.0.0.1:${port}`,
+			};
+			await vscode.workspace
+				.getConfiguration('rewst-buddy')
+				.update('regions', [region], vscode.ConfigurationTarget.Global);
+
+			const savedProfile: SessionProfile = {
+				region,
+				org: { id: 'org-restore', name: 'Restored Org' },
+				allManagedOrgs: [{ id: 'org-restore', name: 'Restored Org' }],
+				label: 'restored-user (Restored Org)',
+				user: { id: 'user-1' } as SessionProfile['user'],
+			};
+			await context.globalState.update('SessionProfiles', [savedProfile]);
+			await context.secrets.store('org-restore', 'appSession=restored-cookie');
+
+			let promptCalled = false;
+			const unstub = stubShowInputBox(async () => {
+				promptCalled = true;
+				return '';
+			});
+
+			let sessions: Session[];
+			try {
+				sessions = await SessionManager.loadSessions();
+			} finally {
+				unstub();
+			}
+
+			assert.strictEqual(sessions.length, 1);
+			assert.strictEqual(sessions[0].profile.org.id, 'org-restore');
+			assert.strictEqual(promptCalled, false, 'loadSessions must not prompt for a cookie');
+			assert.strictEqual(SessionManager.getSessionForOrg('org-restore'), sessions[0]);
+		});
+	});
+
+	suite('clearProfiles()', () => {
+		test('deletes secrets for primary and managed orgs, and clears known-profile state', async () => {
+			const { session } = createMockSession({
+				profile: {
+					org: { id: 'org-clear-primary', name: 'Primary' },
+					allManagedOrgs: [
+						{ id: 'org-clear-primary', name: 'Primary' },
+						{ id: 'org-clear-managed', name: 'Managed' },
+					],
+				},
+			});
+
+			// Primary-org secret plus a legacy managed-org secret key, both of which
+			// must be deleted by clearProfiles().
+			await context.secrets.store('org-clear-primary', 'cookie-primary');
+			await context.secrets.store('org-clear-managed', 'cookie-managed');
+
+			SessionManager._setSessionsForTesting([session]);
+			SessionManager._setKnownProfilesForTesting([session.profile]);
+
+			assert.strictEqual(await context.secrets.get('org-clear-primary'), 'cookie-primary');
+			assert.strictEqual(await context.secrets.get('org-clear-managed'), 'cookie-managed');
+			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 1);
+
+			await SessionManager.clearProfiles();
+
+			assert.strictEqual(await context.secrets.get('org-clear-primary'), undefined);
+			assert.strictEqual(await context.secrets.get('org-clear-managed'), undefined);
+			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+			assert.throws(() => SessionManager.getSessionForOrg('org-clear-primary'));
 		});
 	});
 });

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -348,18 +348,39 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 
 	public async clearProfiles(): Promise<void> {
 		log.debug('clearProfiles: clearing all sessions');
+
+		// Collect every profile about to be discarded (active sessions plus
+		// anything cached as a known profile) before clearing in-memory state, so
+		// every primary-org and legacy managed-org secret key gets deleted.
+		const profilesToClear = this.getActiveSessions()
+			.map(s => s.profile)
+			.concat(this.getAllKnownProfiles());
+
+		const orgIdsToClear = new Set<string>();
+		for (const profile of profilesToClear) {
+			orgIdsToClear.add(profile.org.id);
+			for (const managedOrg of profile.allManagedOrgs) {
+				orgIdsToClear.add(managedOrg.id);
+			}
+		}
+
+		await Promise.all(Array.from(orgIdsToClear).map(orgId => context.secrets.delete(orgId)));
+
 		await context.globalState.update('SessionProfiles', []);
+		await context.globalState.update('RewstAllKnownProfiles', []);
 		this.sessionMap.clear();
 		this.orgSessionIndex.clear();
+		this.knownProfilesCache = undefined;
+		this.knownProfileOrgIndex.clear();
 		this.setAnyActiveSessions(false);
 
 		this.sessionChangeEmitter.fire({
 			type: 'cleared',
-			allProfiles: this.getAllKnownProfiles(),
+			allProfiles: [],
 			activeProfiles: [],
 		});
 
-		log.trace('clearProfiles: cleared');
+		log.trace('clearProfiles: cleared', { secretsCleared: orgIdsToClear.size });
 	}
 
 	public getSessionForOrg(orgId: string): Session {

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -350,11 +350,12 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		log.debug('clearProfiles: clearing all sessions');
 
 		// Collect every profile about to be discarded (active sessions plus
-		// anything cached as a known profile) before clearing in-memory state, so
-		// every primary-org and legacy managed-org secret key gets deleted.
+		// anything cached or saved as a known profile) before clearing in-memory
+		// state, so every primary-org and legacy managed-org secret key gets deleted.
 		const profilesToClear = this.getActiveSessions()
 			.map(s => s.profile)
-			.concat(this.getAllKnownProfiles());
+			.concat(this.getAllKnownProfiles())
+			.concat(this.getSavedProfiles());
 
 		const orgIdsToClear = new Set<string>();
 		for (const profile of profilesToClear) {

--- a/src/utils/createAndLinkNewTemplate.test.ts
+++ b/src/utils/createAndLinkNewTemplate.test.ts
@@ -1,0 +1,78 @@
+import { LinkManager } from '@models';
+import { FullTemplateFragment } from '@sessions';
+import { Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { createAndLinkNewTemplate } from './createAndLinkNewTemplate';
+import { getHash } from './getHash';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * createAndLinkNewTemplate is the "Template not yet linked" flow shared by
+ * OpenTemplateFromURL and OpenTemplateInteractive: it opens an untitled
+ * document seeded with the fetched template body, prompts the user to save,
+ * and links the saved file. Everything except vscode.workspace.saveAs runs
+ * for real against the test extension host (untitled document creation,
+ * showTextDocument, edit) since that is cheap and exercises the real flow.
+ */
+suite('Unit: createAndLinkNewTemplate', () => {
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+	});
+
+	teardown(async () => {
+		while (restores.length) restores.pop()!();
+		LinkManager._resetForTesting();
+		await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+	});
+
+	function makeTemplate(overrides?: Partial<FullTemplateFragment>): FullTemplateFragment {
+		return Fixtures.fullTemplate({
+			id: 'tpl-new',
+			name: 'Brand New',
+			body: "// fetched template body\n{{ template('aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa') }}",
+			orgId: 'org-new',
+			organization: Fixtures.org({ id: 'org-new', name: 'New Org' }),
+			...overrides,
+		});
+	}
+
+	test('saves the fetched content and links the new file', async () => {
+		const template = makeTemplate();
+		const content = template.body;
+		const fixedUri = vscode.Uri.file('/ws/new-from-template.j2');
+		stub(vscode.workspace, 'saveAs', (async () => fixedUri) as typeof vscode.workspace.saveAs);
+
+		const result = await createAndLinkNewTemplate(template);
+
+		assert.strictEqual(result, true);
+		assert.strictEqual(LinkManager.isLinked(fixedUri), true);
+		const link = LinkManager.getTemplateLink(fixedUri);
+		assert.strictEqual(link.template.id, 'tpl-new');
+		assert.strictEqual(link.bodyHash, getHash(content), 'hash reflects the original fetched body');
+		assert.strictEqual(link.org.id, 'org-new');
+		assert.strictEqual(link.org.name, 'New Org');
+		assert.deepStrictEqual(link.referencedTemplateIds, ['aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa']);
+	});
+
+	test('returns false and links nothing when the user cancels the save dialog', async () => {
+		const template = makeTemplate({ id: 'tpl-cancelled', orgId: 'org-cancel' });
+		stub(vscode.workspace, 'saveAs', (async () => undefined) as typeof vscode.workspace.saveAs);
+
+		const result = await createAndLinkNewTemplate(template);
+
+		assert.strictEqual(result, false);
+		assert.deepStrictEqual(LinkManager.getTemplateLinkFromId('tpl-cancelled'), []);
+	});
+});

--- a/src/utils/requireUnlinked.test.ts
+++ b/src/utils/requireUnlinked.test.ts
@@ -1,0 +1,38 @@
+import { LinkManager, TemplateLink } from '@models';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { requireUnlinked } from './requireUnlinked';
+
+const { suite, test, setup, teardown } = Mocha;
+
+suite('Unit: requireUnlinked', () => {
+	setup(() => {
+		initTestEnvironment();
+		LinkManager._resetForTesting();
+	});
+
+	teardown(() => {
+		LinkManager._resetForTesting();
+	});
+
+	test('does not throw for a file with no link', () => {
+		const uri = vscode.Uri.file('/test/unlinked.j2');
+		assert.doesNotThrow(() => requireUnlinked(uri));
+	});
+
+	test('throws naming the existing template and org when the file is already linked', () => {
+		const uri = vscode.Uri.file('/test/linked.j2');
+		const link: TemplateLink = {
+			uriString: uri.toString(),
+			org: { id: 'org-1', name: 'Org One' },
+			type: 'Template',
+			template: { id: 'tpl-1', name: 'Existing Template', updatedAt: '', orgId: 'org-1' } as any,
+			bodyHash: 'hash',
+		};
+		LinkManager.addLink(link);
+
+		assert.throws(() => requireUnlinked(uri), /Already linked to Existing Template/);
+	});
+});

--- a/src/utils/templateUrl.test.ts
+++ b/src/utils/templateUrl.test.ts
@@ -1,0 +1,55 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { initTestEnvironment } from '@test';
+import { getTemplateURLParams } from './templateUrl';
+
+const { suite, test, setup } = Mocha;
+
+const ORG_ID = '11111111-1111-4111-8111-111111111111';
+const TEMPLATE_ID = '22222222-2222-4222-8222-222222222222';
+
+suite('Unit: getTemplateURLParams', () => {
+	setup(() => {
+		initTestEnvironment();
+	});
+
+	test('parses orgId, templateId and baseURL from a well-formed template URL', async () => {
+		const params = await getTemplateURLParams(
+			`https://app.rewst.io/organizations/${ORG_ID}/templates/${TEMPLATE_ID}`,
+		);
+
+		assert.strictEqual(params.orgId, ORG_ID);
+		assert.strictEqual(params.templateId, TEMPLATE_ID);
+		assert.strictEqual(params.baseURL.host, 'app.rewst.io');
+	});
+
+	test('rejects an undefined URL (user cancelled the input box)', async () => {
+		await assert.rejects(() => getTemplateURLParams(undefined), /not a string/);
+	});
+
+	test('rejects an empty string URL', async () => {
+		await assert.rejects(() => getTemplateURLParams(''), /not a string/);
+	});
+
+	test('rejects a string that is not a valid URL', async () => {
+		await assert.rejects(() => getTemplateURLParams('not a url'), /Invalid URL/);
+	});
+
+	test('rejects a URL whose path does not match the templates pattern', async () => {
+		await assert.rejects(() => getTemplateURLParams('https://app.rewst.io/something/else'), /path does not match/);
+	});
+
+	test('rejects a URL with a non-uuid org id', async () => {
+		await assert.rejects(
+			() => getTemplateURLParams(`https://app.rewst.io/organizations/not-a-uuid/templates/${TEMPLATE_ID}`),
+			/Org ID in URL is not valid uuid/,
+		);
+	});
+
+	test('rejects a URL with a non-uuid template id', async () => {
+		await assert.rejects(
+			() => getTemplateURLParams(`https://app.rewst.io/organizations/${ORG_ID}/templates/not-a-uuid`),
+			/Template ID in URL is not valid uuid/,
+		);
+	});
+});


### PR DESCRIPTION
## Summary
- Add OpenSpec baseline coverage for the major extension surfaces: AI chat, credential server, navigation, MCP bridge, sessions, template linking, template management, and sync.
- Capture follow-up changelog notes for clear-session secret handling and credential server host/CORS hardening.
- Backfill unit coverage around server guards, sessions, template and folder commands, link managers, sync managers, and template URL utilities.

## Test Plan
- [x] npm run test:unit


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added documentation for template linking, sync, chat, MCP tools, session handling, and language navigation behavior.
  * Expanded review rules to keep specs, tests, and behavior aligned.

* **Bug Fixes**
  * Improved session clearing so stored credentials and cached session data are fully removed.
  * Hardened local server access to loopback-only requests for better security.
  * Added tests and safeguards for template linking, syncing, opening, copying IDs, and folder/template management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->