### PR TITLE
Sweep all active sessions in buddy_execution_logs

### DIFF
--- a/changelog.d/execution-logs-cross-session.md
+++ b/changelog.d/execution-logs-cross-session.md
@@ -1,5 +1,6 @@
 ---
 category: Fixed
+pr: 121
 ---
 
 **Task logs across accounts:** `buddy_execution_logs` no longer reports an empty result for executions owned by another signed-in session — it now checks every active session and accepts an optional `orgId` to target the right account directly.

--- a/changelog.d/execution-logs-cross-session.md
+++ b/changelog.d/execution-logs-cross-session.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+**Task logs across accounts:** `buddy_execution_logs` no longer reports an empty result for executions owned by another signed-in session — it now checks every active session and accepts an optional `orgId` to target the right account directly.

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -395,6 +395,35 @@ duration), and tag the approval origin so that approval prompts name the caller.
 - **THEN** the audit line contains the tool, resolved org, outcome, and duration
 - **AND** the log does not include tool arguments or embedded line separators
 
+### Requirement: Resolve execution logs across all active sessions
+
+Because a Rewst session only sees its own org hierarchy and
+`buddy_execution_logs` resolves an execution by its globally unique id without
+requiring an org, the system SHALL NOT report an execution as having no task
+logs based on the first active session alone: when the primary session returns
+zero rows, it SHALL query each other active session (skipping ones that error)
+and use the first non-empty result, noting that the logs came from another
+session. The tool SHALL accept an optional `orgId` that routes the primary
+lookup to the session managing that org, falling back to the default session
+when no session manages it. When no session has rows, the result SHALL say
+that none of the active sessions can see the execution rather than implying
+the execution has no logs.
+
+#### Scenario: Execution owned by another signed-in account
+
+- **GIVEN** two active sessions and an execution in the second session's org
+  hierarchy
+- **WHEN** `buddy_execution_logs` runs without an `orgId`
+- **THEN** the first session's empty result triggers a sweep and the second
+  session's task logs are returned, noting the alternate source
+
+#### Scenario: No session can see the execution
+
+- **GIVEN** an execution id no active session has access to
+- **WHEN** `buddy_execution_logs` runs
+- **THEN** the result states that none of the active sessions can see task
+  logs for it
+
 ### Requirement: Page oversized tool results
 
 The system SHALL keep MCP tool responses below the transport-friendly output

--- a/src/capabilities/chatToolCapabilities.test.ts
+++ b/src/capabilities/chatToolCapabilities.test.ts
@@ -1,0 +1,58 @@
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import { SessionManager } from '@sessions';
+import type { CapabilityContext } from './Capability';
+import { executionLogsDeps } from './chatToolCapabilities';
+
+const { suite, test, setup } = Mocha;
+
+function twoSessionContext() {
+	const one = createMockSession({
+		profile: {
+			org: { id: 'org-1', name: 'One' },
+			user: Fixtures.userFragment({ id: 'user-1', orgId: 'org-1' }),
+		},
+	}).session;
+	const two = createMockSession({
+		profile: {
+			org: { id: 'org-2', name: 'Two' },
+			user: Fixtures.userFragment({ id: 'user-2', orgId: 'org-2' }),
+		},
+	}).session;
+	SessionManager._setSessionsForTesting([one, two]);
+	const ctx: CapabilityContext = { session: one, orgId: 'org-1', sessions: [one, two] };
+	return { ctx, one, two };
+}
+
+suite('Unit: chatToolCapabilities', () => {
+	setup(() => {
+		initTestEnvironment();
+		SessionManager._resetForTesting();
+	});
+
+	suite('executionLogsDeps()', () => {
+		test('without orgId the context session leads and the others become alternates', async () => {
+			const { ctx } = twoSessionContext();
+			const deps = await executionLogsDeps({}, ctx);
+			assert.strictEqual(deps.cacheScope, 'org-1', 'primary is the context session');
+			assert.strictEqual(deps.alternates?.length, 1);
+			assert.strictEqual(deps.alternates![0].cacheScope, 'org-2');
+		});
+
+		test('an orgId routes the primary to the session managing that org', async () => {
+			const { ctx } = twoSessionContext();
+			const deps = await executionLogsDeps({ orgId: 'org-2' }, ctx);
+			assert.strictEqual(deps.cacheScope, 'org-2', 'primary follows the requested org');
+			assert.strictEqual(deps.alternates?.length, 1);
+			assert.strictEqual(deps.alternates![0].cacheScope, 'org-1');
+		});
+
+		test('an unknown orgId falls back to the context session instead of erroring', async () => {
+			const { ctx } = twoSessionContext();
+			const deps = await executionLogsDeps({ orgId: 'org-nope' }, ctx);
+			assert.strictEqual(deps.cacheScope, 'org-1');
+			assert.strictEqual(deps.alternates?.length, 1);
+		});
+	});
+});

