### PR TITLE
Add set_output and sub-workflow composition guidance to workflow edit tooling

### DIFF
--- a/changelog.d/workflow-edit-semantics-docs.md
+++ b/changelog.d/workflow-edit-semantics-docs.md
@@ -1,5 +1,6 @@
 ---
 category: Changed
+pr: 117
 ---
 
 **Workflow tool guidance:** `buddy_workflow_edit` now documents transition first-match order, publishing on failure edges, `with.items` loops (`item()` and collected results), the full `update_task` field list, and recommends sub-workflow composition for large workflows.

--- a/changelog.d/workflow-edit-semantics-docs.md
+++ b/changelog.d/workflow-edit-semantics-docs.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+**Workflow tool guidance:** `buddy_workflow_edit` now documents transition first-match order, publishing on failure edges, `with.items` loops (`item()` and collected results), the full `update_task` field list, and recommends sub-workflow composition for large workflows.

--- a/changelog.d/workflow-set-output.md
+++ b/changelog.d/workflow-set-output.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 117
 ---
 
 **Sub-workflow outputs:** `buddy_workflow_edit` gains a `set_output` operation for defining the values a workflow returns to its caller, and `buddy_workflow_get` now shows those outputs — so AI tools can build composed workflows instead of one giant canvas.

--- a/changelog.d/workflow-set-output.md
+++ b/changelog.d/workflow-set-output.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+**Sub-workflow outputs:** `buddy_workflow_edit` gains a `set_output` operation for defining the values a workflow returns to its caller, and `buddy_workflow_get` now shows those outputs — so AI tools can build composed workflows instead of one giant canvas.

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -265,12 +265,14 @@ SHALL explicitly carry forward its existing advanced settings
 (`transitionMode`, `join`, `publishResultAs`, `timeout`, `humanSecondsSaved`,
 `isMocked`, `mockInput`, `runAsOrgId`, `retry`, `with`, `metadata`,
 `packOverrides`) so that an edit unrelated to those fields does not reset them.
-Top-level workflow fields the tool does not read or write (such as `output`,
-`tags`, `notes`, `triggers`, and the workflow's own `humanSecondsSaved`) SHALL
-be left untouched by the mutation rather than reset, since `updateWorkflow`
-only replaces fields actually present in its input — unlike the per-task
-`tasks` array, the top level of the mutation behaves as a patch, not a full
-replace. A `buddy_workflow_edit` operation that sets a task's `input` or
+Top-level workflow fields the tool does not write (such as `tags`, `notes`,
+`triggers`, and the workflow's own `humanSecondsSaved`) SHALL be left
+untouched by the mutation rather than reset, since `updateWorkflow` only
+replaces fields actually present in its input — unlike the per-task `tasks`
+array, the top level of the mutation behaves as a patch, not a full replace.
+The workflow's `output` list SHALL follow the same rule: it is sent only when
+a `set_output` operation provides it, so an unrelated edit never resends or
+resets it. A `buddy_workflow_edit` operation that sets a task's `input` or
 `with` object SHALL accept that value as a JSON-encoded string and parse it
 back into an object rather than storing the literal string. A `set_transition`
 operation that omits both `to` and `transitionId` SHALL resolve to the task's
@@ -297,8 +299,8 @@ caller to disambiguate with `to` or `transitionId` otherwise.
 - **GIVEN** a workflow has tags, notes, triggers, and output configured
   directly in Rewst
 - **WHEN** `buddy_workflow_edit` saves an unrelated task change
-- **THEN** the mutation input does not include `tags`, `notes`, `triggers`, or
-  the workflow-level `humanSecondsSaved`
+- **THEN** the mutation input does not include `tags`, `notes`, `triggers`,
+  `output`, or the workflow-level `humanSecondsSaved`
 - **AND** those fields remain whatever they were before the edit
 
 #### Scenario: A JSON-string task input is parsed
@@ -317,6 +319,41 @@ caller to disambiguate with `to` or `transitionId` otherwise.
 - **THEN** it targets that sole transition
 - **AND** if the task has more than one outgoing transition instead, the
   operation errors asking for `to` or `transitionId`
+
+### Requirement: Expose the sub-workflow output contract
+
+The system SHALL let a caller define a workflow's outputs — the caller-visible
+values another workflow reads as `RESULT.<name>` when it runs this workflow as
+a sub-workflow task — via a `set_output` operation on `buddy_workflow_edit`,
+and SHALL surface the existing outputs in `buddy_workflow_get` as name/value
+pairs in the workflow header. `set_output` SHALL accept a `{name: "<jinja>"}`
+object or a `[{name, value}]` array, store the result in the API's ordered
+single-key-object list form, wrap raw boolean/number values as Jinja
+expressions, treat an empty array as clearing the outputs, and error when
+`outputs` is missing. The `buddy_workflow_edit` tool description SHALL
+recommend sub-workflow composition — defining a reusable sequence as its own
+workflow with `set_inputs`/`set_output` and calling it via `add_task` with
+`subWorkflowId` — over growing a single large canvas.
+
+#### Scenario: set_output writes the ordered output list
+
+- **GIVEN** a `set_output` operation with
+  `outputs: {success: "{{ CTX.success|d(false) }}"}`
+- **WHEN** `buddy_workflow_edit` applies it
+- **THEN** the mutation input's `output` is
+  `[{"success": "{{ CTX.success|d(false) }}"}]`
+
+#### Scenario: Outputs are visible to a prospective caller
+
+- **GIVEN** a workflow whose `output` list is non-empty
+- **WHEN** `buddy_workflow_get` reads it (either detail level)
+- **THEN** the workflow header lists each output as a `{name, value}` pair
+
+#### Scenario: Raw scalars become Jinja expressions
+
+- **GIVEN** a `set_output` entry whose value is the boolean `true`
+- **WHEN** `buddy_workflow_edit` applies it
+- **THEN** the stored value is the Jinja expression string `{{ true }}`
 
 ### Requirement: Scope reads per configuration
 

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -68,6 +68,7 @@ function sampleWorkflow() {
 			},
 		},
 		updatedAt: '1000',
+		output: [{ user_found: '{{ CTX.user_found|d(false) }}' }],
 		tasks: sampleTasks(),
 	};
 }
