### PR TITLE
Fix stale session resolution; add Remove Session command (#111)

### DIFF
--- a/changelog.d/remove-session.md
+++ b/changelog.d/remove-session.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Remove a single session** — Previously "Clear Sessions" was all-or-nothing. A new "Remove Session" command (also available by right-clicking a session in the Sessions view) removes one authenticated or previously authenticated session without touching the others (#111).

--- a/changelog.d/session-org-index-fallback.md
+++ b/changelog.d/session-org-index-fallback.md
@@ -2,4 +2,4 @@
 category: Fixed
 ---
 
-- **Org lookups skip stale sessions instead of failing** — When more than one signed-in session could manage the same org id, tools and commands could resolve to whichever session was indexed last, even if it had gone stale and another signed-in session for that org was still valid. Lookups now skip an invalid session and fall through to the next one that still works.
+- **Org lookups recover stale sessions instead of failing** — When more than one signed-in session could manage the same org id, tools and commands could resolve to whichever session was indexed last, even if it had gone stale and another signed-in session for that org was still valid. Lookups now try refreshing a stale session before falling through to another one that still works.

--- a/changelog.d/session-org-index-fallback.md
+++ b/changelog.d/session-org-index-fallback.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Org lookups skip stale sessions instead of failing** — When more than one signed-in session could manage the same org id, tools and commands could resolve to whichever session was indexed last, even if it had gone stale and another signed-in session for that org was still valid. Lookups now skip an invalid session and fall through to the next one that still works.

--- a/changelog.d/session-org-index-fallback.md
+++ b/changelog.d/session-org-index-fallback.md
@@ -2,4 +2,4 @@
 category: Fixed
 ---
 
-- **Org lookups recover stale sessions instead of failing** — When more than one signed-in session could manage the same org id, tools and commands could resolve to whichever session was indexed last, even if it had gone stale and another signed-in session for that org was still valid. Lookups now try refreshing a stale session before falling through to another one that still works.
+- **Org lookups recover stale sessions instead of failing** — A stale session sharing an org id with another signed-in session could block access to that org. Lookups now refresh a stale session, or fall through to another valid one, instead of failing.

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -46,6 +46,7 @@ All commands are available via Command Palette (Cmd/Ctrl + Shift + P) under the 
 **Session Management**
 
 - `New Rewst Session` — Add a new session with token
+- `Remove Session` — Remove one authenticated or previously authenticated session (also available by right-clicking it in the Sessions view)
 - `Clear Sessions` — Remove all saved sessions
 
 **Working Scope**

--- a/openspec/specs/language-navigation/spec.md
+++ b/openspec/specs/language-navigation/spec.md
@@ -59,6 +59,14 @@ cached metadata entry — and SHALL indicate when the template is unknown.
 - **WHEN** the user hovers it
 - **THEN** the hover shows the id and marks the template as unknown
 
+#### Scenario: Session removal drops orphaned cached metadata
+
+- **GIVEN** cached metadata loaded from a session that is then removed
+- **WHEN** no remaining session manages the removed session's orgs
+- **THEN** those orgs' cached entries are dropped, so hovers and navigation do
+  not offer templates whose session is gone
+- **AND** metadata for orgs a remaining session manages stays available
+
 ### Requirement: Navigate to the referenced template
 
 On Ctrl+Click of a recognized reference, the system SHALL navigate to the linked

--- a/openspec/specs/language-navigation/spec.md
+++ b/openspec/specs/language-navigation/spec.md
@@ -66,6 +66,8 @@ cached metadata entry — and SHALL indicate when the template is unknown.
 - **THEN** those orgs' cached entries are dropped, so hovers and navigation do
   not offer templates whose session is gone
 - **AND** metadata for orgs a remaining session manages stays available
+- **AND** a metadata load already in flight at removal cannot re-insert the
+  dropped entries
 
 ### Requirement: Navigate to the referenced template
 

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -230,3 +230,41 @@ active.
 - **THEN** known profiles and their primary-org and legacy managed-org secrets
   are removed
 - **AND** future startup does not restore those sessions without a new cookie
+
+### Requirement: Remove a single session
+
+The system SHALL provide a way to remove one authenticated or previously
+authenticated session — active or known-only — without disturbing any other
+session. Removing a session SHALL delete its raw cookie(s) from VS Code
+`secrets` (primary organization key and any legacy managed-organization keys),
+remove its profile from `SessionProfiles` (if active) and `RewstAllKnownProfiles`,
+and clear its entries from in-memory sessions and org indexes. If the removed
+session was the only active session, extension context SHALL be updated so no
+session is considered active.
+
+#### Scenario: User removes one active session from the Sessions tree
+
+- **GIVEN** two or more active sessions
+- **WHEN** the user right-clicks one in the Sessions tree and runs "Remove
+  Session"
+- **THEN** that session's cookie is deleted from `secrets`
+- **AND** its profile is removed from `SessionProfiles` and
+  `RewstAllKnownProfiles`
+- **AND** no org id it managed resolves to it any longer
+- **AND** every other active session is unaffected
+
+#### Scenario: User removes a known-only (previously authenticated) session
+
+- **GIVEN** no active session, but `RewstAllKnownProfiles` contains a
+  previously saved profile
+- **WHEN** the user runs `Rewst Buddy: Remove Session` and picks that profile
+- **THEN** its cookie is deleted from `secrets`
+- **AND** it is removed from `RewstAllKnownProfiles`
+- **AND** future startup does not restore it without a new cookie
+
+#### Scenario: Removing the last active session clears the active-sessions context
+
+- **GIVEN** exactly one active session
+- **WHEN** the user removes it
+- **THEN** the extension no longer considers any session active
+- **AND** the background credential-refresh interval stops

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -131,8 +131,9 @@ active sessions in that region and then match the requested org against primary
 and managed org ids. More than one active session being able to manage the same
 org id is not an error: resolution SHALL return the first capable session.
 Resolution SHALL only return a session that is still valid (per the
-`Cache validation` requirement), skipping a session whose validation fails in
-favor of the next capable session.
+`Cache validation` requirement) or that becomes valid after one credential
+refresh attempt; a session is skipped in favor of the next capable session
+only if it remains invalid after that refresh attempt.
 
 #### Scenario: Operation targets a managed sub-org
 
@@ -149,7 +150,8 @@ favor of the next capable session.
 #### Scenario: Resolution skips a session that is no longer valid
 
 - **GIVEN** an active session that can manage the requested org id
-- **AND** that session's validation fails
+- **AND** that session's validation fails, and a credential refresh attempt
+  also fails to recover it
 - **WHEN** a session is resolved for that org
 - **THEN** the invalid session is not returned
 - **AND** resolution falls through to the next still-valid capable session, or

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -134,11 +134,6 @@ Resolution SHALL only return a session that is still valid (per the
 `Cache validation` requirement), skipping a session whose validation fails in
 favor of the next capable session.
 
-**Implementation status:** region-scoped resolution matches managed sub-orgs
-and skips sessions whose validation fails. The region-less index lookup does
-not yet re-validate the session it returns; extending the still-valid
-guarantee to that path is tracked as follow-up work.
-
 #### Scenario: Operation targets a managed sub-org
 
 - **GIVEN** a session whose login manages a parent org and several sub-orgs

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -155,6 +155,16 @@ favor of the next capable session.
 - **AND** resolution falls through to the next still-valid capable session, or
   fails when none remains
 
+#### Scenario: A stale-but-refreshable session recovers instead of being skipped
+
+- **GIVEN** an active session that can manage the requested org id
+- **AND** that session's cached validation has failed, but its cookie still
+  logs in
+- **WHEN** a session is resolved for that org without a base URL or region
+- **THEN** the extension refreshes the session's credentials
+- **AND** the refreshed session is returned rather than being treated as
+  unreachable or skipped in favor of a worse fallback
+
 #### Scenario: URL targets a managed sub-org in the session region
 
 - **GIVEN** a Rewst URL whose base URL identifies the European region

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -249,10 +249,14 @@ The system SHALL provide a way to remove one authenticated or previously
 authenticated session — active or known-only — without disturbing any other
 session. Removing a session SHALL delete its raw cookie(s) from VS Code
 `secrets` (primary organization key and any legacy managed-organization keys),
-remove its profile from `SessionProfiles` (if active) and `RewstAllKnownProfiles`,
-and clear its entries from in-memory sessions and org indexes. If the removed
+except keys another remaining profile still needs, remove its profile from
+`SessionProfiles` (if active) and `RewstAllKnownProfiles`, and clear its
+entries from in-memory sessions and org indexes before any persistence await,
+so the session stops resolving the moment removal is confirmed. If the removed
 session was the only active session, extension context SHALL be updated so no
-session is considered active.
+session is considered active. A removal that races the startup session load
+SHALL win: the load must not restore the removed session or re-store its
+cookie.
 
 #### Scenario: User removes one active session from the Sessions tree
 
@@ -280,3 +284,24 @@ session is considered active.
 - **WHEN** the user removes it
 - **THEN** the extension no longer considers any session active
 - **AND** the background credential-refresh interval stops
+
+#### Scenario: A secret shared with another profile survives removal
+
+- **GIVEN** session A whose managed orgs include the primary org of session B
+- **WHEN** the user removes session A
+- **THEN** session A's own cookie is deleted from `secrets`
+- **AND** the cookie stored under session B's primary org id is kept
+- **AND** session B still resolves for its orgs
+
+#### Scenario: A session being removed stops resolving immediately
+
+- **GIVEN** an active session being removed
+- **WHEN** an org lookup runs concurrently with the removal
+- **THEN** the lookup does not resolve to the session being removed
+
+#### Scenario: Removal during the startup load is not undone
+
+- **GIVEN** the startup session load is restoring a saved profile
+- **WHEN** the user removes that session before the restore completes
+- **THEN** the completed load does not resurrect the session
+- **AND** its cookie is not re-stored in `secrets`

--- a/openspec/specs/template-sync/spec.md
+++ b/openspec/specs/template-sync/spec.md
@@ -303,3 +303,11 @@ fetched.
   present locally
 - **THEN** the missing templates are written as local files, linked, and the user
   is notified of the count fetched
+
+#### Scenario: One folder's failure does not stop the others
+
+- **GIVEN** several linked folders, one of whose orgs has no usable session
+  (for example, its session was removed)
+- **WHEN** the background fetch runs
+- **THEN** the failing folder is skipped with a logged error
+- **AND** the remaining folders are still fetched

--- a/package.json
+++ b/package.json
@@ -289,6 +289,16 @@
 				"title": "Rewst Buddy: Clear Sessions"
 			},
 			{
+				"command": "rewst-buddy.prefix.RemoveSession",
+				"title": "Rewst Buddy: Remove Session",
+				"icon": "$(trash)"
+			},
+			{
+				"command": "rewst-buddy.RemoveSession",
+				"title": "Remove Session",
+				"icon": "$(trash)"
+			},
+			{
 				"command": "rewst-buddy.prefix.OpenTemplateFromURL",
 				"title": "Rewst Buddy: Open Template from URL"
 			},
@@ -484,6 +494,14 @@
 					"when": "rewst-buddy.anyActiveSessions"
 				},
 				{
+					"command": "rewst-buddy.prefix.RemoveSession",
+					"when": "rewst-buddy.anyActiveSessions"
+				},
+				{
+					"command": "rewst-buddy.RemoveSession",
+					"when": "false"
+				},
+				{
 					"command": "rewst-buddy.prefix.OpenTemplateFromURL",
 					"when": "rewst-buddy.anyActiveSessions"
 				},
@@ -630,6 +648,11 @@
 					"command": "rewst-buddy.DeleteTemplate",
 					"when": "viewItem == bundleTemplate && rewst-buddy.anyActiveSessions",
 					"group": "z_rewst@5"
+				},
+				{
+					"command": "rewst-buddy.RemoveSession",
+					"when": "viewItem == session",
+					"group": "z_rewst@1"
 				}
 			],
 			"editor/context": [

--- a/package.json
+++ b/package.json
@@ -494,10 +494,6 @@
 					"when": "rewst-buddy.anyActiveSessions"
 				},
 				{
-					"command": "rewst-buddy.prefix.RemoveSession",
-					"when": "rewst-buddy.anyActiveSessions"
-				},
-				{
 					"command": "rewst-buddy.RemoveSession",
 					"when": "false"
 				},

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -1,12 +1,13 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
 import { LinkManager, type SyncDecision, type SyncDecisionContext, type TemplateLink } from '@models';
-import type { FullTemplateFragment, Session } from '@sessions';
+import { SessionManager, type FullTemplateFragment, type Session } from '@sessions';
 import vscode from 'vscode';
 import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import {
+	defaultTemplateSyncDeps,
 	matchLinkByPath,
 	resolveLinkedUri,
 	runSync,
@@ -501,6 +502,73 @@ suite('Unit: templateSyncCapabilities', () => {
 			addTemplateLink('/ws/b/dup.j2', 'org-1', 't-b');
 			assert.strictEqual(resolveLinkedUri('dup.j2'), undefined);
 			assert.strictEqual(resolveLinkedUri('/ws/a/dup.j2')?.link.template.id, 't-a');
+		});
+	});
+
+	suite('defaultTemplateSyncDeps.upload', () => {
+		setup(() => {
+			SessionManager._resetForTesting();
+		});
+
+		teardown(() => {
+			SessionManager._resetForTesting();
+		});
+
+		test('resolves the session fresh at upload time instead of reusing target.context.session', async () => {
+			const org = { id: 'org-upload-fresh', name: 'Upload Fresh' };
+			const uri = addTemplateLink('/ws/upload-fresh.j2', org.id, 'tpl-upload-fresh');
+			const link = LinkManager.getTemplateLink(uri);
+
+			// The session captured in target.context (e.g. before an approval
+			// prompt) must not be the one used at mutation time.
+			const { session: staleSession, wrapper: staleWrapper } = createMockSession({
+				profile: { org, allManagedOrgs: [org] },
+			});
+			const { session: freshSession, wrapper: freshWrapper } = createMockSession({
+				profile: { org, allManagedOrgs: [org] },
+			});
+			freshWrapper.when('updateTemplateBody', {
+				data: Fixtures.updateTemplateBodyMutation({
+					id: 'tpl-upload-fresh',
+					name: 'Greeting',
+					updatedAt: 'ts-uploaded',
+					orgId: org.id,
+				}),
+			});
+			SessionManager._setSessionsForTesting([freshSession]);
+
+			const doc = { uri, getText: () => 'local body' } as unknown as vscode.TextDocument;
+			const target: TemplateSyncTarget = {
+				uri,
+				doc,
+				dirty: false,
+				context: {
+					link,
+					session: staleSession,
+					remoteTemplate: {
+						id: 'tpl-upload-fresh',
+						name: 'Greeting',
+						body: 'remote',
+						updatedAt: '1',
+						orgId: org.id,
+					},
+					localBody: 'local body',
+					decision: { action: 'upload-local' },
+				} as unknown as SyncDecisionContext,
+			};
+
+			await defaultTemplateSyncDeps.upload(target);
+
+			assert.strictEqual(
+				staleWrapper.getCallsFor('updateTemplateBody').length,
+				0,
+				'the session captured on target.context must not be used for the upload',
+			);
+			assert.strictEqual(
+				freshWrapper.getCallsFor('updateTemplateBody').length,
+				1,
+				'the freshly-resolved session should receive the upload',
+			);
 		});
 	});
 

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -570,6 +570,46 @@ suite('Unit: templateSyncCapabilities', () => {
 				'the freshly-resolved session should receive the upload',
 			);
 		});
