### PR TITLE
Verify saved task inputs after workflow edits

### DIFF
--- a/changelog.d/workflow-edit-verify-inputs.md
+++ b/changelog.d/workflow-edit-verify-inputs.md
@@ -1,5 +1,6 @@
 ---
 category: Fixed
+pr: 118
 ---
 
 **No more silent input loss:** after a workflow edit, the tool re-reads the saved workflow and warns when the server dropped or coerced task inputs it had accepted — previously such edits reported plain success while data quietly went missing.

--- a/changelog.d/workflow-edit-verify-inputs.md
+++ b/changelog.d/workflow-edit-verify-inputs.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+**No more silent input loss:** after a workflow edit, the tool re-reads the saved workflow and warns when the server dropped or coerced task inputs it had accepted — previously such edits reported plain success while data quietly went missing.

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -376,6 +376,42 @@ clamped numbers, enum checks) rather than trusting the schema.
 - **THEN** the capability clamps it to the allowed maximum rather than honoring
   the raw value
 
+### Requirement: Verify saved task inputs after a workflow edit
+
+Because the Rewst API filters a task's `input` against the action's
+`inputSchema` — dropping unknown keys and coercing mistyped values (a string in
+an object-typed field becomes `{}`) while the save still reports success — the
+system SHALL, after a `buddy_workflow_edit` save whose operations supplied a
+task `input` or `with`, re-read the workflow and compare each such task's
+stored `input`/`with` against what was sent, appending a warning to the tool
+result naming each divergent dotted path. The comparison SHALL be
+one-directional (extra stored keys the server added are not divergences) and
+SHALL tolerate textual-equal scalar coercion (`1` vs `"1"`). Edits whose
+operations carry no `input` or `with` SHALL NOT incur the verification read. A
+failed verification read SHALL append a note advising a manual re-read, not
+fail the edit.
+
+#### Scenario: A dropped nested key is reported
+
+- **GIVEN** an `update_task` operation whose `input` contains a key the
+  action's schema does not accept
+- **WHEN** the save succeeds but the server strips that key
+- **THEN** the tool result contains a warning naming the task and the dotted
+  path of the dropped key
+
+#### Scenario: Graph-only edits stay a single read
+
+- **GIVEN** an edit whose operations only connect or reposition tasks
+- **WHEN** the edit saves
+- **THEN** no verification read is issued
+
+#### Scenario: Verification read failure does not fail the edit
+
+- **GIVEN** the save succeeded and the follow-up read errors
+- **WHEN** the tool result is produced
+- **THEN** it reports the applied operations and notes that the stored inputs
+  could not be verified
+
 ### Requirement: Rate-limit, audit, and attribute tool calls
 
 The system SHALL rate-limit tool calls, audit every call (tool, org, outcome,

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -16,6 +16,7 @@ import {
 	WORKFLOW_SEARCH_TOOL_NAME,
 	WORKFLOW_TOOL_SPECS,
 	_resetWorkflowIndexForTesting,
+	sentValueDivergences,
 	workflowEditConfirmation,
 	workflowEditScope,
 	workflowToInput,
@@ -123,6 +124,44 @@ suite('Unit: workflowTools', () => {
 		});
 		test('null yields empty', () => {
 			assert.deepStrictEqual(normalizePublish(null), []);
+		});
+	});
+
+	suite('sentValueDivergences()', () => {
+		test('flags a nested key the server dropped, with its path', () => {
+			const lines = sentValueDivergences(
+				{ json_body: { status: { name: 'In Progress' } } },
+				{ json_body: { status: {} } },
+				'input',
+			);
+			assert.strictEqual(lines.length, 1);
+			assert.match(lines[0], /^input\.json_body\.status\.name: sent/);
+			assert.match(lines[0], /not stored/);
+		});
+
+		test('flags a string the server coerced into an empty object', () => {
+			const lines = sentValueDivergences({ json_body: '{{ CTX.body }}' }, { json_body: {} }, 'input');
+			assert.strictEqual(lines.length, 1);
+			assert.match(lines[0], /^input\.json_body: sent/);
+		});
+
+		test('ignores extra keys the server added', () => {
+			assert.deepStrictEqual(sentValueDivergences({ a: 1 }, { a: 1, server_default: true }, 'input'), []);
+		});
+
+		test('deep-equal values, including arrays, produce no divergence', () => {
+			const value = { list: [1, { x: 'y' }], flag: false };
+			assert.deepStrictEqual(sentValueDivergences(value, { ...value, extra: 1 }, 'input'), []);
+		});
+
+		test('tolerates harmless primitive coercion (1 vs "1")', () => {
+			assert.deepStrictEqual(sentValueDivergences({ concurrency: 1 }, { concurrency: '1' }, 'with'), []);
+		});
+
+		test('flags an array the server truncated', () => {
+			const lines = sentValueDivergences({ ids: ['a', 'b'] }, { ids: ['a'] }, 'input');
+			assert.strictEqual(lines.length, 1);
+			assert.match(lines[0], /^input\.ids: sent/);
 		});
 	});
 
