### PR TITLE
Merge execution context snapshots in buddy_render_jinja by default

### DIFF
--- a/changelog.d/render-jinja-merged-context.md
+++ b/changelog.d/render-jinja-merged-context.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+**Accurate Jinja test context:** `buddy_render_jinja` now merges an execution's context snapshots into one cumulative view by default — previously it used only the last snapshot, which holds just the final publish's keys, making run inputs and earlier variables appear undefined.

--- a/changelog.d/render-jinja-merged-context.md
+++ b/changelog.d/render-jinja-merged-context.md
@@ -1,5 +1,6 @@
 ---
 category: Fixed
+pr: 119
 ---
 
 **Accurate Jinja test context:** `buddy_render_jinja` now merges an execution's context snapshots into one cumulative view by default — previously it used only the last snapshot, which holds just the final publish's keys, making run inputs and earlier variables appear undefined.

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -417,6 +417,31 @@ evicted or was never cached.
 - **THEN** the bridge returns the requested character slice without re-running the
   original Rewst API call
 
+### Requirement: Render Jinja against a merged execution context
+
+Because an execution's stored context snapshots are per-publish deltas — each
+frame holds only the keys that publish wrote, so the last frame is not the
+most complete view — `buddy_render_jinja` SHALL, when given an `executionId`
+and no `contextIndex`, merge all snapshots in order into one cumulative
+context (later writes to a key win) and use that as `CTX`. A `contextIndex`
+SHALL select that single raw snapshot without merging. Keys mode SHALL report
+how many snapshots the listed context was merged from.
+
+#### Scenario: Early-frame keys stay visible by default
+
+- **GIVEN** an execution whose first snapshot holds the run inputs and whose
+  later snapshots each hold only newly published keys
+- **WHEN** `buddy_render_jinja` renders `{{ CTX.<run input> }}` with no
+  `contextIndex`
+- **THEN** the value renders from the merged context rather than being
+  undefined
+
+#### Scenario: contextIndex inspects one raw delta
+
+- **GIVEN** an execution with several snapshots
+- **WHEN** `buddy_render_jinja` is called with `contextIndex: 0`
+- **THEN** the render context is exactly that snapshot, unmerged
+
 ### Requirement: Derive the Jinja docs engine host and cache only successful fetches
 
 `buddy_get_jinja_filter_docs` SHALL derive the Jinja engine host from the

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -888,6 +888,7 @@ suite('Unit: workflowTools', () => {
 				pollStatus: string;
 				pollError: string;
 				renderResult: unknown;
+				contexts: Record<string, unknown>[];
 				taskLogs: unknown[];
 				executions: unknown[];
 				indexWorkflows: { id: string; name: string; orgId: string; orgName: string }[];
@@ -912,7 +913,9 @@ suite('Unit: workflowTools', () => {
 					return updateResults[Math.min(updateIndex++, updateResults.length - 1)];
 				}
 				if (query.includes('RewstBuddyExecutionContexts')) {
-					return { data: { workflowExecutionContexts: [{ proceed: false }, { proceed: true }] } };
+					return {
+						data: { workflowExecutionContexts: over.contexts ?? [{ proceed: false }, { proceed: true }] },
+					};
 				}
 				if (query.includes('RewstBuddyRenderJinja')) {
 					// Echo the context value the tool passed, to prove it rendered against it.
@@ -1066,7 +1069,7 @@ suite('Unit: workflowTools', () => {
 			assert.strictEqual(calls.length, 0, 'short-circuits without hitting the API');
 		});
 
-		test('buddy_render_jinja renders against an execution (last snapshot) and returns only the result', async () => {
+		test('buddy_render_jinja renders against an execution (merged snapshots) and returns only the result', async () => {
 			const { deps, calls } = makeDeps();
 			const output = await runWorkflowTool(
 				{
@@ -1075,7 +1078,7 @@ suite('Unit: workflowTools', () => {
 				},
 				deps,
 			);
-			// Mock has snapshots [{proceed:false},{proceed:true}]; default uses the last.
+			// Mock has snapshots [{proceed:false},{proceed:true}]; the merge keeps the latest value.
 			assert.match(output, /Rendered: true \(type boolean\)/);
 			assert.ok(
 				calls.some(c => c.query.includes('RewstBuddyExecutionContexts')),
@@ -1083,8 +1086,32 @@ suite('Unit: workflowTools', () => {
 			);
 		});
 
-		test('buddy_render_jinja honors contextIndex', async () => {
-			const { deps } = makeDeps();
+		test('buddy_render_jinja merges all delta snapshots by default', async () => {
+			// Execution context snapshots are per-publish DELTAS: the initial frame
+			// holds the run inputs, later frames only the keys each publish wrote.
+			// The default context must be the in-order merge of all of them.
+			const { deps, calls } = makeDeps({
+				contexts: [{ user_upn: 'a@b.c', mode: 'review' }, { ticket_id: '43' }, { automation_log: ['x'] }],
+			});
+			await runWorkflowTool(
+				{
+					tool: 'buddy_render_jinja',
+					args: { orgId: 'org-1', executionId: 'exec-1', template: '{{ CTX.user_upn }}' },
+				},
+				deps,
+			);
+			const render = calls.find(c => c.query.includes('RewstBuddyRenderJinja'))!;
+			assert.deepStrictEqual(
+				render.variables!.vars,
+				{ user_upn: 'a@b.c', mode: 'review', ticket_id: '43', automation_log: ['x'] },
+				'the render context is the cumulative merge, so early-frame keys stay visible',
+			);
+		});
+
+		test('buddy_render_jinja honors contextIndex as one raw delta, without merging', async () => {
+			const { deps, calls } = makeDeps({
+				contexts: [{ proceed: false, initial: true }, { proceed: true }],
+			});
 			const output = await runWorkflowTool(
 				{
 					tool: 'buddy_render_jinja',
@@ -1093,6 +1120,36 @@ suite('Unit: workflowTools', () => {
 				deps,
 			);
 			assert.match(output, /Rendered: false/);
+			const render = calls.find(c => c.query.includes('RewstBuddyRenderJinja'))!;
+			assert.deepStrictEqual(
+				render.variables!.vars,
+				{ proceed: false, initial: true },
+				'contextIndex selects the raw snapshot as-is',
+			);
+		});
+
+		test('buddy_render_jinja keys mode reports how many snapshots were merged', async () => {
+			const { deps } = makeDeps({
+				contexts: [{ a: 1 }, { b: 2 }, { a: 3 }],
+			});
+			const output = await runWorkflowTool(
+				{ tool: 'buddy_render_jinja', args: { orgId: 'org-1', executionId: 'exec-1', keys: true } },
+				deps,
+			);
+			assert.match(output, /Context top-level keys \(2\): a, b/);
+			assert.match(output, /merged from 3 snapshot/i);
+		});
+
+		test('buddy_render_jinja spec describes snapshots as merged deltas', () => {
+			const spec = WORKFLOW_TOOL_SPECS.find(tool => tool.name === 'buddy_render_jinja');
+			assert.ok(spec, 'buddy_render_jinja spec exists');
+			assert.match(spec.description, /per-publish deltas/i);
+			assert.match(spec.description, /merges/i);
+			assert.doesNotMatch(spec.description, /the last context snapshot of the run is used/i);
+			const contextIndex = (spec.inputSchema as { properties: { contextIndex: { description: string } } })
+				.properties.contextIndex;
+			assert.match(contextIndex.description, /raw|single/i);
+			assert.doesNotMatch(contextIndex.description, /most-complete/i);
 		});
 
 		test('buddy_render_jinja renders ad-hoc vars without an execution', async () => {

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -215,7 +215,7 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 		name: 'buddy_render_jinja',
 		args: '{"orgId": string, "template"?: string, "executionId"?: string, "vars"?: object, "contextIndex"?: number, "keys"?: boolean}',
 		description:
-			"Render a Jinja template against a real workflow execution's context and return only the result. Use this to CONFIRM a transition condition, task input, or publish expression evaluates the way you expect BEFORE editing a workflow — the agent otherwise guesses wrong (e.g. comparing a boolean to the string 'true', or reading a sub-workflow result from CTX.<field> instead of CTX.<publishResultAs>.<field>). Pass executionId and the tool fetches that run's context server-side, so the (large) context never enters the chat; or pass vars as an ad-hoc context object. This renders against the STORED context snapshot, which is the CTX namespace only — the live runtime objects WORKFLOW, ORG, USER, and RESULT do NOT exist here, so use their CTX equivalents: the execution id is CTX.execution_id, the org id is CTX.organization.id, and the running workflow's own id is CTX.trigger_instance.trigger.workflow_id. To discover what a run actually holds, pass keys:true to list the context's top-level keys instead of rendering (then drill in with {{ CTX.<key> }}). In the template, CTX is the context: read a field as {{ CTX.field }}, and to dump the whole context use {{ CTX() }} with parentheses — in a live Rewst workflow CTX is callable, so bare {{ CTX }} does not work. By default the last context snapshot of the run is used; contextIndex picks another. Returns the rendered value, or the Jinja error if it fails.",
+			"Render a Jinja template against a real workflow execution's context and return only the result. Use this to CONFIRM a transition condition, task input, or publish expression evaluates the way you expect BEFORE editing a workflow — the agent otherwise guesses wrong (e.g. comparing a boolean to the string 'true', or reading a sub-workflow result from CTX.<field> instead of CTX.<publishResultAs>.<field>). Pass executionId and the tool fetches that run's context server-side, so the (large) context never enters the chat; or pass vars as an ad-hoc context object. This renders against the STORED context snapshot, which is the CTX namespace only — the live runtime objects WORKFLOW, ORG, USER, and RESULT do NOT exist here, so use their CTX equivalents: the execution id is CTX.execution_id, the org id is CTX.organization.id, and the running workflow's own id is CTX.trigger_instance.trigger.workflow_id. To discover what a run actually holds, pass keys:true to list the context's top-level keys instead of rendering (then drill in with {{ CTX.<key> }}). In the template, CTX is the context: read a field as {{ CTX.field }}, and to dump the whole context use {{ CTX() }} with parentheses — in a live Rewst workflow CTX is callable, so bare {{ CTX }} does not work. An execution's stored snapshots are per-publish deltas (each holds only the keys that publish wrote), so by default the tool merges them all, in order, into one cumulative context — the closest view of the run's final CTX; pass contextIndex to inspect one raw delta instead. Returns the rendered value, or the Jinja error if it fails.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -236,7 +236,8 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 				},
 				contextIndex: {
 					type: 'number',
-					description: 'Which context snapshot of the execution to use (default: the last/most-complete).',
+					description:
+						'Inspect a single raw snapshot (a per-publish delta) by index instead of the default merged context.',
 				},
 				keys: {
 					type: 'boolean',
@@ -1495,6 +1496,7 @@ async function runRenderJinja(request: ToolRequest, deps: GraphqlToolDeps): Prom
 	// Resolve the render context (CTX). An executionId is fetched server-side so the
 	// (large) run context never enters the chat; vars is an inline alternative.
 	let vars = request.args.vars && typeof request.args.vars === 'object' ? (request.args.vars as object) : undefined;
+	let contextNote = '';
 	const executionId = asStringArg(request.args, 'executionId');
 	if (executionId) {
 		const result = await deps.execute(EXECUTION_CONTEXTS_QUERY, { id: executionId });
@@ -1503,10 +1505,21 @@ async function runRenderJinja(request: ToolRequest, deps: GraphqlToolDeps): Prom
 		const raw = (result.data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts;
 		const snapshots = Array.isArray(raw) ? raw : raw ? [raw] : [];
 		if (snapshots.length === 0) throw new Error(`Execution ${executionId} has no context to render against.`);
-		const requested =
-			typeof request.args.contextIndex === 'number' ? request.args.contextIndex : snapshots.length - 1;
-		const index = Math.max(0, Math.min(snapshots.length - 1, requested));
-		vars = snapshots[index] as object;
+		if (typeof request.args.contextIndex === 'number') {
+			const index = Math.max(0, Math.min(snapshots.length - 1, request.args.contextIndex));
+			vars = snapshots[index] as object;
+			contextNote = ` (snapshot ${index} of ${snapshots.length}, unmerged)`;
+		} else {
+			// The stored snapshots are per-publish DELTAS, not cumulative states —
+			// the last one holds only the keys of the run's final publish. Merge
+			// them in order so the default context is the closest view of the
+			// run's final CTX (later writes to a key win).
+			vars = Object.assign(
+				{},
+				...snapshots.filter(s => typeof s === 'object' && s !== null && !Array.isArray(s)),
+			) as object;
+			contextNote = ` (merged from ${snapshots.length} snapshot(s))`;
+		}
 	}
 	if (!vars) {
 		throw new Error(
@@ -1517,7 +1530,7 @@ async function runRenderJinja(request: ToolRequest, deps: GraphqlToolDeps): Prom
 	if (keysMode) {
 		const keys = Object.keys(vars as Record<string, unknown>).sort();
 		return formatWorkflowOutput(
-			`Context top-level keys (${keys.length}): ${keys.join(', ') || '(none)'}\n\nDrill in with {{ CTX.<key> }}. System vars: execution id = CTX.execution_id, org id = CTX.organization.id, this workflow's id = CTX.trigger_instance.trigger.workflow_id.`,
+			`Context top-level keys (${keys.length}): ${keys.join(', ') || '(none)'}${contextNote}\n\nDrill in with {{ CTX.<key> }}. System vars: execution id = CTX.execution_id, org id = CTX.organization.id, this workflow's id = CTX.trigger_instance.trigger.workflow_id.`,
 		);
 	}
 


### PR DESCRIPTION
## Why

Both workflow-tooling experiments hit the same trap: an execution's stored context snapshots are **per-publish deltas** — each frame holds only the keys that publish wrote. The tool's default ("the last/most-complete snapshot") could therefore be a single-key frame: run inputs and every earlier variable rendered as undefined, and the tool's own hint (`CTX.execution_id`) failed against its own default context. Verified live: the last snapshot of a smoke run held 1 key; snapshot 0 held all 19 system + input keys.

## What

- With `executionId` and no `contextIndex`, `buddy_render_jinja` now merges all snapshots in order into one cumulative context (later writes to a key win) — the closest view of the run's final CTX.
- `contextIndex` still selects a single raw, unmerged delta for inspecting one specific publish; its description no longer claims the last one is "most-complete".
- Keys mode reports how many snapshots the listed context was merged from (`merged from N snapshot(s)`).
- Tool description now explains the delta semantics.

Spec: new `Render Jinja against a merged execution context` requirement in `openspec/specs/mcp-bridge/spec.md` (anchored next to the Jinja-docs requirement, clear of PR #117/#118 spec regions).

## Testing

- New unit tests: default merge keeps early-frame keys visible (asserts the exact vars sent to renderJinja), `contextIndex` passes the raw snapshot unmerged, keys mode reports the merge count, spec-wording regression (delta description present, "last snapshot" claim gone). Red before implementation, green after.
- Full unit suite green.