+
+		test('propagates a clear error when no session remains for the org at upload time', async () => {
+			const org = { id: 'org-upload-missing', name: 'Upload Missing' };
+			const uri = addTemplateLink('/ws/upload-missing.j2', org.id, 'tpl-upload-missing');
+			const link = LinkManager.getTemplateLink(uri);
+			const { session: staleSession, wrapper: staleWrapper } = createMockSession({
+				profile: { org, allManagedOrgs: [org] },
+			});
+
+			// No session registered for the org — simulates removal while the
+			// approval prompt was pending.
+			SessionManager._setSessionsForTesting([]);
+
+			const doc = { uri, getText: () => 'local body' } as unknown as vscode.TextDocument;
+			const target: TemplateSyncTarget = {
+				uri,
+				doc,
+				dirty: false,
+				context: {
+					link,
+					session: staleSession,
+					remoteTemplate: {
+						id: 'tpl-upload-missing',
+						name: 'Greeting',
+						body: 'remote',
+						updatedAt: '1',
+						orgId: org.id,
+					},
+					localBody: 'local body',
+					decision: { action: 'upload-local' },
+				} as unknown as SyncDecisionContext,
+			};
+
+			await assert.rejects(() => defaultTemplateSyncDeps.upload(target), /no session found/);
+			assert.strictEqual(
+				staleWrapper.getCallsFor('updateTemplateBody').length,
+				0,
+				'the stale session captured on target.context must not be used as a fallback',
+			);
+		});
 	});
 
 	suite('capability descriptors', () => {

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -7,6 +7,7 @@ import {
 	type SyncDecisionContext,
 	type TemplateLink,
 } from '@models';
+import { SessionManager } from '@sessions';
 import vscode from 'vscode';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
 import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
@@ -131,7 +132,12 @@ export const defaultTemplateSyncDeps: TemplateSyncDeps = {
 		}
 	},
 	async upload(target) {
-		await SyncManager.updateTemplateBody(target.doc);
+		// Re-resolve rather than reusing target.context.session: upload() runs
+		// behind the per-call VS Code approval prompt, which can wait
+		// indefinitely for the user, during which that session could be
+		// refreshed, removed, or replaced.
+		const session = await SessionManager.getSessionForOrg(target.context.link.org.id);
+		await SyncManager.updateTemplateBody(target.doc, session);
 		const link = LinkManager.getTemplateLink(target.uri);
 		return { templateId: link.template.id, name: link.template.name, updatedAt: link.template.updatedAt };
 	},

--- a/src/commands/sessions/RemoveSession.test.ts
+++ b/src/commands/sessions/RemoveSession.test.ts
@@ -1,0 +1,137 @@
+import { SessionManager } from '@sessions';
+import { SessionTreeItem } from '@ui';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import { RemoveSession } from './RemoveSession';
+
+const { suite, test, setup, teardown } = Mocha;
+
+/**
+ * RemoveSession drives the "remove one authenticated or previously
+ * authenticated session" flow (issue #111): resolve a profile from a
+ * Sessions-tree context menu item or, from the command palette, a quick pick
+ * across every known profile, confirm with a modal, then delegate to
+ * SessionManager.removeSession.
+ */
+suite('Unit: RemoveSession', () => {
+	const restores: (() => void)[] = [];
+
+	function stub<T extends object, K extends keyof T>(obj: T, key: K, impl: T[K]): void {
+		const original = obj[key];
+		Object.defineProperty(obj, key, { value: impl, configurable: true, writable: true });
+		restores.push(() => Object.defineProperty(obj, key, { value: original, configurable: true, writable: true }));
+	}
+
+	function stubConfirm(response: 'Remove' | undefined): void {
+		stub(
+			vscode.window,
+			'showWarningMessage',
+			(async () => response) as unknown as typeof vscode.window.showWarningMessage,
+		);
+	}
+
+	function stubQuickPick(selectLabel: string | undefined): void {
+		stub(vscode.window, 'showQuickPick', (async (items: { label: string }[]) =>
+			selectLabel === undefined
+				? undefined
+				: items.find(item => item.label === selectLabel)) as unknown as typeof vscode.window.showQuickPick);
+	}
+
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+	});
+
+	test('removes the session for a Sessions-tree context menu item after confirmation', async () => {
+		const { session } = createMockSession({
+			profile: {
+				user: Fixtures.userFragment({ id: 'user-tree-remove' }),
+				org: { id: 'org-tree-remove', name: 'Tree Remove' },
+				allManagedOrgs: [{ id: 'org-tree-remove', name: 'Tree Remove' }],
+			},
+		});
+		SessionManager._setSessionsForTesting([session]);
+		const item = new SessionTreeItem(session.profile, true, vscode.TreeItemCollapsibleState.None);
+		stubConfirm('Remove');
+
+		await new RemoveSession().execute([item]);
+
+		assert.strictEqual(SessionManager.getActiveSessions().length, 0);
+		assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+	});
+
+	test('does nothing when the user dismisses the confirmation', async () => {
+		const { session } = createMockSession({
+			profile: {
+				user: Fixtures.userFragment({ id: 'user-keep' }),
+				org: { id: 'org-keep', name: 'Keep' },
+				allManagedOrgs: [{ id: 'org-keep', name: 'Keep' }],
+			},
+		});
+		SessionManager._setSessionsForTesting([session]);
+		const item = new SessionTreeItem(session.profile, true, vscode.TreeItemCollapsibleState.None);
+		stubConfirm(undefined);
+
+		await new RemoveSession().execute([item]);
+
+		assert.strictEqual(SessionManager.getActiveSessions().length, 1);
+	});
+
+	test('falls back to a picker across known profiles when run from the command palette', async () => {
+		const { session } = createMockSession({
+			profile: {
+				user: Fixtures.userFragment({ id: 'user-palette' }),
+				org: { id: 'org-palette', name: 'Palette Org' },
+				allManagedOrgs: [{ id: 'org-palette', name: 'Palette Org' }],
+			},
+		});
+		SessionManager._setKnownProfilesForTesting([session.profile]);
+		stubConfirm('Remove');
+
+		await new RemoveSession().execute();
+
+		assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+	});
+
+	test('picks the selected profile out of several known profiles and removes only it', async () => {
+		const { session: keep } = createMockSession({
+			profile: {
+				label: 'Keep Me',
+				user: Fixtures.userFragment({ id: 'user-multi-keep' }),
+				org: { id: 'org-multi-keep', name: 'Keep Me' },
+				allManagedOrgs: [{ id: 'org-multi-keep', name: 'Keep Me' }],
+			},
+		});
+		const { session: remove } = createMockSession({
+			profile: {
+				label: 'Remove Me',
+				user: Fixtures.userFragment({ id: 'user-multi-remove' }),
+				org: { id: 'org-multi-remove', name: 'Remove Me' },
+				allManagedOrgs: [{ id: 'org-multi-remove', name: 'Remove Me' }],
+			},
+		});
+		SessionManager._setKnownProfilesForTesting([keep.profile, remove.profile]);
+		stubQuickPick('Remove Me');
+		stubConfirm('Remove');
+
+		await new RemoveSession().execute();
+
+		const remaining = SessionManager.getAllKnownProfiles();
+		assert.strictEqual(remaining.length, 1);
+		assert.strictEqual(remaining[0].user.id, 'user-multi-keep');
+	});
+
+	test('does nothing when there are no known sessions to remove', async () => {
+		await new RemoveSession().execute();
+
+		assert.strictEqual(SessionManager.getActiveSessions().length, 0);
+		assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+	});
+});

--- a/src/commands/sessions/RemoveSession.test.ts
+++ b/src/commands/sessions/RemoveSession.test.ts
@@ -1,6 +1,7 @@
 import { SessionManager } from '@sessions';
 import { SessionTreeItem } from '@ui';
 import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import { log } from '@utils';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import vscode from 'vscode';
@@ -65,6 +66,31 @@ suite('Unit: RemoveSession', () => {
 
 		assert.strictEqual(SessionManager.getActiveSessions().length, 0);
 		assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+	});