--- a/src/capabilities/chatToolCapabilities.ts
+++ b/src/capabilities/chatToolCapabilities.ts
@@ -1,4 +1,5 @@
-import { createGraphqlDeps } from '../ui/chat/tools/graphqlTool';
+import { SessionManager } from '@sessions';
+import { createGraphqlDeps, type GraphqlToolDeps } from '../ui/chat/tools/graphqlTool';
 import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 import {
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
@@ -40,14 +41,30 @@ async function runViaChatToolPath(
 	spec: ToolSpec,
 	input: Record<string, unknown>,
 	ctx: CapabilityContext,
+	deps: GraphqlToolDeps = createGraphqlDeps(ctx.session),
 ): Promise<string> {
-	const [result] = await runToolRequests(
-		[{ tool: spec.name, args: input }],
-		undefined,
-		undefined,
-		createGraphqlDeps(ctx.session),
-	);
+	const [result] = await runToolRequests([{ tool: spec.name, args: input }], undefined, undefined, deps);
 	return result.ok ? result.output : `Error: ${result.output}`;
+}
+
+/**
+ * Deps for buddy_execution_logs, which resolves an execution by its globally
+ * unique id and carries no required org. requiresOrg:false capabilities run
+ * against the first active session, but each session only sees its own org
+ * hierarchy — an execution owned by another signed-in account would come back
+ * empty (#116). So: an optional orgId routes the primary to the session
+ * managing that org, and every other active session rides along as an
+ * alternate for the tool's empty-result sweep.
+ */
+export async function executionLogsDeps(
+	input: Record<string, unknown>,
+	ctx: CapabilityContext,
+): Promise<GraphqlToolDeps> {
+	const orgId = typeof input.orgId === 'string' && input.orgId ? input.orgId : undefined;
+	const primary = orgId ? await SessionManager.getSessionForOrg(orgId).catch(() => ctx.session) : ctx.session;
+	const deps = createGraphqlDeps(primary);
+	deps.alternates = ctx.sessions.filter(session => session !== primary).map(createGraphqlDeps);
+	return deps;
 }
 
 function mcpCapability(
@@ -75,9 +92,15 @@ export const WORKSPACE_CHAT_CAPABILITIES: Capability[] = WORKSPACE_TOOL_SPECS.ma
 
 export const WORKFLOW_CHAT_CAPABILITIES: Capability[] = WORKFLOW_TOOL_SPECS.map(spec => {
 	const access = workflowAccessFor(spec);
-	return access === 'write'
-		? mcpCapability(spec, access, 'workflow', true, (input, ctx) =>
-				runWorkflowMutationWithApproval(spec, input, ctx),
-			)
-		: mcpCapability(spec, access, 'workflow', true);
+	if (access === 'write') {
+		return mcpCapability(spec, access, 'workflow', true, (input, ctx) =>
+			runWorkflowMutationWithApproval(spec, input, ctx),
+		);
+	}
+	if (spec.name === WORKFLOW_EXECUTION_LOGS_TOOL_NAME) {
+		return mcpCapability(spec, access, 'workflow', true, async (input, ctx) =>
+			runViaChatToolPath(spec, input, ctx, await executionLogsDeps(input, ctx)),
+		);
+	}
+	return mcpCapability(spec, access, 'workflow', true);
 });

--- a/src/ui/chat/tools/graphqlTool.ts
+++ b/src/ui/chat/tools/graphqlTool.ts
@@ -93,6 +93,13 @@ export interface GraphqlToolDeps {
 	 * same extension host never reuses another session's data. Undefined in tests.
 	 */
 	cacheScope?: string;
+	/**
+	 * Deps bound to the OTHER active sessions. A tool that looks an entity up by
+	 * a globally unique id (e.g. execution logs by execution id) can sweep these
+	 * when the primary session cannot see the entity — each Rewst session only
+	 * sees its own org hierarchy.
+	 */
+	alternates?: GraphqlToolDeps[];
 }
 
 interface GraphqlTypeRef {

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -1425,6 +1425,64 @@ suite('Unit: workflowTools', () => {
 			assert.ok(!output.includes('"ok":true'), "succeeded task's result is hidden by default");
 		});
 
+		test('buddy_execution_logs sweeps alternate sessions when the primary sees no rows', async () => {
+			// An execution in another account's org hierarchy returns zero rows on
+			// the primary session; the tool must try the other active sessions
+			// (issue #116). The first alternate here errors and must be skipped.
+			const depsFor = (taskLogs: unknown): GraphqlToolDeps => ({
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async query =>
+					query.includes('RewstBuddyTaskLogs')
+						? (taskLogs as { data?: unknown; errors?: unknown })
+						: { data: {} },
+			});
+			const deps = depsFor({ data: { taskLogs: [] } });
+			deps.alternates = [
+				depsFor({ errors: [{ message: 'no access' }] }),
+				depsFor({
+					data: { taskLogs: [{ originalWorkflowTaskName: 'do_thing', status: 'succeeded' }] },
+				}),
+			];
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, args: { executionId: 'exec-9' } },
+				deps,
+			);
+			assert.match(output, /1 task\(s\), 0 failed/);
+			assert.match(output, /do_thing: succeeded/);
+			assert.match(output, /another active session/i);
+		});
+
+		test('buddy_execution_logs explains visibility when no session has rows', async () => {
+			const empty = (): GraphqlToolDeps => ({
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async () => ({ data: { taskLogs: [] } }),
+			});
+			const deps = empty();
+			deps.alternates = [empty()];
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, args: { executionId: 'exec-9' } },
+				deps,
+			);
+			assert.match(output, /0 task\(s\)/);
+			assert.match(output, /none of the \d+ active session/i);
+		});
+
+		test('buddy_execution_logs spec accepts an optional orgId for session routing', () => {
+			const spec = WORKFLOW_TOOL_SPECS.find(tool => tool.name === WORKFLOW_EXECUTION_LOGS_TOOL_NAME);
+			assert.ok(spec, 'buddy_execution_logs spec exists');
+			assert.match(spec.args, /"orgId"\?/);
+			const orgId = (spec.inputSchema as { properties: Record<string, { description?: string }> }).properties
+				.orgId;
+			assert.ok(orgId, 'inputSchema declares orgId');
+			assert.match(orgId.description ?? '', /session|account/i);
+			assert.ok(
+				!(spec.inputSchema as { required?: string[] }).required?.includes('orgId'),
+				'orgId stays optional',
+			);
+		});
+
 		test('buddy_execution_logs failedOnly lists only failed tasks', async () => {
 			const { deps } = makeDeps({
 				taskLogs: [

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -195,13 +195,18 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 	},
 	{
 		name: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
-		args: '{"executionId": string, "failedOnly"?: boolean, "includeResult"?: boolean}',
+		args: '{"executionId": string, "orgId"?: string, "failedOnly"?: boolean, "includeResult"?: boolean}',
 		description:
-			"Inspect one workflow execution's task logs: per task, its status, and for failed tasks the message, the input it received, and the result it produced — the fastest way to see WHY a run failed, instead of hand-writing taskLogs GraphQL. Get an executionId from buddy_workflow_run or buddy_workflow_executions. By default every task shows name + status and failed tasks additionally show message, input, and result (truncated); pass includeResult to include every task's result, or failedOnly to list only failed tasks. A task's input shows exactly what it received (an empty-string id means the caller passed nothing); its result shows the real output shape — read it before assuming a wrapper key (e.g. some actions return a list directly, not { items: [...] }).",
+			"Inspect one workflow execution's task logs: per task, its status, and for failed tasks the message, the input it received, and the result it produced — the fastest way to see WHY a run failed, instead of hand-writing taskLogs GraphQL. Get an executionId from buddy_workflow_run or buddy_workflow_executions. By default every task shows name + status and failed tasks additionally show message, input, and result (truncated); pass includeResult to include every task's result, or failedOnly to list only failed tasks. A task's input shows exactly what it received (an empty-string id means the caller passed nothing); its result shows the real output shape — read it before assuming a wrapper key (e.g. some actions return a list directly, not { items: [...] }). Each signed-in Rewst session only sees its own org hierarchy: if the first session has no rows for the execution, the other active sessions are checked automatically; pass orgId (the org that owns the execution) to query the right session directly.",
 		inputSchema: {
 			type: 'object',
 			properties: {
 				executionId: { type: 'string', description: 'The workflow execution id to inspect.' },
+				orgId: {
+					type: 'string',
+					description:
+						'Optional: the org that owns the execution — routes the lookup to the session managing that org (useful with several signed-in accounts).',
+				},
 				failedOnly: { type: 'boolean', description: 'List only failed tasks (default false).' },
 				includeResult: {
 					type: 'boolean',
@@ -1674,10 +1679,33 @@ async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Pr
 	if (!executionId) throw new Error('buddy_execution_logs requires "executionId".');
 	const failedOnly = request.args.failedOnly === true;
 	const includeResult = request.args.includeResult === true;
-	const rows = await fetchTaskLogs(deps, executionId);
+	let rows = await fetchTaskLogs(deps, executionId);
+	let sourceNote = '';
+	// A Rewst session only sees its own org hierarchy, so an execution owned by
+	// another signed-in account legitimately yields zero rows here (#116). The
+	// execution id is globally unique — sweep the other sessions before
+	// concluding the execution has no logs.
+	const alternates = deps.alternates ?? [];
+	if (rows.length === 0) {
+		for (const alternate of alternates) {
+			try {
+				rows = await fetchTaskLogs(alternate, executionId);
+			} catch {
+				continue;
+			}
+			if (rows.length > 0) {
+				sourceNote = ' (found via another active session)';
+				break;
+			}
+		}
+	}
 	const failed = rows.filter(r => isFailedStatus(r.status)).length;
-	const header = `Execution ${executionId}: ${rows.length} task(s), ${failed} failed.`;
-	return formatWorkflowOutput(`${header}\n${formatTaskLogs(rows, { failedOnly, includeResult })}`);
+	const header = `Execution ${executionId}: ${rows.length} task(s), ${failed} failed.${sourceNote}`;
+	const emptyHint =
+		rows.length === 0 && alternates.length > 0
+			? `\nNone of the ${alternates.length + 1} active session(s) can see task logs for this execution — check the execution id, or sign in to the Rewst account whose org owns it.`
+			: '';
+	return formatWorkflowOutput(`${header}${emptyHint}\n${formatTaskLogs(rows, { failedOnly, includeResult })}`);
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Fixes #116.

## Why

`buddy_execution_logs` is a `requiresOrg: false` capability, and every such capability runs against **the first active session** (`resolveContext`, `McpActions.ts`). A Rewst session only sees its own org hierarchy, so an execution owned by another signed-in account — including a managed sub-org, exactly issue #116's report — returned `0 task(s)` with no explanation even though the run completed.

## What

- **Cross-session sweep:** when the primary session returns zero rows, the tool queries each other active session in turn (sessions that error are skipped) and uses the first non-empty result, noting `(found via another active session)`.
- **Optional `orgId`:** routes the primary lookup to the session managing that org directly (falls back to the default session when nothing manages it). Stays optional — the execution id alone still works.
- **Honest empty result:** when no session has rows, the output says none of the N active sessions can see the execution, instead of implying it has no logs.
- Plumbing: `GraphqlToolDeps` gains an optional `alternates` list; the execution-logs capability builds it from the capability context's sessions (`executionLogsDeps`).

Spec: new `Resolve execution logs across all active sessions` requirement in `openspec/specs/mcp-bridge/spec.md` (anchored clear of PR #120's spec regions).

## Testing

- New unit tests (red before implementation via diagnostics/missing export, green after):
  - tool level: alternate-session sweep returns rows and notes the source (first alternate erroring is skipped); all-empty case names the visibility problem; spec declares optional `orgId`.
  - capability level (`chatToolCapabilities.test.ts`, new): primary follows the passed `orgId`'s managing session, others become alternates; no `orgId` → context session leads; unknown `orgId` falls back without erroring.
- Full unit suite green (1114 passing).

## Note for reviewers

The same `sessions[0]` default also affects `buddy_workflow_search`'s cross-account index (its cache is per-session-scope, so results from other accounts' hierarchies are invisible there too). Left out of this PR to keep it scoped to #116; tracked in the tooling backlog.