@@ -1156,6 +1195,104 @@ suite('Unit: workflowTools', () => {
 			assert.match(output, /2000/);
 			const update = calls.find(c => c.query.includes('RewstBuddyWorkflowUpdate'))!;
 			assert.strictEqual(update.variables!.openedAt, '1000', 'openedAt is the updatedAt read at fetch');
+		});
+
+		test('buddy_workflow_edit warns when the server did not store an input as sent', async () => {
+			// The Rewst API filters task input against the action's inputSchema and
+			// reports success anyway; the tool must catch the drop by re-reading.
+			let gets = 0;
+			const calls: { query: string }[] = [];
+			const execute: GraphqlToolDeps['execute'] = async query => {
+				calls.push({ query });
+				if (query.includes('RewstBuddyWorkflowGet')) {
+					gets += 1;
+					const w = sampleWorkflow();
+					if (gets > 1) {
+						// The verification read: the nested key was silently stripped.
+						(w.tasks[0] as Record<string, unknown>).input = { json_body: { status: {} } };
+					}
+					return { data: { workflow: w } };
+				}
+				if (query.includes('RewstBuddyWorkflowUpdate')) {
+					return { data: { updateWorkflow: { id: 'wf-1', updatedAt: '2000' } } };
+				}
+				return { data: {} };
+			};
+			const deps: GraphqlToolDeps = { isEnabled: () => true, confirmMutation: async () => true, execute };
+			const output = await runWorkflowTool(
+				{
+					tool: 'buddy_workflow_edit',
+					args: {
+						workflowId: 'wf-1',
+						workflowName: 'Sample',
+						orgId: 'org-1',
+						orgName: 'Acme',
+						operations: [
+							{
+								op: 'update_task',
+								name: 'start',
+								set: { input: { json_body: { status: { name: 'In Progress' } } } },
+							},
+						],
+					},
+				},
+				deps,
+			);
+			assert.strictEqual(gets, 2, 'the save is verified with a re-read');
+			assert.match(output, /Applied 1 operation/, 'the edit still reports what was applied');
+			assert.match(output, /WARNING — the server did not store/i);
+			assert.match(output, /task "start": input\.json_body\.status\.name/);
+			assert.match(output, /inputSchema/, 'explains why the server dropped the key');
+		});
+
+		test('buddy_workflow_edit skips the verification read when no operation carries input', async () => {
+			const { deps, calls } = makeDeps();
+			await runWorkflowTool(
+				{
+					tool: 'buddy_workflow_edit',
+					args: {
+						workflowId: 'wf-1',
+						workflowName: 'Sample',
+						orgId: 'org-1',
+						orgName: 'Acme',
+						operations: [{ op: 'connect', from: 'end', to: 'start' }],
+					},
+				},
+				deps,
+			);
+			const gets = calls.filter(c => c.query.includes('RewstBuddyWorkflowGet'));
+			assert.strictEqual(gets.length, 1, 'no verification read for a graph-only edit');
+		});
+
+		test('buddy_workflow_edit notes a failed verification read without failing the edit', async () => {
+			let gets = 0;
+			const execute: GraphqlToolDeps['execute'] = async query => {
+				if (query.includes('RewstBuddyWorkflowGet')) {
+					gets += 1;
+					if (gets > 1) return { errors: [{ message: 'read timed out' }] };
+					return { data: { workflow: sampleWorkflow() } };
+				}
+				if (query.includes('RewstBuddyWorkflowUpdate')) {
+					return { data: { updateWorkflow: { id: 'wf-1', updatedAt: '2000' } } };
+				}
+				return { data: {} };
+			};
+			const deps: GraphqlToolDeps = { isEnabled: () => true, confirmMutation: async () => true, execute };
+			const output = await runWorkflowTool(
+				{
+					tool: 'buddy_workflow_edit',
+					args: {
+						workflowId: 'wf-1',
+						workflowName: 'Sample',
+						orgId: 'org-1',
+						orgName: 'Acme',
+						operations: [{ op: 'update_task', name: 'start', set: { input: { params: { text: 'x' } } } }],
+					},
+				},
+				deps,
+			);
+			assert.match(output, /Applied 1 operation/, 'the edit itself succeeded');
+			assert.match(output, /could not verify/i);
 		});
 
 		test('buddy_workflow_edit retries once on a version conflict with the fresh token', async () => {

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -1543,6 +1543,121 @@ function requireScopeFields(toolName: string, args: Record<string, unknown>): { 
 	return { workflowId: asStringArg(args, 'workflowId')!, orgId: asStringArg(args, 'orgId')! };
 }
 
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+	return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/**
+ * One-directional deep match: everything we sent must be present deep-equal in
+ * what the server stored; extra stored keys (server defaults) are fine. One
+ * deliberate looseness: two non-object values with the same textual value
+ * (1 vs "1") match, because the server round-trips scalars through its own
+ * typing and that is not data loss.
+ */
+function storedValueMatches(sent: unknown, stored: unknown): boolean {
+	if (sent === stored) return true;
+	if (isPlainObject(sent) && isPlainObject(stored)) {
+		return Object.entries(sent).every(([key, value]) => key in stored && storedValueMatches(value, stored[key]));
+	}
+	if (Array.isArray(sent) && Array.isArray(stored)) {
+		return sent.length === stored.length && sent.every((value, i) => storedValueMatches(value, stored[i]));
+	}
+	if (sent != null && stored != null && typeof sent !== 'object' && typeof stored !== 'object') {
+		return String(sent) === String(stored);
+	}
+	return false;
+}
+
+/**
+ * Lines describing where a stored value diverges from what was sent, each
+ * prefixed with the dotted path. The Rewst API filters a task's input against
+ * the action's inputSchema and reports success anyway — dropped keys and
+ * coerced values are only visible by re-reading and comparing.
+ */
+export function sentValueDivergences(sent: unknown, stored: unknown, path: string): string[] {
+	if (isPlainObject(sent) && isPlainObject(stored)) {
+		const lines: string[] = [];
+		for (const [key, value] of Object.entries(sent)) {
+			const childPath = `${path}.${key}`;
+			if (!(key in stored)) {
+				lines.push(`${childPath}: sent ${briefValue(value)}, not stored`);
+			} else {
+				lines.push(...sentValueDivergences(value, stored[key], childPath));
+			}
+		}
+		return lines;
+	}
+	return storedValueMatches(sent, stored) ? [] : [`${path}: sent ${briefValue(sent)}, stored ${briefValue(stored)}`];
+}
+
+/**
+ * The tasks whose stored input/with are worth verifying after a save: those an
+ * operation in this batch supplied an input or with for. Graph-only edits
+ * (connect, reposition, autolayout…) verify nothing, so they stay one read.
+ */
+function tasksToVerify(operations: WorkflowOperation[], sentTasks: RawTask[]): RawTask[] {
+	const byId = new Map<string, RawTask>();
+	for (const operation of operations) {
+		let provided: Record<string, unknown> | undefined;
+		let ref: string | undefined;
+		if (operation.op === 'add_task') {
+			provided = operation;
+			ref = str(operation.name);
+		} else if (operation.op === 'update_task') {
+			provided = asObject(operation.set);
+			ref = str(operation.id) ?? str(operation.name);
+		}
+		if (!provided || !ref || (provided.input == null && provided.with == null)) continue;
+		try {
+			const task = resolveTask(sentTasks, ref);
+			byId.set(task.id, task);
+		} catch {
+			// Renamed by a later operation in the batch or deleted again; skip.
+		}
+	}
+	return [...byId.values()];
+}
+
+/**
+ * Best-effort post-save check: re-read the workflow and compare each verified
+ * task's stored input/with against what was sent. Returns a suffix for the
+ * tool result — a WARNING listing divergences, a note when the verification
+ * read failed, or an empty string when everything matches.
+ */
+async function verifySavedTaskValues(
+	deps: GraphqlToolDeps,
+	workflowId: string,
+	orgId: string,
+	toVerify: RawTask[],
+): Promise<string> {
+	try {
+		const saved = await fetchWorkflow(deps, workflowId, orgId);
+		const storedById = new Map(saved.tasks.map(t => [t.id, t]));
+		const problems: string[] = [];
+		for (const sent of toVerify) {
+			const stored = storedById.get(sent.id);
+			if (!stored) {
+				problems.push(`- task "${sent.name}": not present in the saved workflow`);
+				continue;
+			}
+			const lines = [
+				...sentValueDivergences(sent.input ?? {}, stored.input ?? {}, 'input'),
+				...(sent.with != null ? sentValueDivergences(sent.with, stored.with ?? {}, 'with') : []),
+			];
+			problems.push(...lines.map(line => `- task "${sent.name}": ${line}`));
+		}
+		if (problems.length === 0) return '';
+		return (
+			`\n\nWARNING — the server did not store some task values as sent. Rewst filters a task's input against its action's inputSchema: unknown keys are dropped and mistyped values coerced (a string in an object-typed field becomes {}), while the save still reports success.\n` +
+			`${problems.join('\n')}\n` +
+			`Check the action's accepted parameters with buddy_action_search describe mode, then re-apply with matching keys and types.`
+		);
+	} catch (error) {
+		const message = error instanceof Error ? error.message : String(error);
+		return `\n\nNote: the edit saved, but the tool could not verify the stored task inputs (${message}); re-read with buddy_workflow_get to confirm.`;
+	}
+}
+
 /**
  * The shared workflow write pipeline: resolve any action refs, read the current
  * workflow, apply the operations to the whole graph, and save with the correct
@@ -1588,7 +1703,12 @@ async function applyWorkflowMutation(
 
 	const updated = (result.data as { updateWorkflow?: { name?: string; updatedAt?: string } } | undefined)
 		?.updateWorkflow;
-	return `Applied ${applied.length} operation(s) to "${workflow.name}":\n${applied.map(line => `- ${line}`).join('\n')}\n\nSaved. New version token: ${updated?.updatedAt ?? '(unknown)'}.`;
+	// The server can accept the save yet silently drop or coerce task input
+	// keys (schema filtering). Re-read and compare what this batch sent, so a
+	// "success" that lost data comes back as an explicit warning instead.
+	const toVerify = tasksToVerify(operations, tasks);
+	const verification = toVerify.length > 0 ? await verifySavedTaskValues(deps, workflowId, orgId, toVerify) : '';
+	return `Applied ${applied.length} operation(s) to "${workflow.name}":\n${applied.map(line => `- ${line}`).join('\n')}\n\nSaved. New version token: ${updated?.updatedAt ?? '(unknown)'}.${verification}`;
 }
 
 async function runWorkflowEdit(request: ToolRequest, deps: GraphqlToolDeps): Promise<string> {


### PR DESCRIPTION
## Why

Worst finding from the agent-replication experiments: the Rewst API filters a task's `input` against the action's `inputSchema` and reports success anyway — unknown keys silently dropped, mistyped values coerced (a string in an object-typed field becomes `{}`). `buddy_workflow_edit` answered "Saved." while a `status: {name: "In Progress"}` object was quietly stored as `{}`; the round-1 builder only caught it by hand re-reading the workflow.

## What

After a save whose operations supplied a task `input` or `with`, the edit pipeline re-reads the workflow and compares each such task's stored values against what was sent:

- **One-directional deep diff** (`sentValueDivergences`): every sent value must appear deep-equal in the stored task; extra server-added keys are fine; textual-equal scalar coercion (`1` vs `"1"`) is tolerated as not-data-loss.
- Divergences append a **WARNING** to the tool result naming the task and each dotted path (`task "move_ticket_in_progress": input.json_body.status.name: sent "In Progress", not stored`), with the schema-filtering explanation and a pointer to `buddy_action_search` describe mode.
- **Graph-only edits** (connect, reposition, autolayout, transitions) skip the verification read entirely — no added latency for the common case.
- A failed verification read appends a "could not verify" note; it never fails the edit.

Spec: new `Verify saved task inputs after a workflow edit` requirement in `openspec/specs/mcp-bridge/spec.md` (anchored away from PR #117's spec region to avoid conflicts).

## Testing

- Unit: divergence helper cases (dropped nested key, string→`{}` coercion, extra-server-keys ignored, deep-equal arrays, scalar looseness, truncated array) and edit-flow cases (warning surfaces with path, graph-only edit issues exactly one read, verification-read failure notes without failing).
- Full unit suite green.