@@ -108,6 +109,40 @@ suite('Unit: workflowTools', () => {
 		assert.match(spec.description, /does not expose parallel task controls/i);
 	});
 
+	test('buddy_workflow_edit spec teaches sub-workflow composition through set_output', () => {
+		const spec = WORKFLOW_TOOL_SPECS.find(tool => tool.name === WORKFLOW_EDIT_TOOL_NAME);
+		assert.ok(spec, 'buddy_workflow_edit spec exists');
+		assert.match(spec.description, /set_output \{outputs/, 'set_output is listed as an operation');
+		assert.match(spec.description, /RESULT\.<name>/, 'ties a sub-workflow call result to the set_output contract');
+		assert.match(spec.description, /prefer composition/i, 'recommends composing over one giant canvas');
+		assert.match(
+			spec.description,
+			/sign to split/i,
+			'names the smell that should push a build toward sub-workflows',
+		);
+	});
+
+	test('buddy_workflow_edit spec states transition, publish, and loop semantics', () => {
+		const spec = WORKFLOW_TOOL_SPECS.find(tool => tool.name === WORKFLOW_EDIT_TOOL_NAME);
+		assert.ok(spec, 'buddy_workflow_edit spec exists');
+		assert.match(
+			spec.description,
+			/at most one outgoing transition.*first.*listed order/i,
+			'documents first-match transition evaluation',
+		);
+		assert.match(
+			spec.description,
+			/publish entries apply whenever that transition is taken, including on \{\{ FAILED \}\}/i,
+			'documents publish firing on failure edges',
+		);
+		assert.match(spec.description, /\{\{ item\(\) \}\}/, 'documents the with.items current-element callable');
+		assert.match(
+			spec.description,
+			/update_task \{id\|name, set:\{name\?, input\?, action\? or subWorkflowId\?, publishResultAs\?, timeout\?, description\?, with\?\}\}/,
+			'enumerates the update_task settable fields',
+		);
+	});
+
 	suite('normalizePublish()', () => {
 		test('keeps {key,value} array form', () => {
 			assert.deepStrictEqual(normalizePublish([{ key: 'a', value: '1' }]), [{ key: 'a', value: '1' }]);
@@ -145,6 +180,19 @@ suite('Unit: workflowTools', () => {
 			const w = sampleWorkflow();
 			const input = workflowToInput(w as never, w.tasks as never);
 			assert.deepStrictEqual(input.parameters, w.action.parameters, 'parameters preserved');
+		});
+
+		test('output is sent only when a set_output override provides it', () => {
+			// The top level of updateWorkflow behaves as a patch: omitting output
+			// leaves it untouched server-side, so an unrelated edit must not resend
+			// the read-back value — only set_output writes it.
+			const w = sampleWorkflow();
+			const without = workflowToInput(w as never, w.tasks as never);
+			assert.ok(!('output' in without), 'read-back output is not resent on unrelated edits');
+			const withOverride = workflowToInput(w as never, w.tasks as never, {
+				output: [{ done: '{{ true }}' }],
+			});
+			assert.deepStrictEqual(withOverride.output, [{ done: '{{ true }}' }], 'set_output override wins');
 		});
 
 		test('resends a task pack override (integration override) so an edit does not drop it', () => {
@@ -315,6 +363,54 @@ suite('Unit: workflowTools', () => {
 			assert.strictEqual(params.drop.default, '{{ false }}', 'raw boolean default is Jinja-wrapped');
 			assert.strictEqual(schema.properties.drop.default, '{{ false }}', 'inputSchema default is wrapped too');
 			assert.ok(!('varsSchema' in workflow), 'varsSchema is never touched by set_inputs');
+		});
+
+		test('set_output builds the ordered single-key output list from an object map', () => {
+			const ops: WorkflowOperation[] = [
+				{
+					op: 'set_output',
+					outputs: { success: '{{ CTX.success|d(false) }}', data: '{{ CTX.data|d(None) }}' },
+				},
+			];
+			const { workflow, applied } = applyOperations(sampleTasks() as never, ops, NO_ACTIONS);
+			assert.deepStrictEqual(
+				workflow.output,
+				[{ success: '{{ CTX.success|d(false) }}' }, { data: '{{ CTX.data|d(None) }}' }],
+				'stored as the API\'s ordered [{name: "<jinja>"}] list',
+			);
+			assert.match(applied[0], /set_output \(2: success, data\)/);
+		});
+
+		test('set_output accepts a {name, value} array and wraps raw scalars as Jinja', () => {
+			const ops: WorkflowOperation[] = [
+				{
+					op: 'set_output',
+					outputs: [
+						{ name: 'enabled', value: true },
+						{ name: 'count', value: 3 },
+						{ name: 'log', value: '{{ CTX.automation_log|d([]) }}' },
+					],
+				},
+			];
+			const { workflow } = applyOperations(sampleTasks() as never, ops, NO_ACTIONS);
+			assert.deepStrictEqual(workflow.output, [
+				{ enabled: '{{ true }}' },
+				{ count: '{{ 3 }}' },
+				{ log: '{{ CTX.automation_log|d([]) }}' },
+			]);
+		});
+
+		test('set_output with an empty array clears the outputs', () => {
+			const ops: WorkflowOperation[] = [{ op: 'set_output', outputs: [] }];
+			const { workflow } = applyOperations(sampleTasks() as never, ops, NO_ACTIONS);
+			assert.deepStrictEqual(workflow.output, []);
+		});
+
+		test('set_output without outputs throws instead of clearing', () => {
+			assert.throws(
+				() => applyOperations(sampleTasks() as never, [{ op: 'set_output' }], NO_ACTIONS),
+				/set_output requires "outputs"/,
+			);
 		});
 
 		test('a new task defaults to FOLLOW_FIRST + join 1 and gets a terminal transition', () => {
@@ -1000,6 +1096,23 @@ suite('Unit: workflowTools', () => {
 			assert.strictEqual(parsed.nodes[0].id, 'aa01', 'task id present in full view');
 			assert.deepStrictEqual(parsed.nodes[0].position, { x: 0, y: 0 }, 'position present in full view');
 			assert.deepStrictEqual(parsed.edges[0].to, ['end (bb02)'], 'targets carry the id in full view');
+		});
+
+		test('buddy_workflow_get surfaces workflow outputs, the sub-workflow return contract', async () => {
+			const { deps, calls } = makeDeps();
+			const output = await runWorkflowTool(
+				{ tool: 'buddy_workflow_get', args: { workflowId: 'wf-1', orgId: 'org-1' } },
+				deps,
+			);
+			const getCall = calls.find(c => c.query.includes('RewstBuddyWorkflowGet'));
+			assert.ok(getCall && /\boutput\b/.test(getCall.query), 'the read query selects the output field');
+			const parsed = JSON.parse(output);
+			assert.deepStrictEqual(
+				parsed.workflow.outputs,
+				[{ name: 'user_found', value: '{{ CTX.user_found|d(false) }}' }],
+				'outputs are surfaced as name/value pairs in the workflow header',
+			);
+			assert.match(parsed.note, /set_output/, 'the note points at set_output for changing the contract');
 		});
 
 		test('buddy_workflow_get hides task mode and join criteria', async () => {

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -108,7 +108,7 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 		name: WORKFLOW_EDIT_TOOL_NAME,
 		args: '{"workflowId": string, "workflowName": string, "orgId": string, "orgName": string, "operations": object[], "comment"?: string}',
 		description:
-			'Edit a Rewst workflow by applying high-level operations. The tool reads the current workflow, applies the operations to the full graph, and saves it back with conflict detection and an undoable patch — you never resend the whole workflow or manage version tokens yourself. Operations (each an object with an "op" field): add_task {name, action (ref or id) OR subWorkflowId, input?, publishResultAs?, with?, x?, y?}; update_task {id|name, set:{...}}; delete_task {id|name} (also removes edges pointing at it); connect {from, to, when?, label?, publish?} (from/to are task names or ids); disconnect {from, to?|transitionId?}; set_transition {from, to?|transitionId?, set:{when?, label?, publish?, to?}}; reposition {task, x, y} (move a task to canvas coordinates); set_inputs {inputs: [{name, type?, title?, default?, description?, required?, multiline?}]} (replace the workflow\'s run/call inputs; an input default is a Jinja expression like "{{ false }}" or "{{ CTX.x }}" — raw booleans/numbers are wrapped for you). Define workflow inputs ONLY with set_inputs: it writes the input name list, the action parameters that actually drive the run/call form, and the inputSchema together. Do not put inputs in varsSchema, which is a separate variables map. To call another workflow as a sub-workflow, set subWorkflowId (or action) to that workflow\'s id — a workflow\'s id is its action id; there is no separate run-workflow action. To branch on what a task returned, read RESULT.<field> in that task\'s own outgoing transition conditions, or CTX.<alias>.<field> when the task sets publishResultAs to <alias>; a task\'s or sub-workflow\'s internally published variables are NOT in this workflow\'s CTX. when defaults to "{{ SUCCEEDED }}"; the tool automatically orders each task\'s transitions so custom conditions come before the success catch-all. It does not expose parallel task controls: new tasks use sequential graph defaults, and any `with.items` value is only per-action loop concurrency inside that one task. A new task is positioned on the canvas below the action it is connected from (leaving a gap) unless you pass x/y; x is canvas right, y is down, in free pixels. This is a mutation: it MUST include workflowId, workflowName, orgId, orgName (get them from buddy_workflow_get) and requires user approval, remembered per workflow for the session.',
+			'Edit a Rewst workflow by applying high-level operations. The tool reads the current workflow, applies the operations to the full graph, and saves it back with conflict detection and an undoable patch — you never resend the whole workflow or manage version tokens yourself. Operations (each an object with an "op" field): add_task {name, action (ref or id) OR subWorkflowId, input?, publishResultAs?, with?, x?, y?}; update_task {id|name, set:{name?, input?, action? or subWorkflowId?, publishResultAs?, timeout?, description?, with?}}; delete_task {id|name} (also removes edges pointing at it); connect {from, to, when?, label?, publish?} (from/to are task names or ids); disconnect {from, to?|transitionId?}; set_transition {from, to?|transitionId?, set:{when?, label?, publish?, to?}}; reposition {task, x, y} (move a task to canvas coordinates); set_inputs {inputs: [{name, type?, title?, default?, description?, required?, multiline?}]} (replace the workflow\'s run/call inputs; an input default is a Jinja expression like "{{ false }}" or "{{ CTX.x }}" — raw booleans/numbers are wrapped for you); set_output {outputs: {name: "<jinja>"} object or [{name, value}] array} (replace the workflow\'s caller-visible outputs; raw booleans/numbers are wrapped for you). Define workflow inputs ONLY with set_inputs: it writes the input name list, the action parameters that actually drive the run/call form, and the inputSchema together. Do not put inputs in varsSchema, which is a separate variables map. To call another workflow as a sub-workflow, set subWorkflowId (or action) to that workflow\'s id — a workflow\'s id is its action id; there is no separate run-workflow action. PREFER COMPOSITION over one giant canvas: give a chunky reusable sequence (ticket lifecycle, user lookup, license handling) its own workflow with set_inputs for its run inputs and set_output for its return values, then call it with add_task subWorkflowId — the calling task reads RESULT.<name> for exactly the names set_output declared (or CTX.<publishResultAs>.<name> when it sets publishResultAs). A single canvas growing past roughly 15-20 tasks with distinct concerns is a sign to split. To branch on what a task returned, read RESULT.<field> in that task\'s own outgoing transition conditions, or CTX.<alias>.<field> when the task sets publishResultAs to <alias>; a task\'s or sub-workflow\'s internally published variables are NOT in this workflow\'s CTX. At runtime a task follows at most one outgoing transition — the first, in listed order, whose condition holds — so a custom-condition edge followed by the "{{ SUCCEEDED }}" catch-all forms a clean two-way branch. when defaults to "{{ SUCCEEDED }}"; the tool automatically orders each task\'s transitions so custom conditions come before the success catch-all. A transition\'s publish entries apply whenever that transition is taken, including on {{ FAILED }} edges, and entries on one transition evaluate in order (a later entry can read an earlier one from CTX); transition publish is the only place to compute context variables — tasks have no publish of their own, only publishResultAs for their raw result. Inside a with.items loop task, reference the current element as the callable {{ item() }} (not CTX.item); when such a task sets publishResultAs, the published value is a list with one wrapper per item, each holding that item\'s result. It does not expose parallel task controls: new tasks use sequential graph defaults, and any `with.items` value is only per-action loop concurrency inside that one task. A new task is positioned on the canvas below the action it is connected from (leaving a gap) unless you pass x/y; x is canvas right, y is down, in free pixels. This is a mutation: it MUST include workflowId, workflowName, orgId, orgName (get them from buddy_workflow_get) and requires user approval, remembered per workflow for the session.',
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -319,6 +319,9 @@ interface RawWorkflow {
 	action?: { parameters?: Record<string, unknown> | null } | null;
 	updatedAt?: string | null;
 	input?: string[] | null;
+	// The caller-visible return contract: an ordered [{name: "<jinja>"}] list a
+	// sub-workflow renders at end of run — what its caller reads as RESULT.<name>.
+	output?: unknown;
 	inputSchema?: unknown;
 	outputSchema?: unknown;
 	varsSchema?: unknown;
@@ -332,7 +335,7 @@ const WORKFLOW_GET_QUERY = `query RewstBuddyWorkflowGet($where: WorkflowWhereInp
 		id name description type schemaVersion version orgId updatedAt
 		organization { id name }
 		action { parameters }
-		input inputSchema outputSchema varsSchema metadata timeout
+		input output inputSchema outputSchema varsSchema metadata timeout
 		tasks {
 			id name actionId description input metadata
 			transitionMode publishResultAs join timeout humanSecondsSaved
@@ -1119,6 +1122,43 @@ export function applyOperations(
 				applied.push(`set_inputs (${names.length}: ${names.join(', ') || 'none'})`);
 				break;
 			}
+			case 'set_output': {
+				// The workflow's outputs are its return contract to callers: when
+				// another workflow runs this one as a sub-workflow task, RESULT.<name>
+				// (or CTX.<publishResultAs>.<name>) is exactly these entries, rendered
+				// at end of run. Stored as the API's ordered [{name: "<jinja>"}] list.
+				const raw = operation.outputs;
+				if (raw == null || typeof raw !== 'object') {
+					throw new Error(
+						'set_output requires "outputs": a {name: "<jinja>"} object or [{name, value}] array (an empty array clears the outputs).',
+					);
+				}
+				// Accept the natural {name, value} array spelling alongside the
+				// {key, value} / object-map / single-key-object forms normalizePublish
+				// already handles.
+				const withKeys = Array.isArray(raw)
+					? raw.map(entry => {
+							const record = entry as Record<string, unknown>;
+							return record &&
+								typeof record === 'object' &&
+								typeof record.name === 'string' &&
+								'value' in record
+								? { key: record.name, value: record.value }
+								: entry;
+						})
+					: raw;
+				const entries = normalizePublish(withKeys);
+				// Output values are Jinja expression strings; wrap raw scalars the same
+				// way set_inputs wraps defaults so a literal true/3 still renders.
+				workflow.output = entries.map(entry => ({
+					[entry.key]:
+						typeof entry.value === 'boolean' || typeof entry.value === 'number'
+							? `{{ ${entry.value} }}`
+							: entry.value,
+				}));
+				applied.push(`set_output (${entries.length}: ${entries.map(entry => entry.key).join(', ') || 'none'})`);
+				break;
+			}
 			default:
 				throw new Error(`Unknown operation "${op}".`);
 		}
@@ -1412,11 +1452,17 @@ function summarizeWorkflow(w: RawWorkflow, detail: 'summary' | 'full' = 'summary
 		type: w.type ?? undefined,
 		inputs,
 	};
+	// Outputs are the caller-visible return contract ([{name: "<jinja>"}] on the
+	// API); shown as name/value pairs so a caller knows what RESULT.<name> holds.
+	const outputEntries = normalizePublish(Array.isArray(w.output) ? w.output : []);
+	if (outputEntries.length > 0) {
+		workflow.outputs = outputEntries.map(entry => ({ name: entry.key, value: entry.value }));
+	}
 	if (full) workflow.versionToken = w.updatedAt;
 
 	const note = full
-		? 'To edit or auto-layout, pass these workflow fields straight through: workflowId=workflow.id, workflowName=workflow.name, orgId=workflow.orgId, orgName=workflow.orgName (use the names, not the ids). The version token is handled for you. node.position is the canvas {x,y} top-left anchor in free pixels (x right, y down); new tasks are auto-placed below the action they connect from unless you pass x/y. To call another workflow, use add_task with subWorkflowId set to that workflow id (there is no run-workflow action). Branch on a task\'s output with RESULT.<field> in that task\'s transitions, or CTX.<publishResultAs>.<field> — not CTX.<field>. "workflow.inputs" are the run/call parameters; change them with the set_inputs operation (do not hand-edit varsSchema). When troubleshooting a condition or expression, render it against a recent execution with buddy_render_jinja before editing — confirm it evaluates as you expect (types matter: a boolean is not the string "true").'
-		: 'Analysis view: task ids, transition ids, canvas positions, and the version token are omitted, and tasks/edges are referenced by NAME — which is exactly what buddy_workflow_edit operations use, so you can edit straight from this view. Call buddy_workflow_get again with detail:"full" only to reposition a task or target one specific transition by its id. To edit or run, pass workflowId=workflow.id, workflowName=workflow.name, orgId=workflow.orgId, orgName=workflow.orgName. To call another workflow, use add_task with subWorkflowId set to that workflow id (there is no run-workflow action). Branch on a task\'s output with RESULT.<field> in that task\'s transitions, or CTX.<publishResultAs>.<field> — not CTX.<field>. "workflow.inputs" are the run/call parameters; change them with the set_inputs operation (do not hand-edit varsSchema). Before changing a condition or expression, confirm it with buddy_render_jinja against a recent execution (types matter: a boolean is not the string "true").';
+		? 'To edit or auto-layout, pass these workflow fields straight through: workflowId=workflow.id, workflowName=workflow.name, orgId=workflow.orgId, orgName=workflow.orgName (use the names, not the ids). The version token is handled for you. node.position is the canvas {x,y} top-left anchor in free pixels (x right, y down); new tasks are auto-placed below the action they connect from unless you pass x/y. To call another workflow, use add_task with subWorkflowId set to that workflow id (there is no run-workflow action). Branch on a task\'s output with RESULT.<field> in that task\'s transitions, or CTX.<publishResultAs>.<field> — not CTX.<field>. "workflow.inputs" are the run/call parameters; change them with the set_inputs operation (do not hand-edit varsSchema). "workflow.outputs" are the return contract a caller reads from this workflow as RESULT.<name>; change them with the set_output operation. When troubleshooting a condition or expression, render it against a recent execution with buddy_render_jinja before editing — confirm it evaluates as you expect (types matter: a boolean is not the string "true").'
+		: 'Analysis view: task ids, transition ids, canvas positions, and the version token are omitted, and tasks/edges are referenced by NAME — which is exactly what buddy_workflow_edit operations use, so you can edit straight from this view. Call buddy_workflow_get again with detail:"full" only to reposition a task or target one specific transition by its id. To edit or run, pass workflowId=workflow.id, workflowName=workflow.name, orgId=workflow.orgId, orgName=workflow.orgName. To call another workflow, use add_task with subWorkflowId set to that workflow id (there is no run-workflow action). Branch on a task\'s output with RESULT.<field> in that task\'s transitions, or CTX.<publishResultAs>.<field> — not CTX.<field>. "workflow.inputs" are the run/call parameters; change them with the set_inputs operation (do not hand-edit varsSchema). "workflow.outputs" are the return contract a caller reads from this workflow as RESULT.<name>; change them with the set_output operation. Before changing a condition or expression, confirm it with buddy_render_jinja against a recent execution (types matter: a boolean is not the string "true").';
 
 	return formatWorkflowOutput(JSON.stringify({ workflow, nodes, edges, note }, null, 1));
 }


### PR DESCRIPTION
## Why

Agent-replication experiments (rounds 1 and 2) showed builders using the MCP workflow tools always produce flat single-canvas workflows, never the sub-workflow composition Rewst's own crates use. Round 2's builder named the blocker explicitly: a workflow could be *called* via `add_task subWorkflowId`, but there was no way to define what it *returns*, so reading a sub-workflow's `RESULT` was guesswork. Several load-bearing platform semantics (transition first-match order, publish on `{{ FAILED }}` edges, `with.items` `item()`) also had to be inferred from crate archaeology.

## What

- **`set_output` operation** on `buddy_workflow_edit`: writes the workflow's caller-visible output list (what a caller reads as `RESULT.<name>`). Accepts a `{name: "<jinja>"}` object or `[{name, value}]` array; raw booleans/numbers are Jinja-wrapped, mirroring `set_inputs`; empty array clears; missing `outputs` errors.
- **`buddy_workflow_get`** now selects `output` and surfaces it as `workflow.outputs` name/value pairs, with the view note pointing at `set_output`. `output` is still only *written* when `set_output` provides it (top-level patch semantics preserved).
- **Description/steering updates** on `buddy_workflow_edit`: prefer-composition guidance (own workflow + `set_inputs`/`set_output` + `add_task subWorkflowId`; 15–20 tasks with distinct concerns = sign to split), first-match transition evaluation, publish firing on failure edges, `with.items` `item()` + collected-result shape, and the full `update_task` settable field list.
- **Spec**: new `Expose the sub-workflow output contract` requirement in `openspec/specs/mcp-bridge/spec.md`; `output` moved out of the never-touched top-level field list with its send-only-on-set_output rule stated.

## Testing

- New unit tests: `set_output` forms (object map, `{name,value}` array, scalar wrapping, clear, missing-arg error), `workflowToInput` output-only-on-override, get view surfacing outputs + query selection, and spec-wording regressions for the composition and semantics guidance.
- Full unit suite green (`npm run test:unit`); markdownlint clean; IDE diagnostics clean.