+
+	test('notifies the user when SessionManager.removeSession fails', async () => {
+		const { session } = createMockSession({
+			profile: {
+				user: Fixtures.userFragment({ id: 'user-remove-fails' }),
+				org: { id: 'org-remove-fails', name: 'Remove Fails' },
+				allManagedOrgs: [{ id: 'org-remove-fails', name: 'Remove Fails' }],
+			},
+		});
+		SessionManager._setSessionsForTesting([session]);
+		const item = new SessionTreeItem(session.profile, true, vscode.TreeItemCollapsibleState.None);
+		stubConfirm('Remove');
+		stub(SessionManager, 'removeSession', (async () => {
+			throw new Error('boom');
+		}) as unknown as typeof SessionManager.removeSession);
+		let notifiedMessage: string | undefined;
+		stub(log, 'notifyError', ((message: string) => {
+			notifiedMessage = message;
+			return new Error(message);
+		}) as unknown as typeof log.notifyError);
+
+		await new RemoveSession().execute([item]);
+
+		assert.match(notifiedMessage ?? '', /Failed to remove session: Error: boom/);
 	});
 
 	test('does nothing when the user dismisses the confirmation', async () => {

--- a/src/commands/sessions/RemoveSession.ts
+++ b/src/commands/sessions/RemoveSession.ts
@@ -1,0 +1,41 @@
+import { SessionManager, SessionProfile } from '@sessions';
+import { SessionTreeItem, pickKnownProfile } from '@ui';
+import { log } from '@utils';
+import vscode from 'vscode';
+import GenericCommand from '../GenericCommand';
+
+export class RemoveSession extends GenericCommand {
+	commandName = 'RemoveSession';
+
+	async execute(...args: unknown[]): Promise<void> {
+		const profile = await this.resolveProfile(args);
+		if (!profile) return;
+
+		const userId = profile.user.id;
+		if (!userId) {
+			log.notifyError(`RemoveSession: profile '${profile.label}' has no user id`);
+			return;
+		}
+
+		const confirm = await vscode.window.showWarningMessage(
+			`Remove session "${profile.label}"? Its stored credentials will be deleted.`,
+			{ modal: true },
+			'Remove',
+		);
+		if (confirm !== 'Remove') return;
+
+		try {
+			await SessionManager.removeSession(userId);
+			log.notifyInfo(`Removed session '${profile.label}'`);
+		} catch (error) {
+			log.notifyError(`Failed to remove session: ${error}`);
+		}
+	}
+
+	private async resolveProfile(args: unknown[]): Promise<SessionProfile | undefined> {
+		const first = args[0];
+		const item = Array.isArray(first) ? first[0] : undefined;
+		if (item instanceof SessionTreeItem) return item.profile;
+		return pickKnownProfile();
+	}
+}

--- a/src/commands/sessions/index.ts
+++ b/src/commands/sessions/index.ts
@@ -1,2 +1,3 @@
 export { ClearSessions } from './ClearSessions';
 export { NewSession } from './NewSession';
+export { RemoveSession } from './RemoveSession';

--- a/src/commands/template/DeleteTemplate.ts
+++ b/src/commands/template/DeleteTemplate.ts
@@ -17,7 +17,7 @@ export class DeleteTemplate extends GenericCommand {
 			throw log.notifyError(`There is no template linked to the file to be deleted: ${document.uri.toString()}`);
 		}
 
-		const session = SessionManager.getSessionForOrg(link.org.id);
+		const session = await SessionManager.getSessionForOrg(link.org.id);
 
 		const confirm = await vscode.window.showWarningMessage(
 			`Delete template "${link.template.name}" from Rewst? This cannot be undone.`,

--- a/src/commands/template/OpenInRewst.test.ts
+++ b/src/commands/template/OpenInRewst.test.ts
@@ -216,7 +216,7 @@ suite('Unit: OpenInRewst', () => {
 		SessionManager._setSessionsForTesting([session]);
 
 		// Verify the URL would be correct by checking getSessionForOrg resolves
-		const resolvedSession = SessionManager.getSessionForOrg(orgId);
+		const resolvedSession = await SessionManager.getSessionForOrg(orgId);
 		const expectedUrl = `${resolvedSession.profile.region.loginUrl}/organizations/${orgId}/templates/${templateId}`;
 		assert.strictEqual(expectedUrl, `https://app.rewst.io/organizations/${orgId}/templates/${templateId}`);
 

--- a/src/commands/template/OpenInRewst.ts
+++ b/src/commands/template/OpenInRewst.ts
@@ -29,7 +29,7 @@ export class OpenInRewst extends GenericCommand {
 
 			let baseUrl: string;
 			try {
-				const session = SessionManager.getSessionForOrg(link.org.id);
+				const session = await SessionManager.getSessionForOrg(link.org.id);
 				baseUrl = session.profile.region.loginUrl;
 			} catch {
 				const knownProfile = SessionManager.getProfileForOrg(link.org.id);

--- a/src/mcp/McpActions.ts
+++ b/src/mcp/McpActions.ts
@@ -209,26 +209,17 @@ async function ensureValidSession(session: Session): Promise<void> {
 }
 
 /**
- * Resolves the session + org context a capability runs against. This does no
- * authenticated I/O — session validation/refresh is deferred to the call site so
- * it runs only after the scope gate, keeping an out-of-scope request from
- * touching Rewst.
+ * Determines which org id a capability call targets — a pure, no-I/O
+ * computation safe to run before the scope gate. Throws org_required for an
+ * org-scoped capability with no resolvable org id, mirroring the priority the
+ * old single-pass resolveContext gave that check.
  */
-function resolveContext(
+function resolveOrgId(
 	capability: Capability,
 	args: Record<string, unknown>,
 	requestOrgId: string | undefined,
-): CapabilityContext {
-	const sessions = SessionManager.getActiveSessions();
-	if (sessions.length === 0) {
-		throw new McpError(
-			'no_session',
-			'No Rewst sessions are active. Open VS Code with Rewst Buddy and sign in, then retry.',
-		);
-	}
-	if (capability.requiresOrg === false) {
-		return { session: sessions[0], orgId: sessions[0].profile.org.id, sessions };
-	}
+): string | undefined {
+	if (capability.requiresOrg === false) return undefined;
 	// When the org is omitted and exactly one working org is pinned, target it —
 	// the model never has to name it and so cannot misname it.
 	const workingOrgs = WorkingScopeManager.getOrgs();
@@ -240,16 +231,46 @@ function resolveContext(
 	// Surface the resolved org back into the arguments so capabilities that read
 	// `orgId` from their input (the common case) see the injected working org.
 	args.orgId = orgId;
+	return orgId;
+}
+
+/**
+ * Resolves the session + org context a capability runs against, given the org
+ * id resolveOrgId already cleared through the scope gate. Session lookup may
+ * run a cached (normally free; network only once the 24h validation cache has
+ * expired) validity check via SessionManager.getSessionForOrg, so an org whose
+ * only registered session has gone stale falls through to another session
+ * that still manages it rather than erroring. Callers MUST run this only
+ * after assertScopeAllowed (see callTool/readResource), so an out-of-scope
+ * request never triggers authenticated Rewst traffic.
+ */
+async function resolveContext(
+	capability: Capability,
+	args: Record<string, unknown>,
+	orgId: string | undefined,
+): Promise<CapabilityContext> {
+	const sessions = SessionManager.getActiveSessions();
+	if (sessions.length === 0) {
+		throw new McpError(
+			'no_session',
+			'No Rewst sessions are active. Open VS Code with Rewst Buddy and sign in, then retry.',
+		);
+	}
+	if (capability.requiresOrg === false) {
+		return { session: sessions[0], orgId: sessions[0].profile.org.id, sessions };
+	}
+	// orgId is guaranteed defined here: resolveOrgId already threw org_required
+	// otherwise, for every capability whose requiresOrg is not false.
 	let session: Session;
 	try {
-		session = SessionManager.getSessionForOrg(orgId);
+		session = await SessionManager.getSessionForOrg(orgId as string);
 	} catch {
 		throw new McpError(
 			'org_not_found',
 			`No active session manages org "${orgId}". Call buddy_list_orgs for valid ids.`,
 		);
 	}
-	return { session, orgId, sessions };
+	return { session, orgId: orgId as string, sessions };
 }
 
 function describeTool(capability: Capability): McpToolDescriptor {
@@ -299,11 +320,14 @@ export async function callTool(
 		}
 
 		const args = params.arguments ?? {};
-		const ctx = resolveContext(capability, args, params.orgId);
-		auditOrgId = capability.requiresOrg === false ? '—' : ctx.orgId || '—';
+		const orgId = resolveOrgId(capability, args, params.orgId);
+		auditOrgId = capability.requiresOrg === false ? '—' : orgId || '—';
 		// Reject an out-of-scope call before the capability runs (and before any
-		// approval modal, which may never surface to an external MCP client).
-		assertScopeAllowed(capability, ctx.orgId, args, settings);
+		// approval modal, which may never surface to an external MCP client), and
+		// before resolving a session for it — an out-of-scope orgId must never
+		// trigger authenticated Rewst traffic.
+		assertScopeAllowed(capability, orgId ?? '', args, settings);
+		const ctx = await resolveContext(capability, args, orgId);
 		// Validate/refresh the session only after the scope gate passes, so an
 		// out-of-scope request triggers no authenticated Rewst traffic.
 		if (capability.requiresOrg !== false) await ensureValidSession(ctx.session);
@@ -393,9 +417,12 @@ export async function readResource(uri: string, settings: McpSettings = readMcpS
 
 	const args: Record<string, unknown> = { orgId: parsed.orgId };
 	if (parsed.id) args[parsed.collection === 'templates' ? 'templateId' : 'workflowId'] = parsed.id;
-	const ctx = resolveContext(capability, args, parsed.orgId);
-	// Resources run read capabilities directly, so honour the working scope here too.
-	assertScopeAllowed(capability, ctx.orgId, args, settings);
+	const orgId = resolveOrgId(capability, args, parsed.orgId);
+	// Resources run read capabilities directly, so honour the working scope here too,
+	// and before resolving a session — an out-of-scope orgId must never trigger
+	// authenticated Rewst traffic.
+	assertScopeAllowed(capability, orgId ?? '', args, settings);
+	const ctx = await resolveContext(capability, args, orgId);
 	await ensureValidSession(ctx.session);
 	const text = formatMcpOutput(toolName, await capability.run(args, ctx));
 	log.info(`MCP readResource: ${uri}`);

--- a/src/models/SyncManager.test.ts
+++ b/src/models/SyncManager.test.ts
@@ -952,6 +952,60 @@ suite('Unit: SyncManager.syncTemplate (conflict resolution)', () => {
 		assert.strictEqual(link.template.updatedAt, 'uploaded-ts', 'link reflects the upload response');
 	});
 
+	test('force override re-resolves the session instead of reusing one captured before the modal', async () => {
+		const { doc, wrapper: staleWrapper, templateId, org } = setUpConflict();
+
+		// A session can be refreshed, removed, or replaced while the user is
+		// staring at the (indefinitely long) conflict modal. Swap in a distinct
+		// session for the same org from inside the modal stub to simulate that,
+		// and assert the upload lands on the new session, not the stale one
+		// captured before the modal was shown.
+		const { session: freshSession, wrapper: freshWrapper } = createMockSession({
+			profile: { org, allManagedOrgs: [org] },
+		});
+		freshWrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: templateId,
+				name: 'Conflict Template',
+				body: '// remote content, different from local',
+				updatedAt: 'remote-ts',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+		freshWrapper.when('updateTemplateBody', {
+			data: Fixtures.updateTemplateBodyMutation({
+				id: templateId,
+				name: 'Conflict Template',
+				updatedAt: 'uploaded-ts',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			}),
+		});
+
+		const restore = stub(vscode.window, 'showInformationMessage', (async () => {
+			SessionManager._setSessionsForTesting([freshSession]);
+			return 'Force Override';
+		}) as unknown as typeof vscode.window.showInformationMessage);
+
+		try {
+			await SyncManager.syncTemplate(doc);
+		} finally {
+			restore();
+		}
+
+		assert.strictEqual(
+			staleWrapper.getCallsFor('updateTemplateBody').length,
+			0,
+			'the session captured before the modal must not be used for the upload',
+		);
+		assert.strictEqual(
+			freshWrapper.getCallsFor('updateTemplateBody').length,
+			1,
+			'the session swapped in during the modal wait should receive the upload',
+		);
+	});
+
 	test('user takes the remote version: the remote body replaces the local file', async () => {
 		const { doc, wrapper } = setUpConflict();
 		const restore = stub(

--- a/src/models/SyncManager.test.ts
+++ b/src/models/SyncManager.test.ts
@@ -1006,6 +1006,30 @@ suite('Unit: SyncManager.syncTemplate (conflict resolution)', () => {
 		);
 	});
 
+	test('force override surfaces a clear error when no session remains for the org after the modal', async () => {
+		const { doc, wrapper: staleWrapper } = setUpConflict();
+
+		// The org's only session is removed while the user is staring at the
+		// conflict modal; re-resolution must fail loudly rather than fall back
+		// to the stale session captured before the modal.
+		const restore = stub(vscode.window, 'showInformationMessage', (async () => {
+			SessionManager._setSessionsForTesting([]);
+			return 'Force Override';
+		}) as unknown as typeof vscode.window.showInformationMessage);
+
+		try {
+			await assert.rejects(() => SyncManager.syncTemplate(doc), /no session found/);
+		} finally {
+			restore();
+		}
+
+		assert.strictEqual(
+			staleWrapper.getCallsFor('updateTemplateBody').length,
+			0,
+			'the stale session must not receive the upload when re-resolution fails',
+		);
+	});
+
 	test('user takes the remote version: the remote body replaces the local file', async () => {
 		const { doc, wrapper } = setUpConflict();
 		const restore = stub(

--- a/src/models/SyncManager.test.ts
+++ b/src/models/SyncManager.test.ts
@@ -1334,6 +1334,42 @@ suite('Unit: SyncManager.fetchAllFolders', () => {
 		assert.strictEqual(fs.readFileSync(fileA, 'utf8'), 'a1-body');
 		assert.strictEqual(fs.readFileSync(fileB, 'utf8'), 'b1-body');
 	});
+
+	test('a folder whose org has no session does not stop the remaining folders from fetching', async () => {
+		// Only org B has a session; org A's folder link is stale (its session
+		// was removed) and its failure must not abort the whole background pass.
+		const { session, wrapper } = createMockSession({ profile: { org: orgB, allManagedOrgs: [orgB] } });
+		wrapper.when('listTemplates', {
+			data: Fixtures.listTemplatesQuery([
+				Fixtures.template({
+					id: 'b1',
+					name: 'Bravo',
+					orgId: orgB.id,
+					organization: Fixtures.org({ id: orgB.id, name: orgB.name }),
+				}),
+			]),
+		});
+		wrapper.when('getTemplate', {
+			data: Fixtures.getTemplateQuery({
+				id: 'b1',
+				name: 'Bravo',
+				body: 'b1-body',
+				orgId: orgB.id,
+				organization: Fixtures.org({ id: orgB.id, name: orgB.name }),
+			}),
+		});
+		SessionManager._setSessionsForTesting([session]);
+
+		// Org A first: its failure previously aborted the loop before org B ran.
+		LinkManager.addLink({ type: 'Folder', uriString: folderUriA.toString(), org: orgA });
+		LinkManager.addLink({ type: 'Folder', uriString: folderUriB.toString(), org: orgB });
+
+		(SyncManager as any)['isActive'] = true;
+		await SyncManager.fetchAllFolders();
+
+		const linksB = LinkManager.getOrgTemplateLinks(orgB);
+		assert.strictEqual(linksB.length, 1, "org B's folder is still fetched after org A's folder failed");
+	});
 });
 
 // Contract from openspec/specs/template-sync "Auto-fetch on open without

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -462,7 +462,13 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		const links = LinkManager.getFolderLinks();
 		for (const link of links) {
 			if (!this.isActive) break; // Stop if deactivated mid-fetch
-			await this.fetchFolder(link);
+			try {
+				await this.fetchFolder(link);
+			} catch (e) {
+				// One folder's failure (e.g. its org's session was removed) must
+				// not stop the remaining folders from being fetched.
+				log.error(`fetchAllFolders: failed to fetch folder ${link.uriString}`, e);
+			}
 		}
 	}
 

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -125,7 +125,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		}
 		const link = rawLink as TemplateLink;
 
-		const session = SessionManager.getSessionForOrg(link.org.id);
+		const session = await SessionManager.getSessionForOrg(link.org.id);
 
 		let remoteTemplate;
 		try {
@@ -186,7 +186,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		log.trace('updateTemplateBody: starting', doc.uri.fsPath);
 		const link = LinkManager.getTemplateLink(doc.uri);
 
-		const session = SessionManager.getSessionForOrg(link.org.id);
+		const session = await SessionManager.getSessionForOrg(link.org.id);
 
 		try {
 			const body = doc.getText() ?? '';
@@ -327,7 +327,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 	 */
 	async computeSyncDecision(doc: vscode.TextDocument): Promise<SyncDecisionContext> {
 		const link = LinkManager.getTemplateLink(doc.uri);
-		const session = SessionManager.getSessionForOrg(link.org.id);
+		const session = await SessionManager.getSessionForOrg(link.org.id);
 
 		let remoteTemplate: FullTemplateFragment;
 		try {
@@ -470,7 +470,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		const ids = new Set(LinkManager.getOrgTemplateLinks(org).map(l => l.template.id));
 		log.debug('fetchFolder: existing template count', ids.size);
 
-		const session = SessionManager.getSessionForOrg(org.id);
+		const session = await SessionManager.getSessionForOrg(org.id);
 
 		log.trace('fetchFolder: listing templates from Rewst');
 		const response = await session.sdk?.listTemplates({ orgId: org.id });

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -182,11 +182,9 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		}
 	}
 
-	async updateTemplateBody(doc: vscode.TextDocument) {
+	async updateTemplateBody(doc: vscode.TextDocument, session: Session) {
 		log.trace('updateTemplateBody: starting', doc.uri.fsPath);
 		const link = LinkManager.getTemplateLink(doc.uri);
-
-		const session = await SessionManager.getSessionForOrg(link.org.id);
 
 		try {
 			const body = doc.getText() ?? '';
@@ -270,7 +268,7 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 
 			case 'upload-local':
 				log.debug('syncTemplateInternal: uploading local changes (in sync)');
-				await this.updateTemplateBody(doc);
+				await this.updateTemplateBody(doc, session);
 				break;
 
 			case 'conflict':
@@ -395,10 +393,16 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		log.debug('handleConflict: user chose', choice);
 
 		switch (choice) {
-			case 'Force Override':
+			case 'Force Override': {
 				log.trace('handleConflict: force overriding remote');
-				await this.updateTemplateBody(doc);
+				// Re-resolve rather than reusing the session captured before this
+				// modal: the user may take arbitrarily long to respond, during which
+				// the session could be refreshed, removed, or replaced.
+				const link = LinkManager.getTemplateLink(doc.uri);
+				const freshSession = await SessionManager.getSessionForOrg(link.org.id);
+				await this.updateTemplateBody(doc, freshSession);
 				break;
+			}
 
 			case 'Download Latest':
 				log.trace('handleConflict: downloading remote');

--- a/src/models/TemplateMetadataStore.test.ts
+++ b/src/models/TemplateMetadataStore.test.ts
@@ -505,6 +505,48 @@ suite('Unit: TemplateMetadataStore', () => {
 				"the surviving session's org metadata stays available",
 			);
 		});
+
+		test('should not let an in-flight load re-insert metadata for a session removed mid-load', async () => {
+			const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Org 1' });
+			const org2 = Fixtures.orgModel({ id: 'org-2', name: 'Org 2' });
+
+			const { session: session1, wrapper: wrapper1 } = createMockSession({
+				profile: { user: Fixtures.userFragment({ id: 'user-1' }), org: org1, allManagedOrgs: [org1] },
+			});
+			// Slow response: still in flight when the session is removed below.
+			wrapper1.when('listTemplates', {
+				data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-org1', name: 'T1', orgId: org1.id })]),
+				delay: 150,
+			});
+			const { session: session2, wrapper: wrapper2 } = createMockSession({
+				profile: { user: Fixtures.userFragment({ id: 'user-2' }), org: org2, allManagedOrgs: [org2] },
+			});
+			wrapper2.when('listTemplates', {
+				data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-org2', name: 'T2', orgId: org2.id })]),
+			});
+
+			LinkManager.addLink(makeTemplateLink(org1.id, org1.name, 'link-org1'));
+			LinkManager.addLink(makeTemplateLink(org2.id, org2.name, 'link-org2'));
+			SessionManager._setSessionsForTesting([session1, session2]);
+
+			TemplateMetadataStore.init();
+			// Remove while org 1's listTemplates response is still pending.
+			await new Promise(resolve => setTimeout(resolve, 50));
+			await SessionManager.removeSession('user-1');
+
+			// Let the delayed response land and any pending reload settle.
+			await new Promise(resolve => setTimeout(resolve, 300));
+
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('t-org1'),
+				undefined,
+				'a load already in flight when the session was removed must not re-insert its metadata',
+			);
+			assert.ok(
+				TemplateMetadataStore.getTemplateMetadata('t-org2'),
+				"the surviving session's org metadata stays available",
+			);
+		});
 	});
 
 	suite('dispose()', () => {

--- a/src/models/TemplateMetadataStore.test.ts
+++ b/src/models/TemplateMetadataStore.test.ts
@@ -465,6 +465,46 @@ suite('Unit: TemplateMetadataStore', () => {
 				'Template should be cleared after sessions cleared',
 			);
 		});
+
+		test('should drop metadata for orgs no remaining session manages when one session is removed', async () => {
+			const org1 = Fixtures.orgModel({ id: 'org-1', name: 'Org 1' });
+			const org2 = Fixtures.orgModel({ id: 'org-2', name: 'Org 2' });
+
+			const { session: session1, wrapper: wrapper1 } = createMockSession({
+				profile: { user: Fixtures.userFragment({ id: 'user-1' }), org: org1, allManagedOrgs: [org1] },
+			});
+			wrapper1.when('listTemplates', {
+				data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-org1', name: 'T1', orgId: org1.id })]),
+			});
+			const { session: session2, wrapper: wrapper2 } = createMockSession({
+				profile: { user: Fixtures.userFragment({ id: 'user-2' }), org: org2, allManagedOrgs: [org2] },
+			});
+			wrapper2.when('listTemplates', {
+				data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-org2', name: 'T2', orgId: org2.id })]),
+			});
+
+			LinkManager.addLink(makeTemplateLink(org1.id, org1.name, 'link-org1'));
+			LinkManager.addLink(makeTemplateLink(org2.id, org2.name, 'link-org2'));
+			SessionManager._setSessionsForTesting([session1, session2]);
+
+			TemplateMetadataStore.init();
+			await new Promise(resolve => setTimeout(resolve, 100));
+			assert.ok(TemplateMetadataStore.getTemplateMetadata('t-org1'), 'org 1 metadata loaded');
+			assert.ok(TemplateMetadataStore.getTemplateMetadata('t-org2'), 'org 2 metadata loaded');
+
+			await SessionManager.removeSession('user-1');
+			await new Promise(resolve => setTimeout(resolve, 100));
+
+			assert.strictEqual(
+				TemplateMetadataStore.getTemplateMetadata('t-org1'),
+				undefined,
+				"the removed session's org metadata must be dropped so hovers cannot offer dead sessions",
+			);
+			assert.ok(
+				TemplateMetadataStore.getTemplateMetadata('t-org2'),
+				"the surviving session's org metadata stays available",
+			);
+		});
 	});
 
 	suite('dispose()', () => {

--- a/src/models/TemplateMetadataStore.ts
+++ b/src/models/TemplateMetadataStore.ts
@@ -52,8 +52,23 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 	private handleSessionChange(event: SessionChangeEvent): void {
 		if (event.type === 'saved') {
 			this.loadAllSessionTemplates(DEFERRED_DELAY_SESSION_EVENT_MS);
+		} else if (event.type === 'removed') {
+			// Drop metadata for orgs no remaining session manages so hovers and
+			// definitions cannot offer templates whose session is gone, then
+			// reload: an org the removed session shared with a survivor stays.
+			this.pruneOrgsWithoutSession();
+			this.loadAllSessionTemplates(DEFERRED_DELAY_SESSION_EVENT_MS);
 		} else if (event.type === 'cleared') {
 			this.clearAll();
+		}
+	}
+
+	private pruneOrgsWithoutSession(): void {
+		const covered = this.collectOrgSessionMap();
+		for (const orgId of Array.from(this.orgIndex.keys())) {
+			if (!covered.has(orgId)) {
+				this.clearOrgTemplates(orgId);
+			}
 		}
 	}
 

--- a/src/models/TemplateMetadataStore.ts
+++ b/src/models/TemplateMetadataStore.ts
@@ -53,6 +53,11 @@ export const TemplateMetadataStore = new (class _ implements vscode.Disposable {
 		if (event.type === 'saved') {
 			this.loadAllSessionTemplates(DEFERRED_DELAY_SESSION_EVENT_MS);
 		} else if (event.type === 'removed') {
+			// Invalidate any load already in flight first: it may still hold the
+			// removed session and would re-insert its orgs' metadata after the
+			// prune below (its generation checks would still pass).
+			this.loadGeneration++;
+			this.clearDeferredTimer();
 			// Drop metadata for orgs no remaining session manages so hovers and
 			// definitions cannot offer templates whose session is gone, then
 			// reload: an org the removed session shared with a survivor stays.

--- a/src/packageManifest.test.ts
+++ b/src/packageManifest.test.ts
@@ -28,6 +28,9 @@ interface PackageManifest {
 		};
 		commands: { command: string; title: string }[];
 		keybindings?: { command: string; key: string; mac?: string }[];
+		menus?: {
+			commandPalette?: { command: string; when?: string }[];
+		};
 	};
 }
 
@@ -115,5 +118,21 @@ suite('Unit: package manifest', () => {
 		const ids = manifest.contributes.commands.map(entry => entry.command);
 		assert.ok(ids.includes('rewst-buddy.SetWorkingScope'));
 		assert.ok(ids.includes('rewst-buddy.ClearWorkingScope'));
+	});
+
+	test('Remove Session is contributed and reachable from the palette without an active session', () => {
+		const ids = manifest.contributes.commands.map(entry => entry.command);
+		assert.ok(ids.includes('rewst-buddy.prefix.RemoveSession'));
+		assert.ok(ids.includes('rewst-buddy.RemoveSession'));
+
+		// A known-only (previously authenticated, no longer active) session must
+		// still be removable, so the palette entry must not be gated on
+		// anyActiveSessions the way ClearSessions is.
+		const paletteEntries = manifest.contributes.menus?.commandPalette ?? [];
+		const gated = paletteEntries.find(entry => entry.command === 'rewst-buddy.prefix.RemoveSession');
+		assert.ok(
+			gated === undefined || gated.when === undefined || !gated.when.includes('anyActiveSessions'),
+			'Remove Session must stay reachable when only known/inactive sessions exist',
+		);
 	});
 });

--- a/src/providers/TemplateDefinitionProvider.ts
+++ b/src/providers/TemplateDefinitionProvider.ts
@@ -51,7 +51,7 @@ export class TemplateDefinitionProvider implements vscode.DefinitionProvider {
 
 	private async openUnlinkedTemplate(templateId: string, metadata: TemplateMetadata): Promise<void> {
 		try {
-			const session = SessionManager.getSessionForOrg(metadata.org.id);
+			const session = await SessionManager.getSessionForOrg(metadata.org.id);
 			const fullTemplate = await session.getTemplate(templateId);
 			await createAndLinkNewTemplate(fullTemplate);
 		} catch (error) {

--- a/src/server/handlers.ts
+++ b/src/server/handlers.ts
@@ -109,7 +109,7 @@ export async function handleOpenTemplate(
 		await SessionManager.loadSessions();
 
 		// Get session for org (needed for both paths)
-		const session = SessionManager.getSessionForOrg(request.orgId);
+		const session = await SessionManager.getSessionForOrg(request.orgId);
 
 		// Check for existing linked document
 		const existingLink = await openTemplateById(request.templateId);

--- a/src/sessions/Session.test.ts
+++ b/src/sessions/Session.test.ts
@@ -210,6 +210,75 @@ suite('Unit: Session', () => {
 		});
 	});
 
+	suite('ensureValid()', () => {
+		test('returns true without refreshing when the session already validates', async () => {
+			const { session, wrapper } = createMockSession();
+
+			const result = await session.ensureValid();
+
+			assert.strictEqual(result, true);
+			assert.strictEqual(wrapper.getCallsFor('User').length, 1);
+		});
+
+		function refreshProfile(orgId: string, port: number): SessionProfile {
+			return {
+				region: {
+					name: 'Local Test',
+					cookieName: 'appSession',
+					graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+					loginUrl: `http://127.0.0.1:${port}`,
+				},
+				org: { id: orgId, name: 'Ensure Valid Org' },
+				allManagedOrgs: [{ id: orgId, name: 'Ensure Valid Org' }],
+				label: 'Ensure Valid Session',
+				user: { id: 'user-1' } as SessionProfile['user'],
+			};
+		}
+
+		test('recovers via refresh when the session is initially invalid but the cookie still logs in', async () => {
+			const orgId = 'org-ensure-valid-recovers';
+			const server = createServer((request, response) => {
+				if (request.method === 'GET') {
+					response.writeHead(200, { 'set-cookie': 'appSession=refreshed-cookie' });
+					response.end();
+					return;
+				}
+				let body = '';
+				request.on('data', chunk => {
+					body += String(chunk);
+				});
+				request.on('end', () => {
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(JSON.stringify({ data: { user: { id: 'user-1' } } }));
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const context = initTestEnvironment();
+			await context.secrets.store(orgId, 'appSession=stale-cookie');
+			// No sdk yet, so validate() fails immediately without a network call,
+			// exactly like a session whose cached User() query previously failed.
+			const session = new Session(undefined, refreshProfile(orgId, port));
+
+			const result = await session.ensureValid();
+
+			assert.strictEqual(result, true);
+			assert.notStrictEqual(session.sdk, undefined, 'refresh should have replaced the in-memory SDK');
+		});
+
+		test('returns false when the session is invalid and the refresh attempt also fails', async () => {
+			const orgId = 'org-ensure-valid-dead';
+			// No secret stored for this org, so refreshToken's getCookies() throws
+			// before any network call — the session cannot be recovered.
+			const session = new Session(undefined, refreshProfile(orgId, 0));
+
+			const result = await session.ensureValid();
+
+			assert.strictEqual(result, false);
+		});
+	});
+
 	suite('refreshToken()', () => {
 		test('replaces the stored secret and the in-memory session with the refreshed cookie', async () => {
 			const orgId = 'org-refresh';

--- a/src/sessions/Session.test.ts
+++ b/src/sessions/Session.test.ts
@@ -1,29 +1,19 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { createServer, type Server } from 'http';
-import type { AddressInfo } from 'net';
 import vscode from 'vscode';
-import { initTestEnvironment, createMockSession } from '@test';
+import {
+	initTestEnvironment,
+	createMockSession,
+	listen,
+	close,
+	createRefreshableSessionServer,
+	refreshableSessionProfile,
+} from '@test';
 import SessionProfile from './SessionProfile';
 import Session from './Session';
 
 const { suite, test, setup, teardown } = Mocha;
-
-function listen(server: Server): Promise<number> {
-	return new Promise((resolve, reject) => {
-		server.once('error', reject);
-		server.listen(0, '127.0.0.1', () => {
-			server.off('error', reject);
-			resolve((server.address() as AddressInfo).port);
-		});
-	});
-}
-
-function close(server: Server): Promise<void> {
-	return new Promise((resolve, reject) => {
-		server.close(error => (error ? reject(error) : resolve()));
-	});
-}
 
 suite('Unit: Session', () => {
 	let servers: Server[] = [];
@@ -220,58 +210,33 @@ suite('Unit: Session', () => {
 			assert.strictEqual(wrapper.getCallsFor('User').length, 1);
 		});
 
-		function refreshProfile(orgId: string, port: number): SessionProfile {
-			return {
-				region: {
-					name: 'Local Test',
-					cookieName: 'appSession',
-					graphqlUrl: `http://127.0.0.1:${port}/graphql`,
-					loginUrl: `http://127.0.0.1:${port}`,
-				},
-				org: { id: orgId, name: 'Ensure Valid Org' },
-				allManagedOrgs: [{ id: orgId, name: 'Ensure Valid Org' }],
-				label: 'Ensure Valid Session',
-				user: { id: 'user-1' } as SessionProfile['user'],
-			};
-		}
-
 		test('recovers via refresh when the session is initially invalid but the cookie still logs in', async () => {
 			const orgId = 'org-ensure-valid-recovers';
-			const server = createServer((request, response) => {
-				if (request.method === 'GET') {
-					response.writeHead(200, { 'set-cookie': 'appSession=refreshed-cookie' });
-					response.end();
-					return;
-				}
-				let body = '';
-				request.on('data', chunk => {
-					body += String(chunk);
-				});
-				request.on('end', () => {
-					response.writeHead(200, { 'content-type': 'application/json' });
-					response.end(JSON.stringify({ data: { user: { id: 'user-1' } } }));
-				});
-			});
+			const { server, port, getRequestCounts } = await createRefreshableSessionServer('user-1');
 			servers.push(server);
-			const port = await listen(server);
 
 			const context = initTestEnvironment();
 			await context.secrets.store(orgId, 'appSession=stale-cookie');
 			// No sdk yet, so validate() fails immediately without a network call,
 			// exactly like a session whose cached User() query previously failed.
-			const session = new Session(undefined, refreshProfile(orgId, port));
+			const session = new Session(undefined, refreshableSessionProfile(orgId, port, 'user-1'));
 
 			const result = await session.ensureValid();
 
 			assert.strictEqual(result, true);
 			assert.notStrictEqual(session.sdk, undefined, 'refresh should have replaced the in-memory SDK');
+			assert.strictEqual(
+				getRequestCounts().post,
+				1,
+				'ensureValid should reuse the validation refreshToken() already performed, not re-query User()',
+			);
 		});
 
 		test('returns false when the session is invalid and the refresh attempt also fails', async () => {
 			const orgId = 'org-ensure-valid-dead';
 			// No secret stored for this org, so refreshToken's getCookies() throws
 			// before any network call — the session cannot be recovered.
-			const session = new Session(undefined, refreshProfile(orgId, 0));
+			const session = new Session(undefined, refreshableSessionProfile(orgId, 0, 'user-1'));
 
 			const result = await session.ensureValid();
 
@@ -419,6 +384,25 @@ suite('Unit: Session', () => {
 				'secret is not overwritten on validation failure',
 			);
 			assert.strictEqual(session.sdk, undefined, 'in-memory SDK is not set on validation failure');
+		});
+
+		test('single-flights concurrent calls into one login/validate round trip', async () => {
+			const orgId = 'org-refresh-concurrent';
+			const { server, port, getRequestCounts } = await createRefreshableSessionServer('user-1');
+			servers.push(server);
+
+			const context = initTestEnvironment();
+			await context.secrets.store(orgId, 'appSession=stale-cookie');
+			const session = new Session(undefined, refreshableSessionProfile(orgId, port, 'user-1'));
+
+			await Promise.all([session.refreshToken(), session.refreshToken(), session.refreshToken()]);
+
+			assert.deepStrictEqual(
+				getRequestCounts(),
+				{ get: 1, post: 1 },
+				'concurrent refreshToken() callers should share one login/validate attempt',
+			);
+			assert.notStrictEqual(session.sdk, undefined);
 		});
 	});
 });

--- a/src/sessions/Session.ts
+++ b/src/sessions/Session.ts
@@ -11,6 +11,7 @@ import { createRetryWrapper } from './retryWrapper';
 export default class Session {
 	private secrets: vscode.SecretStorage;
 	private lastValidated = 0;
+	private refreshPromise: Promise<void> | undefined;
 
 	public constructor(
 		public sdk: Sdk | undefined,
@@ -139,10 +140,30 @@ export default class Session {
 			return false;
 		}
 
-		return this.validate();
+		// refreshToken() already re-validated the refreshed SDK and stamped
+		// lastValidated, so a second live validate() here would just repeat the
+		// same network call it already made.
+		return true;
 	}
 
-	public async refreshToken() {
+	/**
+	 * Single-flights concurrent refresh requests onto one in-progress attempt so
+	 * callers (the 15-minute background refresh, ensureValid(), and any other
+	 * caller) racing each other don't fire duplicate logins or clobber each
+	 * other's cookie/SDK writes.
+	 */
+	public async refreshToken(): Promise<void> {
+		if (this.refreshPromise) return this.refreshPromise;
+
+		this.refreshPromise = this.performRefresh();
+		try {
+			await this.refreshPromise;
+		} finally {
+			this.refreshPromise = undefined;
+		}
+	}
+
+	private async performRefresh(): Promise<void> {
 		log.trace('refreshToken: starting', { label: this.profile.label, orgId: this.profile.org.id });
 
 		const config = this.profile.region;
@@ -177,6 +198,7 @@ export default class Session {
 			log.trace('refreshToken: storing new cookie');
 			await this.secrets.store(this.profile.org.id, cookieString);
 			this.sdk = sdk;
+			this.lastValidated = Date.now();
 			log.info(`refreshToken: success for ${this.profile.label}`);
 		} catch (error) {
 			log.notifyError(`refreshToken: failed for ${this.profile.label}: ${error}`);

--- a/src/sessions/Session.ts
+++ b/src/sessions/Session.ts
@@ -124,6 +124,24 @@ export default class Session {
 		return valid;
 	}
 
+	/**
+	 * Validates the session, attempting one refresh if the check fails, so a
+	 * merely stale (but still logged-in) cookie recovers instead of being
+	 * treated as dead. Used by org resolution, where skipping a session over
+	 * an unattempted refresh would wrongly report the org unreachable.
+	 */
+	public async ensureValid(): Promise<boolean> {
+		if (await this.validate()) return true;
+
+		try {
+			await this.refreshToken();
+		} catch {
+			return false;
+		}
+
+		return this.validate();
+	}
+
 	public async refreshToken() {
 		log.trace('refreshToken: starting', { label: this.profile.label, orgId: this.profile.org.id });
 

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -1,30 +1,21 @@
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { createServer, type Server } from 'http';
-import type { AddressInfo } from 'net';
 import vscode from 'vscode';
 import { context } from '@global';
 import { SessionManager, Session } from '@sessions';
-import { initTestEnvironment, createMockSession, Fixtures } from '@test';
+import {
+	initTestEnvironment,
+	createMockSession,
+	Fixtures,
+	listen,
+	close,
+	createRefreshableSessionServer,
+	refreshableSessionProfile,
+} from '@test';
 import SessionProfile from './SessionProfile';
 
 const { suite, test, setup, teardown } = Mocha;
-
-function listen(server: Server): Promise<number> {
-	return new Promise((resolve, reject) => {
-		server.once('error', reject);
-		server.listen(0, '127.0.0.1', () => {
-			server.off('error', reject);
-			resolve((server.address() as AddressInfo).port);
-		});
-	});
-}
-
-function close(server: Server): Promise<void> {
-	return new Promise((resolve, reject) => {
-		server.close(error => (error ? reject(error) : resolve()));
-	});
-}
 
 interface MockUser {
 	id: string;
@@ -190,42 +181,13 @@ suite('Unit: SessionManager', () => {
 
 		test('recovers a stale-but-refreshable session via refresh instead of skipping or failing it', async () => {
 			const orgId = 'org-recovers-via-refresh';
-			// Answers a GET (refreshToken's login request) with a fresh cookie, and
-			// a POST (the User() query re-validating the refreshed SDK) with a user.
-			const server = createServer((request, response) => {
-				if (request.method === 'GET') {
-					response.writeHead(200, { 'set-cookie': 'appSession=refreshed-cookie' });
-					response.end();
-					return;
-				}
-				let body = '';
-				request.on('data', chunk => {
-					body += String(chunk);
-				});
-				request.on('end', () => {
-					response.writeHead(200, { 'content-type': 'application/json' });
-					response.end(JSON.stringify({ data: { user: { id: 'user-recovers' } } }));
-				});
-			});
-			const port = await listen(server);
+			const { server, port } = await createRefreshableSessionServer('user-recovers');
 
 			try {
 				await context.secrets.store(orgId, 'appSession=stale-cookie');
-				const profile: SessionProfile = {
-					region: {
-						name: 'Local Test',
-						cookieName: 'appSession',
-						graphqlUrl: `http://127.0.0.1:${port}/graphql`,
-						loginUrl: `http://127.0.0.1:${port}`,
-					},
-					org: { id: orgId, name: 'Recovers Via Refresh' },
-					allManagedOrgs: [{ id: orgId, name: 'Recovers Via Refresh' }],
-					label: 'Recovers Via Refresh Session',
-					user: { id: 'user-recovers' } as SessionProfile['user'],
-				};
 				// No sdk yet: validate() fails immediately, exactly like a session
 				// whose cached User() query previously failed.
-				const session = new Session(undefined, profile);
+				const session = new Session(undefined, refreshableSessionProfile(orgId, port, 'user-recovers'));
 				SessionManager._setSessionsForTesting([session]);
 
 				const resolved = await SessionManager.getSessionForOrg(orgId);
@@ -313,6 +275,26 @@ suite('Unit: SessionManager', () => {
 				SessionManager.getOrgSession('org-a', new URL(session.profile.region.loginUrl)),
 				'a session whose validation fails must be skipped, leaving no session to return',
 			);
+		});
+
+		test('getOrgSession recovers a stale-but-refreshable session via refresh instead of skipping it', async () => {
+			const orgId = 'org-recovers-region-scoped';
+			const { server, port } = await createRefreshableSessionServer('user-region-recovers');
+
+			try {
+				await context.secrets.store(orgId, 'appSession=stale-cookie');
+				// No sdk yet: validate() fails immediately, exactly like a session
+				// whose cached User() query previously failed.
+				const session = new Session(undefined, refreshableSessionProfile(orgId, port, 'user-region-recovers'));
+				SessionManager._setSessionsForTesting([session]);
+
+				const resolved = await SessionManager.getOrgSession(orgId, new URL(session.profile.region.loginUrl));
+
+				assert.strictEqual(resolved, session, 'the same session recovers rather than being skipped');
+				assert.notStrictEqual(session.sdk, undefined, 'refresh should have replaced the in-memory SDK');
+			} finally {
+				await close(server);
+			}
 		});
 
 		test('getProfileForOrg returns a capable profile when several known profiles share an org id', () => {

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -78,7 +78,7 @@ suite('Unit: SessionManager', () => {
 	});
 
 	suite('getSessionForOrg()', () => {
-		test('should resolve session via org index for managed (non-primary) org', () => {
+		test('should resolve session via org index for managed (non-primary) org', async () => {
 			const { session } = createMockSession({
 				profile: {
 					org: { id: 'primary-org', name: 'Primary' },
@@ -91,17 +91,17 @@ suite('Unit: SessionManager', () => {
 
 			SessionManager._setSessionsForTesting([session]);
 
-			assert.strictEqual(SessionManager.getSessionForOrg('managed-org'), session);
-			assert.strictEqual(SessionManager.getSessionForOrg('primary-org'), session);
+			assert.strictEqual(await SessionManager.getSessionForOrg('managed-org'), session);
+			assert.strictEqual(await SessionManager.getSessionForOrg('primary-org'), session);
 		});
 
-		test('should throw for unknown org', () => {
+		test('should throw for unknown org', async () => {
 			const { session } = createMockSession({
 				profile: { allManagedOrgs: [{ id: 'org-a', name: 'A' }] },
 			});
 			SessionManager._setSessionsForTesting([session]);
 
-			assert.throws(() => SessionManager.getSessionForOrg('unknown-org'));
+			await assert.rejects(SessionManager.getSessionForOrg('unknown-org'));
 		});
 
 		test('should throw after clearProfiles()', async () => {
@@ -109,11 +109,11 @@ suite('Unit: SessionManager', () => {
 				profile: { org: { id: 'org-a', name: 'A' }, allManagedOrgs: [{ id: 'org-a', name: 'A' }] },
 			});
 			SessionManager._setSessionsForTesting([session]);
-			assert.strictEqual(SessionManager.getSessionForOrg('org-a'), session);
+			assert.strictEqual(await SessionManager.getSessionForOrg('org-a'), session);
 
 			await SessionManager.clearProfiles();
 
-			assert.throws(() => SessionManager.getSessionForOrg('org-a'));
+			await assert.rejects(SessionManager.getSessionForOrg('org-a'));
 		});
 
 		test('re-auth for same user purges index entries for dropped orgs', async () => {
@@ -138,15 +138,54 @@ suite('Unit: SessionManager', () => {
 
 			const saver = SessionManager as unknown as SessionSaver;
 			await saver.saveSession(first);
-			assert.strictEqual(SessionManager.getSessionForOrg('org-b'), first);
+			assert.strictEqual(await SessionManager.getSessionForOrg('org-b'), first);
 
 			await saver.saveSession(second);
 
-			assert.strictEqual(SessionManager.getSessionForOrg('org-a'), second);
-			assert.throws(
-				() => SessionManager.getSessionForOrg('org-b'),
+			assert.strictEqual(await SessionManager.getSessionForOrg('org-a'), second);
+			await assert.rejects(
+				SessionManager.getSessionForOrg('org-b'),
 				'dropped org should no longer resolve to the stale session',
 			);
+		});
+
+		test('skips a session that no longer validates and falls through to another capable session', async () => {
+			const { session: stale, wrapper: staleWrapper } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-stale' }),
+					org: { id: 'dup-org', name: 'Stale' },
+					allManagedOrgs: [{ id: 'dup-org', name: 'Stale' }],
+				},
+			});
+			staleWrapper.when('User', { data: { user: null } });
+			const { session: fresh } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-fresh' }),
+					org: { id: 'dup-org', name: 'Fresh' },
+					allManagedOrgs: [{ id: 'dup-org', name: 'Fresh' }],
+				},
+			});
+			SessionManager._setSessionsForTesting([stale, fresh]);
+
+			const resolved = await SessionManager.getSessionForOrg('dup-org');
+			assert.strictEqual(
+				resolved,
+				fresh,
+				'an invalid session must not be returned when another capable session is still valid',
+			);
+		});
+
+		test('throws when every session capable of managing the org has gone invalid', async () => {
+			const { session, wrapper } = createMockSession({
+				profile: {
+					org: { id: 'org-all-stale', name: 'Stale' },
+					allManagedOrgs: [{ id: 'org-all-stale', name: 'Stale' }],
+				},
+			});
+			wrapper.when('User', { data: { user: null } });
+			SessionManager._setSessionsForTesting([session]);
+
+			await assert.rejects(SessionManager.getSessionForOrg('org-all-stale'));
 		});
 	});
 
@@ -171,7 +210,7 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(resolved, session);
 		});
 
-		test('a duplicate org id resolves to a capable session instead of failing as ambiguous', () => {
+		test('a duplicate org id resolves to a capable session instead of failing as ambiguous', async () => {
 			const { session: northAmerica } = createMockSession({
 				profile: {
 					user: Fixtures.userFragment({ id: 'user-na' }),
@@ -200,7 +239,7 @@ suite('Unit: SessionManager', () => {
 			});
 			SessionManager._setSessionsForTesting([northAmerica, europe]);
 
-			const resolved = SessionManager.getSessionForOrg('dup-org');
+			const resolved = await SessionManager.getSessionForOrg('dup-org');
 			assert.ok(
 				resolved === northAmerica || resolved === europe,
 				'a shared org id must resolve to one of the capable sessions, not error',
@@ -333,7 +372,7 @@ suite('Unit: SessionManager', () => {
 			const session = await SessionManager.createSession('raw-test-token');
 
 			assert.strictEqual(session.profile.label, 'jdoe (Acme Co)');
-			assert.strictEqual(SessionManager.getSessionForOrg('org-create'), session);
+			assert.strictEqual(await SessionManager.getSessionForOrg('org-create'), session);
 			assert.strictEqual(await context.secrets.get('org-create'), 'appSession=raw-test-token');
 		});
 
@@ -410,7 +449,7 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(sessions.length, 1);
 			assert.strictEqual(sessions[0].profile.org.id, 'org-restore');
 			assert.strictEqual(promptCalled, false, 'loadSessions must not prompt for a cookie');
-			assert.strictEqual(SessionManager.getSessionForOrg('org-restore'), sessions[0]);
+			assert.strictEqual(await SessionManager.getSessionForOrg('org-restore'), sessions[0]);
 		});
 	});
 
@@ -443,7 +482,7 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(await context.secrets.get('org-clear-primary'), undefined);
 			assert.strictEqual(await context.secrets.get('org-clear-managed'), undefined);
 			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
-			assert.throws(() => SessionManager.getSessionForOrg('org-clear-primary'));
+			await assert.rejects(SessionManager.getSessionForOrg('org-clear-primary'));
 		});
 
 		test('deletes secrets for profiles saved only in SessionProfiles', async () => {

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -187,6 +187,59 @@ suite('Unit: SessionManager', () => {
 
 			await assert.rejects(SessionManager.getSessionForOrg('org-all-stale'));
 		});
+
+		test('recovers a stale-but-refreshable session via refresh instead of skipping or failing it', async () => {
+			const orgId = 'org-recovers-via-refresh';
+			// Answers a GET (refreshToken's login request) with a fresh cookie, and
+			// a POST (the User() query re-validating the refreshed SDK) with a user.
+			const server = createServer((request, response) => {
+				if (request.method === 'GET') {
+					response.writeHead(200, { 'set-cookie': 'appSession=refreshed-cookie' });
+					response.end();
+					return;
+				}
+				let body = '';
+				request.on('data', chunk => {
+					body += String(chunk);
+				});
+				request.on('end', () => {
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(JSON.stringify({ data: { user: { id: 'user-recovers' } } }));
+				});
+			});
+			const port = await listen(server);
+
+			try {
+				await context.secrets.store(orgId, 'appSession=stale-cookie');
+				const profile: SessionProfile = {
+					region: {
+						name: 'Local Test',
+						cookieName: 'appSession',
+						graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+						loginUrl: `http://127.0.0.1:${port}`,
+					},
+					org: { id: orgId, name: 'Recovers Via Refresh' },
+					allManagedOrgs: [{ id: orgId, name: 'Recovers Via Refresh' }],
+					label: 'Recovers Via Refresh Session',
+					user: { id: 'user-recovers' } as SessionProfile['user'],
+				};
+				// No sdk yet: validate() fails immediately, exactly like a session
+				// whose cached User() query previously failed.
+				const session = new Session(undefined, profile);
+				SessionManager._setSessionsForTesting([session]);
+
+				const resolved = await SessionManager.getSessionForOrg(orgId);
+
+				assert.strictEqual(
+					resolved,
+					session,
+					'the same session recovers rather than being reported unreachable',
+				);
+				assert.notStrictEqual(session.sdk, undefined, 'refresh should have replaced the in-memory SDK');
+			} finally {
+				await close(server);
+			}
+		});
 	});
 
 	// Contract from openspec/specs/session-auth "Manage multiple organizations

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -513,4 +513,104 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
 		});
 	});
+
+	suite('removeSession()', () => {
+		test('removes an active session: deletes its cookie, drops it from active and known profiles, and clears the org index', async () => {
+			const { session } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-remove' }),
+					org: { id: 'org-remove-primary', name: 'Primary' },
+					allManagedOrgs: [
+						{ id: 'org-remove-primary', name: 'Primary' },
+						{ id: 'org-remove-managed', name: 'Managed' },
+					],
+				},
+			});
+			await context.secrets.store('org-remove-primary', 'cookie-primary');
+			await context.secrets.store('org-remove-managed', 'cookie-managed');
+
+			const saver = SessionManager as unknown as SessionSaver;
+			await saver.saveSession(session);
+			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 1);
+
+			await SessionManager.removeSession('user-remove');
+
+			assert.strictEqual(await context.secrets.get('org-remove-primary'), undefined);
+			assert.strictEqual(await context.secrets.get('org-remove-managed'), undefined);
+			assert.strictEqual(SessionManager.getActiveSessions().length, 0);
+			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+			await assert.rejects(SessionManager.getSessionForOrg('org-remove-primary'));
+		});
+
+		test('removes a known-only (previously authenticated) session with no active session', async () => {
+			const knownProfile: SessionProfile = {
+				region: {
+					name: 'Local Test',
+					cookieName: 'appSession',
+					graphqlUrl: 'http://127.0.0.1/graphql',
+					loginUrl: 'http://127.0.0.1',
+				},
+				org: { id: 'org-known-only', name: 'Known Only' },
+				allManagedOrgs: [{ id: 'org-known-only', name: 'Known Only' }],
+				label: 'known-user (Known Only)',
+				user: { id: 'known-user' } as SessionProfile['user'],
+			};
+			SessionManager._setKnownProfilesForTesting([knownProfile]);
+			await context.secrets.store('org-known-only', 'cookie-known');
+
+			await SessionManager.removeSession('known-user');
+
+			assert.strictEqual(await context.secrets.get('org-known-only'), undefined);
+			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+			assert.strictEqual(SessionManager.getProfileForOrg('org-known-only'), undefined);
+		});
+
+		test('removing one active session leaves another active session untouched', async () => {
+			const { session: first } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-a' }),
+					org: { id: 'org-a', name: 'A' },
+					allManagedOrgs: [{ id: 'org-a', name: 'A' }],
+				},
+			});
+			const { session: second } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-b' }),
+					org: { id: 'org-b', name: 'B' },
+					allManagedOrgs: [{ id: 'org-b', name: 'B' }],
+				},
+			});
+			const saver = SessionManager as unknown as SessionSaver;
+			await saver.saveSession(first);
+			await saver.saveSession(second);
+
+			await SessionManager.removeSession('user-a');
+
+			assert.strictEqual(SessionManager.getActiveSessions().length, 1);
+			assert.strictEqual(await SessionManager.getSessionForOrg('org-b'), second);
+			await assert.rejects(SessionManager.getSessionForOrg('org-a'));
+			assert.strictEqual(SessionManager.hasActiveSessions(), true);
+		});
+
+		test('removing the only active session clears the active-sessions context', async () => {
+			const { session } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-solo' }),
+					org: { id: 'org-solo', name: 'Solo' },
+					allManagedOrgs: [{ id: 'org-solo', name: 'Solo' }],
+				},
+			});
+			const saver = SessionManager as unknown as SessionSaver;
+			await saver.saveSession(session);
+			assert.strictEqual(SessionManager.hasActiveSessions(), true);
+
+			await SessionManager.removeSession('user-solo');
+
+			assert.strictEqual(SessionManager.hasActiveSessions(), false);
+		});
+
+		test('throws when no active or known session matches the given user id', async () => {
+			await assert.rejects(SessionManager.removeSession('does-not-exist'));
+		});
+	});
 });

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -486,6 +486,71 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(promptCalled, false, 'loadSessions must not prompt for a cookie');
 			assert.strictEqual(await SessionManager.getSessionForOrg('org-restore'), sessions[0]);
 		});
+
+		test('a session removed while loadSessions is in flight is not resurrected by the load', async () => {
+			// Server that holds every response until released, so Remove Session
+			// can run while the load's createSession is still awaiting the network.
+			let release!: () => void;
+			const gate = new Promise<void>(resolve => (release = resolve));
+			const user = {
+				id: 'user-late',
+				username: 'late-user',
+				organization: { id: 'org-late', name: 'Late Org' },
+				allManagedOrgs: [{ id: 'org-late', name: 'Late Org' }],
+			};
+			const server = createServer((request, response) => {
+				request.on('data', () => {});
+				request.on('end', async () => {
+					await gate;
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(JSON.stringify({ data: { user } }));
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const region = {
+				name: 'Local Test',
+				cookieName: 'appSession',
+				graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+				loginUrl: `http://127.0.0.1:${port}`,
+			};
+			await vscode.workspace
+				.getConfiguration('rewst-buddy')
+				.update('regions', [region], vscode.ConfigurationTarget.Global);
+
+			const savedProfile: SessionProfile = {
+				region,
+				org: { id: 'org-late', name: 'Late Org' },
+				allManagedOrgs: [{ id: 'org-late', name: 'Late Org' }],
+				label: 'late-user (Late Org)',
+				user: { id: 'user-late' } as SessionProfile['user'],
+			};
+			await context.globalState.update('SessionProfiles', [savedProfile]);
+			await context.globalState.update('RewstAllKnownProfiles', [savedProfile]);
+			await context.secrets.store('org-late', 'appSession=late-cookie');
+
+			const loadPromise = SessionManager.loadSessions();
+			// Give the load a moment to read the cookie and start the request.
+			await new Promise(resolve => setTimeout(resolve, 50));
+
+			await SessionManager.removeSession('user-late');
+			release();
+			await loadPromise;
+
+			assert.strictEqual(
+				SessionManager.getActiveSessions().length,
+				0,
+				'the removed session must not be resurrected by the in-flight load',
+			);
+			assert.strictEqual(
+				await context.secrets.get('org-late'),
+				undefined,
+				'the removed session cookie must not be re-stored by the load',
+			);
+			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
+			await assert.rejects(SessionManager.getSessionForOrg('org-late'));
+		});
 	});
 
 	suite('clearProfiles()', () => {
@@ -646,6 +711,64 @@ suite('Unit: SessionManager', () => {
 
 		test('throws when no active or known session matches the given user id', async () => {
 			await assert.rejects(SessionManager.removeSession('does-not-exist'));
+		});
+
+		test('keeps a secret still needed by another profile whose org overlaps the removed session', async () => {
+			const { session: parent } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-parent' }),
+					org: { id: 'org-parent', name: 'Parent' },
+					allManagedOrgs: [
+						{ id: 'org-parent', name: 'Parent' },
+						{ id: 'org-child', name: 'Child' },
+					],
+				},
+			});
+			const { session: child } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-child' }),
+					org: { id: 'org-child', name: 'Child' },
+					allManagedOrgs: [{ id: 'org-child', name: 'Child' }],
+				},
+			});
+			await context.secrets.store('org-parent', 'cookie-parent');
+			await context.secrets.store('org-child', 'cookie-child');
+
+			const saver = SessionManager as unknown as SessionSaver;
+			await saver.saveSession(parent);
+			await saver.saveSession(child);
+
+			await SessionManager.removeSession('user-parent');
+
+			assert.strictEqual(
+				await context.secrets.get('org-parent'),
+				undefined,
+				"the removed session's own cookie is deleted",
+			);
+			assert.strictEqual(
+				await context.secrets.get('org-child'),
+				'cookie-child',
+				"another session's cookie stored under a shared org id must survive",
+			);
+			assert.strictEqual(await SessionManager.getSessionForOrg('org-child'), child);
+		});
+
+		test('stops resolving the session for its orgs before any persistence completes', async () => {
+			const { session } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-race' }),
+					org: { id: 'org-race', name: 'Race' },
+					allManagedOrgs: [{ id: 'org-race', name: 'Race' }],
+				},
+			});
+			const saver = SessionManager as unknown as SessionSaver;
+			await saver.saveSession(session);
+
+			const removal = SessionManager.removeSession('user-race');
+			// Deliberately not awaited yet: a concurrent sync must not land on a
+			// session the user has already confirmed removing.
+			await assert.rejects(SessionManager.getSessionForOrg('org-race'));
+			await removal;
 		});
 	});
 });

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -173,7 +173,9 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 				continue;
 			}
 
-			if (!(await session.validate())) {
+			// ensureValid (not validate) so a stale-but-refreshable session
+			// recovers here too, matching getSessionForOrg's contract.
+			if (!(await session.ensureValid())) {
 				log.trace('getOrgSession: skipping session, validation failed');
 				continue;
 			}
@@ -349,13 +351,21 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 	}
 
 	private unindexSession(session: Session): void {
-		for (const [orgId, sessions] of this.orgSessionIndex) {
-			const remaining = sessions.filter(candidate => candidate !== session);
-			if (remaining.length === 0) {
-				this.orgSessionIndex.delete(orgId);
-			} else if (remaining.length !== sessions.length) {
-				this.orgSessionIndex.set(orgId, remaining);
-			}
+		this.removeFromOrgIndex(session.profile.org.id, session);
+		for (const org of session.profile.allManagedOrgs) {
+			this.removeFromOrgIndex(org.id, session);
+		}
+	}
+
+	private removeFromOrgIndex(orgId: string, session: Session): void {
+		const sessions = this.orgSessionIndex.get(orgId);
+		if (!sessions) return;
+
+		const remaining = sessions.filter(candidate => candidate !== session);
+		if (remaining.length === 0) {
+			this.orgSessionIndex.delete(orgId);
+		} else if (remaining.length !== sessions.length) {
+			this.orgSessionIndex.set(orgId, remaining);
 		}
 	}
 

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -401,6 +401,50 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		log.trace('clearProfiles: cleared', { secretsCleared: orgIdsToClear.size });
 	}
 
+	/**
+	 * Removes one authenticated or previously authenticated session — active or
+	 * known-only — identified by its profile's user id, without disturbing any
+	 * other session. Mirrors clearProfiles() but scoped to a single profile.
+	 */
+	public async removeSession(userId: string): Promise<void> {
+		log.debug('removeSession: removing', userId);
+
+		const session = this.sessionMap.get(userId);
+		const knownProfile = this.getAllKnownProfiles().find(profile => profile.user.id === userId);
+		const profile = session?.profile ?? knownProfile;
+		if (!profile) {
+			throw log.error(`removeSession: no active or known session found for user ${userId}`);
+		}
+
+		const orgIdsToClear = new Set<string>([profile.org.id, ...profile.allManagedOrgs.map(org => org.id)]);
+		await Promise.all(Array.from(orgIdsToClear).map(orgId => context.secrets.delete(orgId)));
+
+		if (session) {
+			this.unindexSession(session);
+			this.sessionMap.delete(userId);
+			this.setAnyActiveSessions(this.sessionMap.size > 0);
+		}
+
+		await context.globalState.update(
+			'SessionProfiles',
+			this.getSavedProfiles().filter(saved => saved.user.id !== userId),
+		);
+
+		const remainingKnown = this.getAllKnownProfiles().filter(known => known.user.id !== userId);
+		this.knownProfilesCache = remainingKnown;
+		await context.globalState.update('RewstAllKnownProfiles', remainingKnown);
+		this.rebuildKnownProfileOrgIndex();
+
+		this.sessionChangeEmitter.fire({
+			type: 'removed',
+			session,
+			allProfiles: remainingKnown,
+			activeProfiles: this.getActiveSessions().map(s => s.profile),
+		});
+
+		log.info(`removeSession: removed ${profile.label}`);
+	}
+
 	public async getSessionForOrg(orgId: string): Promise<Session> {
 		log.trace('getSessionForOrg: looking for', orgId);
 		for (const session of this.orgSessionIndex.get(orgId) ?? []) {

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -17,7 +17,7 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 
 	sessionMap: Map<string, Session> = new Map<string, Session>();
 	private knownProfileOrgIndex = new Map<string, SessionProfile>();
-	private orgSessionIndex = new Map<string, Session>();
+	private orgSessionIndex = new Map<string, Session[]>();
 	private knownProfilesCache: SessionProfile[] | undefined;
 	private suppressProfileSaves = false;
 
@@ -330,15 +330,32 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 	}
 
 	private indexSession(session: Session): void {
-		this.orgSessionIndex.set(session.profile.org.id, session);
+		this.addToOrgIndex(session.profile.org.id, session);
 		for (const org of session.profile.allManagedOrgs) {
-			this.orgSessionIndex.set(org.id, session);
+			this.addToOrgIndex(org.id, session);
+		}
+	}
+
+	// Several active sessions can legitimately manage the same org id (see
+	// getSessionForOrg); keep every capable session so resolution can fall
+	// through to the next one when the first is no longer valid.
+	private addToOrgIndex(orgId: string, session: Session): void {
+		const existing = this.orgSessionIndex.get(orgId);
+		if (existing) {
+			if (!existing.includes(session)) existing.push(session);
+		} else {
+			this.orgSessionIndex.set(orgId, [session]);
 		}
 	}
 
 	private unindexSession(session: Session): void {
-		for (const [orgId, indexed] of this.orgSessionIndex) {
-			if (indexed === session) this.orgSessionIndex.delete(orgId);
+		for (const [orgId, sessions] of this.orgSessionIndex) {
+			const remaining = sessions.filter(candidate => candidate !== session);
+			if (remaining.length === 0) {
+				this.orgSessionIndex.delete(orgId);
+			} else if (remaining.length !== sessions.length) {
+				this.orgSessionIndex.set(orgId, remaining);
+			}
 		}
 	}
 
@@ -384,12 +401,14 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		log.trace('clearProfiles: cleared', { secretsCleared: orgIdsToClear.size });
 	}
 
-	public getSessionForOrg(orgId: string): Session {
+	public async getSessionForOrg(orgId: string): Promise<Session> {
 		log.trace('getSessionForOrg: looking for', orgId);
-		const session = this.orgSessionIndex.get(orgId);
-		if (session) {
-			log.trace('getSessionForOrg: found', { label: session.profile.label });
-			return session;
+		for (const session of this.orgSessionIndex.get(orgId) ?? []) {
+			if (await session.validate()) {
+				log.trace('getSessionForOrg: found', { label: session.profile.label });
+				return session;
+			}
+			log.trace('getSessionForOrg: skipping invalid session', { label: session.profile.label });
 		}
 		throw log.error(`getSessionForOrg: no session found for ${orgId}`);
 	}

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -448,7 +448,10 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 	public async getSessionForOrg(orgId: string): Promise<Session> {
 		log.trace('getSessionForOrg: looking for', orgId);
 		for (const session of this.orgSessionIndex.get(orgId) ?? []) {
-			if (await session.validate()) {
+			// ensureValid (not validate) so a stale-but-refreshable session
+			// recovers here rather than being skipped in favor of a worse
+			// fallback, or a false "no session manages this org".
+			if (await session.ensureValid()) {
 				log.trace('getSessionForOrg: found', { label: session.profile.label });
 				return session;
 			}

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -20,6 +20,9 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 	private orgSessionIndex = new Map<string, Session[]>();
 	private knownProfilesCache: SessionProfile[] | undefined;
 	private suppressProfileSaves = false;
+	// User ids removed while loadSessions was in flight; the load reconciles
+	// these afterwards so a completed createSession cannot resurrect them.
+	private removedDuringLoad = new Set<string>();
 
 	private readonly sessionChangeEmitter = new vscode.EventEmitter<SessionChangeEvent>();
 	private loaded = false;
@@ -250,6 +253,19 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 
 			await this.saveProfiles();
 
+			// A profile removed while its cookie-driven load was still in flight
+			// may have been resurrected by createSession completing afterwards;
+			// purge it again now that the load has settled.
+			const toPurge = Array.from(this.removedDuringLoad);
+			this.removedDuringLoad.clear();
+			for (const userId of toPurge) {
+				if (this.sessionMap.has(userId)) {
+					log.debug('loadSessions: purging session resurrected past its removal', userId);
+					await this.removeSession(userId);
+				}
+			}
+			this.removedDuringLoad.clear();
+
 			log.debug('loadSessions: completed', { sessionCount: this.sessionMap.size });
 			return this.getActiveSessions();
 		} finally {
@@ -426,14 +442,40 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 			throw log.error(`removeSession: no active or known session found for user ${userId}`);
 		}
 
-		const orgIdsToClear = new Set<string>([profile.org.id, ...profile.allManagedOrgs.map(org => org.id)]);
-		await Promise.all(Array.from(orgIdsToClear).map(orgId => context.secrets.delete(orgId)));
-
+		// Drop the session from the in-memory indexes before any await so a
+		// concurrent getSessionForOrg cannot resolve a session the user has
+		// already confirmed removing.
 		if (session) {
 			this.unindexSession(session);
 			this.sessionMap.delete(userId);
 			this.setAnyActiveSessions(this.sessionMap.size > 0);
 		}
+
+		// A load in flight may have already read this profile's cookie and can
+		// re-create the session after this removal completes; mark it so
+		// loadSessions purges any such resurrection once the load finishes.
+		if (this.loading) {
+			this.removedDuringLoad.add(userId);
+		}
+
+		// Only delete secrets no remaining profile still needs: another session
+		// can legitimately store its cookie under one of this profile's org ids
+		// (e.g. this session managed the other session's primary org).
+		const retainedOrgIds = new Set<string>();
+		const remainingProfiles = this.getActiveSessions()
+			.map(s => s.profile)
+			.concat(this.getAllKnownProfiles().filter(known => known.user.id !== userId))
+			.concat(this.getSavedProfiles().filter(saved => saved.user.id !== userId));
+		for (const remaining of remainingProfiles) {
+			retainedOrgIds.add(remaining.org.id);
+			for (const org of remaining.allManagedOrgs) {
+				retainedOrgIds.add(org.id);
+			}
+		}
+		const orgIdsToClear = [profile.org.id, ...profile.allManagedOrgs.map(org => org.id)].filter(
+			orgId => !retainedOrgIds.has(orgId),
+		);
+		await Promise.all(orgIdsToClear.map(orgId => context.secrets.delete(orgId)));
 
 		await context.globalState.update(
 			'SessionProfiles',
@@ -531,6 +573,7 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		this.orgSessionIndex.clear();
 		this.knownProfilesCache = undefined;
 		this.suppressProfileSaves = false;
+		this.removedDuringLoad.clear();
 		this.loaded = false;
 		this.loading = false;
 		this.setAnyActiveSessions(false);

--- a/src/test/helpers/index.ts
+++ b/src/test/helpers/index.ts
@@ -25,3 +25,6 @@ export { createMockSession, MockSessionOptions } from './mockSession';
 
 export { createCapabilityTestHarness, fakeCapabilityContext, findTestCapability } from './capabilityTestUtils';
 export type { RawGraphqlCall } from './capabilityTestUtils';
+
+export { listen, close, createRefreshableSessionServer, refreshableSessionProfile } from './refreshableServer';
+export type { RefreshableSessionServer } from './refreshableServer';

--- a/src/test/helpers/refreshableServer.ts
+++ b/src/test/helpers/refreshableServer.ts
@@ -1,0 +1,76 @@
+import { createServer, type Server } from 'http';
+import type { AddressInfo } from 'net';
+import type { SessionProfile } from '@sessions';
+
+export function listen(server: Server): Promise<number> {
+	return new Promise((resolve, reject) => {
+		server.once('error', reject);
+		server.listen(0, '127.0.0.1', () => {
+			server.off('error', reject);
+			resolve((server.address() as AddressInfo).port);
+		});
+	});
+}
+
+export function close(server: Server): Promise<void> {
+	return new Promise((resolve, reject) => {
+		server.close(error => (error ? reject(error) : resolve()));
+	});
+}
+
+export interface RefreshableSessionServer {
+	server: Server;
+	port: number;
+	getRequestCounts(): { get: number; post: number };
+}
+
+/**
+ * A local server that answers a GET (refreshToken's login request) with a
+ * fresh set-cookie header, and a POST (a User() query) with a fixed user
+ * response — shared by Session.test.ts and SessionManager.test.ts, both of
+ * which exercise a stale-but-refreshable session recovering via refresh.
+ */
+export async function createRefreshableSessionServer(
+	userId: string,
+	refreshedCookie = 'appSession=refreshed-cookie',
+): Promise<RefreshableSessionServer> {
+	let getCount = 0;
+	let postCount = 0;
+
+	const server = createServer((request, response) => {
+		if (request.method === 'GET') {
+			getCount++;
+			response.writeHead(200, { 'set-cookie': refreshedCookie });
+			response.end();
+			return;
+		}
+
+		let body = '';
+		request.on('data', chunk => {
+			body += String(chunk);
+		});
+		request.on('end', () => {
+			postCount++;
+			response.writeHead(200, { 'content-type': 'application/json' });
+			response.end(JSON.stringify({ data: { user: { id: userId } } }));
+		});
+	});
+
+	const port = await listen(server);
+	return { server, port, getRequestCounts: () => ({ get: getCount, post: postCount }) };
+}
+
+export function refreshableSessionProfile(orgId: string, port: number, userId: string): SessionProfile {
+	return {
+		region: {
+			name: 'Local Test',
+			cookieName: 'appSession',
+			graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+			loginUrl: `http://127.0.0.1:${port}`,
+		},
+		org: { id: orgId, name: 'Recovers Via Refresh' },
+		allManagedOrgs: [{ id: orgId, name: 'Recovers Via Refresh' }],
+		label: 'Recovers Via Refresh Session',
+		user: { id: userId } as SessionProfile['user'],
+	};
+}

--- a/src/ui/StatusBarIcon.test.ts
+++ b/src/ui/StatusBarIcon.test.ts
@@ -1,0 +1,114 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { LinkManager, SyncOnSaveManager, type TemplateLink } from '@models';
+import { Session, SessionManager } from '@sessions';
+import { Fixtures, initTestEnvironment, stub } from '@test';
+import vscode from 'vscode';
+import { StatusBar } from './StatusBarIcon';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function itemOf(bar: StatusBar): vscode.StatusBarItem {
+	return (bar as unknown as { item: vscode.StatusBarItem }).item;
+}
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+	let resolve!: (value: T) => void;
+	const promise = new Promise<T>(r => (resolve = r));
+	return { promise, resolve };
+}
+
+suite('Unit: StatusBar', () => {
+	const restores: (() => void)[] = [];
+
+	function stubActiveEditor(uri: vscode.Uri | undefined): void {
+		restores.push(
+			stub(
+				vscode.window,
+				'activeTextEditor',
+				(uri ? { document: { uri } } : undefined) as unknown as vscode.TextEditor,
+			),
+		);
+	}
+
+	setup(() => {
+		initTestEnvironment();
+	});
+
+	teardown(() => {
+		while (restores.length) restores.pop()!();
+		SessionManager._resetForTesting();
+	});
+
+	test('a slow session lookup for a previous file does not overwrite the status bar set for the current file', async () => {
+		const uriA = vscode.Uri.file('/test/docA.jinja');
+		const uriB = vscode.Uri.file('/test/docB.jinja');
+
+		const linkA: TemplateLink = {
+			type: 'Template',
+			uriString: uriA.toString(),
+			org: { id: 'org-A', name: 'Org A' },
+			bodyHash: 'hash-a',
+			template: Fixtures.fullTemplate({ name: 'Template A' }),
+		};
+		const linkB: TemplateLink = {
+			type: 'Template',
+			uriString: uriB.toString(),
+			org: { id: 'org-B', name: 'Org B' },
+			bodyHash: 'hash-b',
+			template: Fixtures.fullTemplate({ name: 'Template B' }),
+		};
+
+		restores.push(
+			stub(LinkManager, 'getTemplateLink', ((uri: vscode.Uri) =>
+				uri.toString() === uriA.toString() ? linkA : linkB) as typeof LinkManager.getTemplateLink),
+		);
+		restores.push(
+			stub(SessionManager, 'hasActiveSessions', (() => true) as typeof SessionManager.hasActiveSessions),
+		);
+
+		const orgAGate = deferred<Session>();
+		restores.push(
+			stub(SessionManager, 'getSessionForOrg', ((orgId: string) =>
+				orgId === 'org-A'
+					? orgAGate.promise
+					: Promise.resolve({} as Session)) as typeof SessionManager.getSessionForOrg),
+		);
+		restores.push(
+			stub(
+				SyncOnSaveManager,
+				'isUriSynced',
+				((uri: vscode.Uri) => uri.toString() === uriB.toString()) as typeof SyncOnSaveManager.isUriSynced,
+			),
+		);
+
+		// Prevent the constructor's own fire-and-forget update() from racing the
+		// manual calls below.
+		stubActiveEditor(undefined);
+		const bar = new StatusBar();
+		try {
+			stubActiveEditor(uriA);
+			const callA = bar.update();
+
+			stubActiveEditor(uriB);
+			await bar.update();
+
+			assert.strictEqual(
+				itemOf(bar).text,
+				'Rewst Sync-On-Save: ON $(check)',
+				'the current file (B) should show its own synced state',
+			);
+
+			orgAGate.resolve({} as Session);
+			await callA;
+
+			assert.strictEqual(
+				itemOf(bar).text,
+				'Rewst Sync-On-Save: ON $(check)',
+				"the stale update for file A must not overwrite file B's status once A's slow lookup resolves",
+			);
+		} finally {
+			bar.dispose();
+		}
+	});
+});

--- a/src/ui/StatusBarIcon.test.ts
+++ b/src/ui/StatusBarIcon.test.ts
@@ -12,10 +12,14 @@ function itemOf(bar: StatusBar): vscode.StatusBarItem {
 	return (bar as unknown as { item: vscode.StatusBarItem }).item;
 }
 
-function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void; reject: (error: unknown) => void } {
 	let resolve!: (value: T) => void;
-	const promise = new Promise<T>(r => (resolve = r));
-	return { promise, resolve };
+	let reject!: (error: unknown) => void;
+	const promise = new Promise<T>((res, rej) => {
+		resolve = res;
+		reject = rej;
+	});
+	return { promise, resolve, reject };
 }
 
 suite('Unit: StatusBar', () => {
@@ -106,6 +110,78 @@ suite('Unit: StatusBar', () => {
 				itemOf(bar).text,
 				'Rewst Sync-On-Save: ON $(check)',
 				"the stale update for file A must not overwrite file B's status once A's slow lookup resolves",
+			);
+		} finally {
+			bar.dispose();
+		}
+	});
+
+	test('a slow session lookup for a previous file that rejects does not overwrite the status bar for the current file', async () => {
+		const uriA = vscode.Uri.file('/test/docA2.jinja');
+		const uriB = vscode.Uri.file('/test/docB2.jinja');
+
+		const linkA: TemplateLink = {
+			type: 'Template',
+			uriString: uriA.toString(),
+			org: { id: 'org-A', name: 'Org A' },
+			bodyHash: 'hash-a',
+			template: Fixtures.fullTemplate({ name: 'Template A' }),
+		};
+		const linkB: TemplateLink = {
+			type: 'Template',
+			uriString: uriB.toString(),
+			org: { id: 'org-B', name: 'Org B' },
+			bodyHash: 'hash-b',
+			template: Fixtures.fullTemplate({ name: 'Template B' }),
+		};
+
+		restores.push(
+			stub(LinkManager, 'getTemplateLink', ((uri: vscode.Uri) =>
+				uri.toString() === uriA.toString() ? linkA : linkB) as typeof LinkManager.getTemplateLink),
+		);
+		restores.push(
+			stub(SessionManager, 'hasActiveSessions', (() => true) as typeof SessionManager.hasActiveSessions),
+		);
+
+		const orgAGate = deferred<Session>();
+		restores.push(
+			stub(SessionManager, 'getSessionForOrg', ((orgId: string) =>
+				orgId === 'org-A'
+					? orgAGate.promise
+					: Promise.resolve({} as Session)) as typeof SessionManager.getSessionForOrg),
+		);
+		restores.push(
+			stub(
+				SyncOnSaveManager,
+				'isUriSynced',
+				((uri: vscode.Uri) => uri.toString() === uriB.toString()) as typeof SyncOnSaveManager.isUriSynced,
+			),
+		);
+
+		// Prevent the constructor's own fire-and-forget update() from racing the
+		// manual calls below.
+		stubActiveEditor(undefined);
+		const bar = new StatusBar();
+		try {
+			stubActiveEditor(uriA);
+			const callA = bar.update();
+
+			stubActiveEditor(uriB);
+			await bar.update();
+
+			assert.strictEqual(
+				itemOf(bar).text,
+				'Rewst Sync-On-Save: ON $(check)',
+				'the current file (B) should show its own synced state',
+			);
+
+			orgAGate.reject(new Error('session lookup failed for org-A'));
+			await callA;
+
+			assert.strictEqual(
+				itemOf(bar).text,
+				'Rewst Sync-On-Save: ON $(check)',
+				"the stale rejected lookup for file A must not overwrite file B's status with the no-session warning",
 			);
 		} finally {
 			bar.dispose();

--- a/src/ui/StatusBarIcon.ts
+++ b/src/ui/StatusBarIcon.ts
@@ -34,6 +34,7 @@ export class StatusBar implements vscode.Disposable {
 			this.clear();
 			return;
 		}
+		const editorUriAtStart = activeEditor.document.uri.toString();
 
 		let link;
 		try {
@@ -55,10 +56,15 @@ export class StatusBar implements vscode.Disposable {
 		try {
 			await SessionManager.getSessionForOrg(link.org.id);
 		} catch (e) {
+			// The active editor may have changed while this awaited; a stale
+			// result must not clobber the status bar the newer update() owns.
+			if (!this.isStillActiveEditor(editorUriAtStart)) return;
 			log.error(`No session found with access to org ${link.template.organization.name}`);
 			this.privateWarnNoSession();
 			return;
 		}
+
+		if (!this.isStillActiveEditor(editorUriAtStart)) return;
 
 		const isSyncEnabled = SyncOnSaveManager.isUriSynced(activeEditor.document.uri);
 
@@ -67,6 +73,10 @@ export class StatusBar implements vscode.Disposable {
 		} else {
 			this.privateWarnSyncOnSaveDisabled();
 		}
+	}
+
+	private isStillActiveEditor(uriString: string): boolean {
+		return vscode.window.activeTextEditor?.document.uri.toString() === uriString;
 	}
 
 	private privateWarnSyncOnSaveDisabled() {

--- a/src/ui/StatusBarIcon.ts
+++ b/src/ui/StatusBarIcon.ts
@@ -53,7 +53,7 @@ export class StatusBar implements vscode.Disposable {
 
 		// Check if we have a session for this template's organization
 		try {
-			SessionManager.getSessionForOrg(link.org.id);
+			await SessionManager.getSessionForOrg(link.org.id);
 		} catch (e) {
 			log.error(`No session found with access to org ${link.template.organization.name}`);
 			this.privateWarnNoSession();

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
@@ -65,7 +65,7 @@ function makeHarness(turns: ConversationEvent[][], overrides: Partial<ProviderDe
 	const deps: ProviderDeps = {
 		ask,
 		sessions: () => [session],
-		sessionForOrg: () => session,
+		sessionForOrg: async () => session,
 		workspaceRoot: () => undefined,
 		aiConfig: () => ({
 			customInstructions: '',

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.ts
@@ -50,7 +50,7 @@ const MAX_OUTPUT_TOKENS = 16_000;
 export interface ProviderDeps {
 	ask(options: AskOptions): AsyncGenerator<ConversationEvent>;
 	sessions(): Session[];
-	sessionForOrg(orgId: string): Session;
+	sessionForOrg(orgId: string): Promise<Session>;
 	workspaceRoot(): string | undefined;
 	aiConfig(): {
 		customInstructions: string;
@@ -296,7 +296,7 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 	): Promise<void> {
 		if (messages.length === 0) throw new Error('No messages in the chat request.');
 		const orgId = model.id;
-		const session = this.deps.sessionForOrg(orgId);
+		const session = await this.deps.sessionForOrg(orgId);
 		const tools = options.tools ?? [];
 		const vscodeNames = new Set(tools.map(tool => tool.name));
 		// Buddy (MCP) tools the chat advertises and runs in-process, so they survive

--- a/src/ui/pickers/SessionPicker.ts
+++ b/src/ui/pickers/SessionPicker.ts
@@ -1,4 +1,4 @@
-import { Session, SessionManager } from '@sessions';
+import { Session, SessionManager, SessionProfile } from '@sessions';
 import { log } from '@utils';
 import vscode from 'vscode';
 
@@ -26,4 +26,36 @@ export async function pickSession(): Promise<Session | undefined> {
 	});
 
 	return picked?.session;
+}
+
+/**
+ * Picks from every known session profile — active or previously authenticated
+ * (known-only) — for operations like removal that must reach an inactive
+ * profile too, not just a currently active one.
+ */
+export async function pickKnownProfile(): Promise<SessionProfile | undefined> {
+	const profiles = SessionManager.getAllKnownProfiles();
+
+	if (profiles.length === 0) {
+		log.notifyWarn('No sessions available.');
+		return undefined;
+	}
+
+	if (profiles.length === 1) {
+		log.debug(`Only one known session, returning it for ease`);
+		return profiles[0];
+	}
+
+	const activeUserIds = new Set(SessionManager.getActiveSessions().map(session => session.profile.user.id));
+	const items = profiles.map(profile => ({
+		label: profile.label,
+		description: `${profile.org.id}${activeUserIds.has(profile.user.id) ? '' : ' (inactive)'}`,
+		profile,
+	}));
+
+	const picked = await vscode.window.showQuickPick(items, {
+		placeHolder: 'Select a session to remove',
+	});
+
+	return picked?.profile;
 }

--- a/src/ui/pickers/index.ts
+++ b/src/ui/pickers/index.ts
@@ -1,3 +1,3 @@
 export { pickOrganization } from './OrganizationPicker';
-export { pickSession } from './SessionPicker';
+export { pickKnownProfile, pickSession } from './SessionPicker';
 export { pickTemplate } from './TemplatePicker';


### PR DESCRIPTION
## Summary

- **Session resolution bug fix**: `SessionManager.getSessionForOrg` (the region-less org→session lookup used by MCP/buddy tool calls, chat, sync, and template commands) indexed one session per org id and returned it without checking whether it was still valid — so a stale duplicate session could shadow a still-valid one managing the same org, and the choice of which session "won" the index slot was non-deterministic across restarts (concurrent session loading). It now keeps every capable session per org id and validates candidates in order, recovering a merely stale-but-refreshable session via one refresh attempt (`Session.ensureValid()`) before falling through to the next capable session.
- **`MCP` resolution restructured**: `McpActions.resolveContext` is split into a pure `resolveOrgId` (no I/O, runs before the scope gate) and an async `resolveContext` (session resolution/validation, runs after the gate), preserving the existing "no authenticated I/O for an out-of-scope request" guarantee now that session resolution can validate/refresh.
- **New feature** (issue #111, "Cannot remove sessions"): "Clear Sessions" was previously all-or-nothing. Adds `SessionManager.removeSession(userId)` and a "Remove Session" command — right-click a session in the Sessions view to remove it directly, or run it from the command palette to pick from any known profile (active or previously-authenticated/inactive). The palette entry is always visible (not gated on having an active session), since removing a known-only/inactive session is exactly the case it needs to cover.
- `openspec/specs/session-auth/spec.md` updated to close two documented implementation gaps and add the new "Remove a single session" requirement + scenarios.

## Test plan

- [x] `npm test` — 1094 passing, 6 pending (pre-existing), 7 failing (pre-existing live-integration tests requiring a fresh `REWST_TEST_TOKEN`, unrelated to this change)
- [x] `npm run type-check` — clean
- [x] New/updated unit tests: `SessionManager.test.ts` (org-index fallback + refresh recovery + `removeSession`), `Session.test.ts` (`ensureValid()`), `McpActions.test.ts` (unchanged tests still pass, including the "no authenticated I/O before scope gate" regression guard), `RemoveSession.test.ts`, `packageManifest.test.ts` (Remove Session palette visibility)
- [x] Reviewed by Codex; two findings from that pass (stale-session-not-refreshed regression in MCP path, Remove Session hidden from palette without an active session) were fixed and covered with tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a **Remove Session** command to delete a single authenticated (or previously authenticated) session, without clearing other sessions. Available from the **Sessions** view (right-click) and the command palette.
* **Bug Fixes**
  * Session org lookups now recover more reliably from stale sessions by refreshing when possible, instead of failing or falling back incorrectly.
  * Improved reliability across template and chat actions by properly waiting for session resolution.
  * Prevented status bar updates from being overwritten by slower, earlier session lookups.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->