### PR TITLE
Surface sub-workflow executions in execution logs

### DIFF
--- a/changelog.d/127.md
+++ b/changelog.d/127.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Sub-workflow visibility in execution logs** — `buddy_execution_logs` now marks tasks that spawned sub-workflow executions and, with `includeSubExecutions`, inlines the child runs' task logs.

--- a/changelog.d/127.md
+++ b/changelog.d/127.md
@@ -1,5 +1,6 @@
 ---
 category: Added
+pr: 128
 ---
 
 - **Sub-workflow visibility in execution logs** — `buddy_execution_logs` now marks tasks that spawned sub-workflow executions and, with `includeSubExecutions`, inlines the child runs' task logs.

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -529,6 +529,40 @@ confined to sessions managing an org in the effective allowed set.
 - **THEN** the out-of-scope session is never queried and its rows do not
   appear in the result
 
+### Requirement: Surface sub-workflow executions in execution logs
+
+Because a sub-workflow call appears in its parent's task logs as a single
+opaque task whose child run is otherwise invisible, `buddy_execution_logs`
+SHALL look up the execution's direct child executions and mark each task that
+spawned one with the child's workflow name, execution id, and status, and
+SHALL summarize the spawned children with a pointer to drill down by calling
+the tool again with a child's execution id. An `includeSubExecutions` option
+SHALL additionally inline the task logs of the first few child executions
+(bounded, so a wide fan-out cannot flood the output). Child executions that
+cannot be tied to a listed task SHALL still be listed. A failed
+child-execution lookup SHALL NOT fail the call: the task logs are returned
+with a note that sub-executions could not be checked.
+
+#### Scenario: A task that ran a sub-workflow is marked
+
+- **GIVEN** an execution with a task that spawned a sub-workflow execution
+- **WHEN** `buddy_execution_logs` runs
+- **THEN** that task's entry names the child's workflow, execution id, and
+  status, and the result summarizes how many sub-executions were spawned
+
+#### Scenario: Sub-execution details on demand
+
+- **GIVEN** the same execution
+- **WHEN** `buddy_execution_logs` runs with `includeSubExecutions: true`
+- **THEN** the result appends the child execution's own task logs
+
+#### Scenario: Child lookup failure degrades gracefully
+
+- **GIVEN** the child-execution lookup errors
+- **WHEN** `buddy_execution_logs` runs
+- **THEN** the parent's task logs are returned with a note that sub-workflow
+  executions could not be checked
+
 ### Requirement: Page oversized tool results
 
 The system SHALL keep MCP tool responses below the transport-friendly output

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -538,8 +538,9 @@ spawned one with the child's workflow name, execution id, and status, and
 SHALL summarize the spawned children with a pointer to drill down by calling
 the tool again with a child's execution id. An `includeSubExecutions` option
 SHALL additionally inline the task logs of the first few child executions
-(bounded, so a wide fan-out cannot flood the output). Child executions that
-cannot be tied to a listed task SHALL still be listed. A failed
+(bounded, so a wide fan-out cannot flood the output). A child execution whose
+spawning task is not shown — unmatched, or hidden by `failedOnly` — SHALL
+still be listed in the result so its execution id stays reachable. A failed
 child-execution lookup SHALL NOT fail the call: the task logs are returned
 with a note that sub-executions could not be checked.
 

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -1037,6 +1037,9 @@ suite('Unit: workflowTools', () => {
 				renderResult: unknown;
 				contexts: Record<string, unknown>[];
 				taskLogs: unknown[];
+				taskLogsByExecution: Record<string, unknown[]>;
+				childExecutions: unknown[];
+				childExecutionsError: string;
 				executions: unknown[];
 				executionOwnerOrgId: string;
 				indexWorkflows: { id: string; name: string; orgId: string; orgName: string }[];
@@ -1103,7 +1106,18 @@ suite('Unit: workflowTools', () => {
 					};
 				}
 				if (query.includes('RewstBuddyTaskLogs')) {
+					const where = (variables?.where ?? {}) as { workflowExecutionId?: string };
+					const byExecution = over.taskLogsByExecution ?? {};
+					if (where.workflowExecutionId && where.workflowExecutionId in byExecution) {
+						return { data: { taskLogs: byExecution[where.workflowExecutionId] } };
+					}
 					return { data: { taskLogs: over.taskLogs ?? [] } };
+				}
+				if (query.includes('RewstBuddyChildExecutions')) {
+					if (over.childExecutionsError) return { errors: [{ message: over.childExecutionsError }] };
+					return {
+						data: { workflowExecution: { id: 'exec-1', childExecutions: over.childExecutions ?? [] } },
+					};
 				}
 				if (query.includes('RewstBuddyWorkflowsIndex')) {
 					const all = over.indexWorkflows ?? [
@@ -2038,6 +2052,117 @@ suite('Unit: workflowTools', () => {
 				() => runWorkflowTool({ tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, args: {} }, deps),
 				/executionId/,
 			);
+		});
+
+		test('buddy_execution_logs marks tasks that spawned sub-workflow executions', async () => {
+			const { deps } = makeDeps({
+				taskLogs: [
+					{ originalWorkflowTaskName: 'call_sub', status: 'succeeded', taskExecutionId: 'te-1' },
+					{ originalWorkflowTaskName: 'plain', status: 'succeeded', taskExecutionId: 'te-2' },
+				],
+				childExecutions: [
+					{
+						id: 'exec-child',
+						status: 'succeeded',
+						createdAt: '1500',
+						parentTaskExecutionId: 'te-1',
+						workflow: { id: 'wf-sub', name: 'Sub Flow' },
+					},
+				],
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /call_sub: succeeded/);
+			assert.match(
+				output,
+				/sub-execution: Sub Flow \(exec-child, succeeded\)/,
+				'the spawning task names its child execution',
+			);
+			const annotations = output.split('\n').filter(line => line.startsWith('    sub-execution:'));
+			assert.strictEqual(annotations.length, 1, 'only the spawning task is marked, not plain tasks');
+			assert.match(output, /1 sub-workflow execution\(s\)/, 'the summary counts spawned children');
+			assert.match(output, /includeSubExecutions/, 'the summary names the drill-down option');
+		});
+
+		test('buddy_execution_logs lists sub-executions it cannot tie to a task', async () => {
+			const { deps } = makeDeps({
+				taskLogs: [{ originalWorkflowTaskName: 'start', status: 'succeeded' }],
+				childExecutions: [
+					{
+						id: 'exec-orphan',
+						status: 'running',
+						createdAt: '1500',
+						parentTaskExecutionId: null,
+						workflow: { id: 'wf-sub', name: 'Sub Flow' },
+					},
+				],
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /Sub Flow \(exec-orphan, running\)/, 'unmatched children are still listed');
+		});
+
+		test('buddy_execution_logs keeps task logs when the sub-execution lookup fails', async () => {
+			const { deps } = makeDeps({
+				taskLogs: [{ originalWorkflowTaskName: 'start', status: 'succeeded' }],
+				childExecutionsError: 'resolver broke',
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /start: succeeded/, 'the primary task logs still come back');
+			assert.match(output, /[Ss]ub-workflow executions could not be checked/);
+		});
+
+		test('buddy_execution_logs includeSubExecutions inlines child task logs', async () => {
+			const { deps } = makeDeps({
+				taskLogs: [{ originalWorkflowTaskName: 'call_sub', status: 'succeeded', taskExecutionId: 'te-1' }],
+				childExecutions: [
+					{
+						id: 'exec-child',
+						status: 'failed',
+						createdAt: '1500',
+						parentTaskExecutionId: 'te-1',
+						workflow: { id: 'wf-sub', name: 'Sub Flow' },
+					},
+				],
+				taskLogsByExecution: {
+					'exec-child': [
+						{
+							originalWorkflowTaskName: 'inner_task',
+							status: 'failed',
+							message: 'inner boom',
+							input: {},
+							result: {},
+						},
+					],
+				},
+			});
+			const output = await runWorkflowTool(
+				{
+					tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+					args: { executionId: 'exec-1', includeSubExecutions: true },
+				},
+				deps,
+			);
+			assert.match(output, /Sub-execution Sub Flow \(exec-child, failed\):/);
+			assert.match(output, /inner_task: failed/);
+			assert.match(output, /inner boom/);
+		});
+
+		test('buddy_execution_logs spec documents sub-execution visibility and includeSubExecutions', () => {
+			const spec = WORKFLOW_TOOL_SPECS.find(tool => tool.name === WORKFLOW_EXECUTION_LOGS_TOOL_NAME);
+			assert.ok(spec, 'buddy_execution_logs spec exists');
+			assert.match(spec.args, /"includeSubExecutions"\?/);
+			assert.match(spec.description, /sub-workflow/i, 'description explains sub-workflow visibility');
+			assert.match(spec.description, /includeSubExecutions/);
+			const props = (spec.inputSchema as { properties: Record<string, unknown> }).properties;
+			assert.ok('includeSubExecutions' in props, 'inputSchema declares includeSubExecutions');
 		});
 
 		test('buddy_workflow_search indexes every accessible org and shows the org name', async () => {

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -2155,6 +2155,203 @@ suite('Unit: workflowTools', () => {
 			assert.match(output, /inner boom/);
 		});
 
+		test('buddy_execution_logs failedOnly still surfaces sub-execution ids for hidden tasks', async () => {
+			const { deps } = makeDeps({
+				taskLogs: [
+					{ originalWorkflowTaskName: 'call_sub', status: 'succeeded', taskExecutionId: 'te-1' },
+					{ originalWorkflowTaskName: 'broken', status: 'failed', message: 'boom', input: {}, result: {} },
+				],
+				childExecutions: [
+					{
+						id: 'exec-child',
+						status: 'failed',
+						createdAt: '1500',
+						parentTaskExecutionId: 'te-1',
+						workflow: { id: 'wf-sub', name: 'Sub Flow' },
+					},
+				],
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, args: { executionId: 'exec-1', failedOnly: true } },
+				deps,
+			);
+			assert.ok(!output.includes('call_sub:'), 'the succeeded spawning task itself stays hidden');
+			assert.match(
+				output,
+				/Sub Flow \(exec-child, failed\)/,
+				"a hidden task's child execution id is still listed in the footer",
+			);
+		});
+
+		test('buddy_execution_logs accepts includeSubExecutions as the string "true"', async () => {
+			const { deps } = makeDeps({
+				taskLogs: [{ originalWorkflowTaskName: 'call_sub', status: 'succeeded', taskExecutionId: 'te-1' }],
+				childExecutions: [
+					{
+						id: 'exec-child',
+						status: 'succeeded',
+						createdAt: '1500',
+						parentTaskExecutionId: 'te-1',
+						workflow: { id: 'wf-sub', name: 'Sub Flow' },
+					},
+				],
+				taskLogsByExecution: {
+					'exec-child': [{ originalWorkflowTaskName: 'inner_task', status: 'succeeded' }],
+				},
+			});
+			const output = await runWorkflowTool(
+				{
+					tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+					args: { executionId: 'exec-1', includeSubExecutions: 'true' },
+				},
+				deps,
+			);
+			assert.match(output, /Sub-execution Sub Flow \(exec-child, succeeded\):/, 'string flags are coerced');
+		});
+
+		test('buddy_execution_logs fetches sub-executions from the session that saw the rows', async () => {
+			const primaryCalls: string[] = [];
+			const primary: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async query => {
+					primaryCalls.push(query);
+					if (query.includes('RewstBuddyTaskLogs')) return { data: { taskLogs: [] } };
+					return { data: {} };
+				},
+			};
+			const alternateCalls: string[] = [];
+			const alternate: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async query => {
+					alternateCalls.push(query);
+					if (query.includes('RewstBuddyTaskLogs')) {
+						return {
+							data: {
+								taskLogs: [
+									{
+										originalWorkflowTaskName: 'call_sub',
+										status: 'succeeded',
+										taskExecutionId: 'te-1',
+									},
+								],
+							},
+						};
+					}
+					if (query.includes('RewstBuddyChildExecutions')) {
+						return {
+							data: {
+								workflowExecution: {
+									id: 'exec-1',
+									childExecutions: [
+										{
+											id: 'exec-child',
+											status: 'succeeded',
+											parentTaskExecutionId: 'te-1',
+											workflow: { id: 'wf-sub', name: 'Sub Flow' },
+										},
+									],
+								},
+							},
+						};
+					}
+					return { data: {} };
+				},
+			};
+			primary.alternates = [alternate];
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, args: { executionId: 'exec-1' } },
+				primary,
+			);
+			assert.match(output, /sub-execution: Sub Flow \(exec-child, succeeded\)/);
+			assert.ok(
+				!primaryCalls.some(q => q.includes('RewstBuddyChildExecutions')),
+				'the primary session is not asked for children it cannot see',
+			);
+			assert.ok(
+				alternateCalls.some(q => q.includes('RewstBuddyChildExecutions')),
+				'children come from the session that produced the rows',
+			);
+		});
+
+		test('buddy_execution_logs caps how many sub-executions it inlines', async () => {
+			const children = Array.from({ length: 6 }, (_, i) => ({
+				id: `exec-c${i}`,
+				status: 'succeeded',
+				parentTaskExecutionId: null,
+				workflow: { id: 'wf-sub', name: `Sub ${i}` },
+			}));
+			const { deps } = makeDeps({
+				taskLogs: [{ originalWorkflowTaskName: 'start', status: 'succeeded' }],
+				childExecutions: children,
+				taskLogsByExecution: Object.fromEntries(
+					children.map(c => [c.id, [{ originalWorkflowTaskName: 'inner', status: 'succeeded' }]]),
+				),
+			});
+			const output = await runWorkflowTool(
+				{
+					tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+					args: { executionId: 'exec-1', includeSubExecutions: true },
+				},
+				deps,
+			);
+			const inlined = output.split('\n').filter(line => /^Sub-execution Sub \d/.test(line)).length;
+			assert.strictEqual(inlined, 5, 'only the first five children are inlined');
+			assert.match(output, /1 more sub-execution\(s\) not inlined/);
+		});
+
+		test('buddy_execution_logs notes a child whose task logs cannot be read', async () => {
+			const deps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async (query, variables) => {
+					if (query.includes('RewstBuddyTaskLogs')) {
+						const where = (variables?.where ?? {}) as { workflowExecutionId?: string };
+						if (where.workflowExecutionId === 'exec-child') throw new Error('child hidden');
+						return {
+							data: {
+								taskLogs: [
+									{
+										originalWorkflowTaskName: 'call_sub',
+										status: 'succeeded',
+										taskExecutionId: 'te-1',
+									},
+								],
+							},
+						};
+					}
+					if (query.includes('RewstBuddyChildExecutions')) {
+						return {
+							data: {
+								workflowExecution: {
+									id: 'exec-1',
+									childExecutions: [
+										{
+											id: 'exec-child',
+											status: 'succeeded',
+											parentTaskExecutionId: 'te-1',
+											workflow: { id: 'wf-sub', name: 'Sub Flow' },
+										},
+									],
+								},
+							},
+						};
+					}
+					return { data: {} };
+				},
+			};
+			const output = await runWorkflowTool(
+				{
+					tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+					args: { executionId: 'exec-1', includeSubExecutions: true },
+				},
+				deps,
+			);
+			assert.match(output, /call_sub: succeeded/, 'parent logs survive the child read failure');
+			assert.match(output, /task logs could not be read \(child hidden\)/);
+		});
+
 		test('buddy_execution_logs spec documents sub-execution visibility and includeSubExecutions', () => {
 			const spec = WORKFLOW_TOOL_SPECS.find(tool => tool.name === WORKFLOW_EXECUTION_LOGS_TOOL_NAME);
 			assert.ok(spec, 'buddy_execution_logs spec exists');

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -195,9 +195,9 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 	},
 	{
 		name: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
-		args: '{"executionId": string, "orgId"?: string, "failedOnly"?: boolean, "includeResult"?: boolean}',
+		args: '{"executionId": string, "orgId"?: string, "failedOnly"?: boolean, "includeResult"?: boolean, "includeSubExecutions"?: boolean}',
 		description:
-			"Inspect one workflow execution's task logs: per task, its status, and for failed tasks the message, the input it received, and the result it produced — the fastest way to see WHY a run failed, instead of hand-writing taskLogs GraphQL. Get an executionId from buddy_workflow_run or buddy_workflow_executions. By default every task shows name + status and failed tasks additionally show message, input, and result (truncated); pass includeResult to include every task's result, or failedOnly to list only failed tasks. A task's input shows exactly what it received (an empty-string id means the caller passed nothing); its result shows the real output shape — read it before assuming a wrapper key (e.g. some actions return a list directly, not { items: [...] }). Each signed-in Rewst session only sees its own org hierarchy: if the first session has no rows for the execution, the other active sessions are checked automatically; pass orgId (the org that owns the execution) to query the right session directly.",
+			"Inspect one workflow execution's task logs: per task, its status, and for failed tasks the message, the input it received, and the result it produced — the fastest way to see WHY a run failed, instead of hand-writing taskLogs GraphQL. Get an executionId from buddy_workflow_run or buddy_workflow_executions. By default every task shows name + status and failed tasks additionally show message, input, and result (truncated); pass includeResult to include every task's result, or failedOnly to list only failed tasks. A task that called a sub-workflow is marked with the sub-execution it spawned (workflow name, execution id, status) — a sub-workflow's own tasks are NOT in the parent's logs, so drill into a sub-execution by calling this tool again with its execution id, or pass includeSubExecutions:true to inline the task logs of the first few sub-executions. A task's input shows exactly what it received (an empty-string id means the caller passed nothing); its result shows the real output shape — read it before assuming a wrapper key (e.g. some actions return a list directly, not { items: [...] }). Each signed-in Rewst session only sees its own org hierarchy: if the first session has no rows for the execution, the other active sessions are checked automatically; pass orgId (the org that owns the execution) to query the right session directly.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -211,6 +211,11 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = [
 				includeResult: {
 					type: 'boolean',
 					description: "Include every task's result, not just failed tasks' (default false).",
+				},
+				includeSubExecutions: {
+					type: 'boolean',
+					description:
+						'Also inline the task logs of the first few sub-workflow executions this run spawned (default false).',
 				},
 			},
 			required: ['executionId'],
@@ -1355,7 +1360,19 @@ const WORKFLOW_EXECUTIONS_QUERY = `query RewstBuddyExecutions($where: WorkflowEx
 
 const TASK_LOGS_QUERY = `query RewstBuddyTaskLogs($where: TaskLogWhereInput) {
 	taskLogs(where: $where, order: [["createdAt", "ASC"]]) {
-		id originalWorkflowTaskName status message input result createdAt
+		id originalWorkflowTaskName status message input result createdAt taskExecutionId
+	}
+}`;
+
+// A sub-workflow call spawns a child execution whose parentTaskExecutionId
+// points back at the spawning task's taskExecutionId — the only linkage between
+// a parent's task logs and its sub-workflow runs. WorkflowExecutionWhereInput
+// has no parentExecutionId filter, so children are read via the parent's
+// childExecutions traversal.
+const CHILD_EXECUTIONS_QUERY = `query RewstBuddyChildExecutions($where: WorkflowExecutionWhereInput) {
+	workflowExecution(where: $where) {
+		id
+		childExecutions { id status createdAt parentTaskExecutionId workflow { id name } }
 	}
 }`;
 
@@ -1816,9 +1833,21 @@ interface TaskLogRow {
 	input?: unknown;
 	result?: unknown;
 	createdAt?: string | null;
+	taskExecutionId?: string | null;
+}
+
+interface ChildExecutionRow {
+	id?: string | null;
+	status?: string | null;
+	createdAt?: string | null;
+	parentTaskExecutionId?: string | null;
+	workflow?: { id?: string | null; name?: string | null } | null;
 }
 
 const TASK_VALUE_CHARS = 600;
+// includeSubExecutions inlines one extra task-log read per child; cap it so a
+// wide fan-out (a loop task spawning dozens of runs) cannot flood the output.
+const MAX_INLINE_SUB_EXECUTIONS = 5;
 
 /** A failed/errored status, for both task and execution status strings. */
 function isFailedStatus(status: string | null | undefined): boolean {
@@ -1839,6 +1868,31 @@ async function fetchTaskLogs(deps: GraphqlToolDeps, executionId: string): Promis
 	return ((result.data as { taskLogs?: (TaskLogRow | null)[] } | undefined)?.taskLogs ?? []).filter(
 		(r): r is TaskLogRow => !!r,
 	);
+}
+
+/**
+ * Direct child executions (sub-workflow runs) of one execution. Non-fatal by
+ * design: the primary task logs must still come back if this traversal errors,
+ * so failures are returned as a note, never thrown.
+ */
+async function fetchChildExecutions(
+	deps: GraphqlToolDeps,
+	executionId: string,
+): Promise<{ children: ChildExecutionRow[]; error?: string }> {
+	try {
+		const result = await deps.execute(CHILD_EXECUTIONS_QUERY, { where: { id: executionId } });
+		const error = firstErrorMessage(result);
+		if (error) return { children: [], error };
+		const parent = (result.data as { workflowExecution?: { childExecutions?: (ChildExecutionRow | null)[] } })
+			?.workflowExecution;
+		return { children: (parent?.childExecutions ?? []).filter((row): row is ChildExecutionRow => !!row) };
+	} catch (error) {
+		return { children: [], error: error instanceof Error ? error.message : String(error) };
+	}
+}
+
+function describeChildExecution(child: ChildExecutionRow): string {
+	return `${child.workflow?.name ?? '(unknown workflow)'} (${child.id ?? '?'}, ${child.status ?? '?'})`;
 }
 
 async function assertExecutionBelongsToOrg(deps: GraphqlToolDeps, executionId: string, orgId: string): Promise<void> {
@@ -1865,7 +1919,11 @@ async function fetchTaskLogsForVisibleExecution(
 	return fetchTaskLogs(deps, executionId);
 }
 
-function formatTaskLogs(rows: TaskLogRow[], opts: { failedOnly?: boolean; includeResult?: boolean }): string {
+function formatTaskLogs(
+	rows: TaskLogRow[],
+	opts: { failedOnly?: boolean; includeResult?: boolean },
+	childrenByTask?: Map<string, ChildExecutionRow[]>,
+): string {
 	const visible = opts.failedOnly ? rows.filter(r => isFailedStatus(r.status)) : rows;
 	if (visible.length === 0) {
 		return opts.failedOnly ? 'No failed tasks in this execution.' : 'This execution has no task logs yet.';
@@ -1875,6 +1933,9 @@ function formatTaskLogs(rows: TaskLogRow[], opts: { failedOnly?: boolean; includ
 			const name = row.originalWorkflowTaskName ?? '(unnamed task)';
 			const failed = isFailedStatus(row.status);
 			const parts = [`- ${name}: ${row.status ?? '?'}`];
+			for (const child of (row.taskExecutionId && childrenByTask?.get(row.taskExecutionId)) || []) {
+				parts.push(`    sub-execution: ${describeChildExecution(child)}`);
+			}
 			if (failed) {
 				if (row.message) parts.push(`    message: ${briefValue(row.message)}`);
 				parts.push(`    input: ${briefValue(row.input)}`);
@@ -1893,7 +1954,9 @@ async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Pr
 	const orgId = asStringArg(request.args, 'orgId');
 	const failedOnly = request.args.failedOnly === true;
 	const includeResult = request.args.includeResult === true;
+	const includeSubExecutions = request.args.includeSubExecutions === true;
 	let rows: TaskLogRow[] = [];
+	let sourceDeps = deps;
 	let sourceNote = '';
 	let firstError: unknown;
 	let hadVisibleSession = false;
@@ -1901,6 +1964,7 @@ async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Pr
 		try {
 			const found = await fetchTaskLogsForVisibleExecution(candidate, executionId, orgId);
 			hadVisibleSession = true;
+			sourceDeps = candidate;
 			return found;
 		} catch (error) {
 			firstError ??= error;
@@ -1933,7 +1997,65 @@ async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Pr
 		rows.length === 0 && alternates.length > 0
 			? `\nNone of the ${alternates.length + 1} active session(s) can see task logs for this execution — check the execution id, or sign in to the Rewst account whose org owns it.`
 			: '';
-	return formatWorkflowOutput(`${header}${emptyHint}\n${formatTaskLogs(rows, { failedOnly, includeResult })}`);
+
+	// Sub-workflow calls look like one opaque task in the parent's logs (#127);
+	// surface the child executions they spawned so the run tree is visible.
+	let children: ChildExecutionRow[] = [];
+	let childLookupError: string | undefined;
+	if (rows.length > 0) {
+		({ children, error: childLookupError } = await fetchChildExecutions(sourceDeps, executionId));
+	}
+	const childrenByTask = new Map<string, ChildExecutionRow[]>();
+	const orphanChildren: ChildExecutionRow[] = [];
+	const taskExecutionIds = new Set(rows.map(row => row.taskExecutionId).filter((id): id is string => !!id));
+	for (const child of children) {
+		const parentTask = child.parentTaskExecutionId;
+		if (parentTask && taskExecutionIds.has(parentTask)) {
+			childrenByTask.set(parentTask, [...(childrenByTask.get(parentTask) ?? []), child]);
+		} else {
+			orphanChildren.push(child);
+		}
+	}
+
+	const footer: string[] = [];
+	if (childLookupError) {
+		footer.push(`Sub-workflow executions could not be checked: ${childLookupError}`);
+	}
+	if (children.length > 0) {
+		footer.push(
+			`Spawned ${children.length} sub-workflow execution(s). Drill into one with buddy_execution_logs {"executionId": "<sub-execution id>"}${includeSubExecutions ? '' : ', or pass includeSubExecutions:true to inline their task logs'}.`,
+		);
+	}
+	if (orphanChildren.length > 0) {
+		footer.push(
+			`Sub-execution(s) not tied to a listed task: ${orphanChildren.map(describeChildExecution).join(', ')}`,
+		);
+	}
+	if (includeSubExecutions) {
+		for (const child of children.slice(0, MAX_INLINE_SUB_EXECUTIONS)) {
+			if (!child.id) continue;
+			try {
+				const childRows = await fetchTaskLogs(sourceDeps, child.id);
+				footer.push(
+					`Sub-execution ${describeChildExecution(child)}:\n${formatTaskLogs(childRows, { failedOnly, includeResult })}`,
+				);
+			} catch (error) {
+				footer.push(
+					`Sub-execution ${describeChildExecution(child)}: task logs could not be read (${error instanceof Error ? error.message : String(error)})`,
+				);
+			}
+		}
+		if (children.length > MAX_INLINE_SUB_EXECUTIONS) {
+			footer.push(
+				`(${children.length - MAX_INLINE_SUB_EXECUTIONS} more sub-execution(s) not inlined — drill into them individually.)`,
+			);
+		}
+	}
+
+	const footerText = footer.length > 0 ? `\n${footer.join('\n')}` : '';
+	return formatWorkflowOutput(
+		`${header}${emptyHint}\n${formatTaskLogs(rows, { failedOnly, includeResult }, childrenByTask)}${footerText}`,
+	);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -1952,9 +1952,9 @@ async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Pr
 	const executionId = asStringArg(request.args, 'executionId');
 	if (!executionId) throw new Error('buddy_execution_logs requires "executionId".');
 	const orgId = asStringArg(request.args, 'orgId');
-	const failedOnly = request.args.failedOnly === true;
-	const includeResult = request.args.includeResult === true;
-	const includeSubExecutions = request.args.includeSubExecutions === true;
+	const failedOnly = asBooleanArg(request.args, 'failedOnly') ?? false;
+	const includeResult = asBooleanArg(request.args, 'includeResult') ?? false;
+	const includeSubExecutions = asBooleanArg(request.args, 'includeSubExecutions') ?? false;
 	let rows: TaskLogRow[] = [];
 	let sourceDeps = deps;
 	let sourceNote = '';
@@ -2006,14 +2006,20 @@ async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Pr
 		({ children, error: childLookupError } = await fetchChildExecutions(sourceDeps, executionId));
 	}
 	const childrenByTask = new Map<string, ChildExecutionRow[]>();
-	const orphanChildren: ChildExecutionRow[] = [];
-	const taskExecutionIds = new Set(rows.map(row => row.taskExecutionId).filter((id): id is string => !!id));
+	const unshownChildren: ChildExecutionRow[] = [];
+	// Match against the rows the caller will actually see: a failedOnly view
+	// hides succeeded tasks, and a child annotated onto a hidden row would
+	// vanish with it — its id must fall through to the footer instead.
+	const shownRows = failedOnly ? rows.filter(row => isFailedStatus(row.status)) : rows;
+	const shownTaskExecutionIds = new Set(
+		shownRows.map(row => row.taskExecutionId).filter((id): id is string => !!id),
+	);
 	for (const child of children) {
 		const parentTask = child.parentTaskExecutionId;
-		if (parentTask && taskExecutionIds.has(parentTask)) {
+		if (parentTask && shownTaskExecutionIds.has(parentTask)) {
 			childrenByTask.set(parentTask, [...(childrenByTask.get(parentTask) ?? []), child]);
 		} else {
-			orphanChildren.push(child);
+			unshownChildren.push(child);
 		}
 	}
 
@@ -2026,9 +2032,9 @@ async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Pr
 			`Spawned ${children.length} sub-workflow execution(s). Drill into one with buddy_execution_logs {"executionId": "<sub-execution id>"}${includeSubExecutions ? '' : ', or pass includeSubExecutions:true to inline their task logs'}.`,
 		);
 	}
-	if (orphanChildren.length > 0) {
+	if (unshownChildren.length > 0) {
 		footer.push(
-			`Sub-execution(s) not tied to a listed task: ${orphanChildren.map(describeChildExecution).join(', ')}`,
+			`Sub-execution(s) not shown with a task above: ${unshownChildren.map(describeChildExecution).join(', ')}`,
 		);
 	}
 	if (includeSubExecutions) {


### PR DESCRIPTION
## Problem

A sub-workflow call appears in its parent's task logs as one opaque task. `buddy_execution_logs` gave no indication that a child execution existed, and no way to see its details (#127).

## Change

- `buddy_execution_logs` now reads the execution's direct child executions (`workflowExecution → childExecutions`; each child's `parentTaskExecutionId` ties it to the spawning task's `taskExecutionId`).
- Tasks that spawned a sub-workflow are marked inline with the child's workflow name, execution id, and status; a footer summarizes the spawned runs and points at drilling down by calling the tool again with the child id.
- New `includeSubExecutions` option inlines the task logs of the first 5 children (capped so a wide fan-out cannot flood the output).
- A child whose spawning task is not shown (unmatched, or hidden by `failedOnly`) is still listed in the footer so its id stays reachable.
- The child lookup is non-fatal: if the traversal errors, the parent's task logs still return with a note.
- Execution-log boolean flags (`failedOnly`, `includeResult`, `includeSubExecutions`) now coerce string forms via `asBooleanArg` (MCP passes arguments unvalidated).
- Openspec: new `Surface sub-workflow executions in execution logs` requirement with scenarios; changelog note added.

## Testing

- `npm run test:unit` — 1139 passing; `npm run lint` — clean.
- New unit tests cover: annotation + summary, footer listing for unmatched/hidden children, `includeSubExecutions` inlining (object and string `"true"` forms), the 5-child inline cap, a failed child log read, a failed child lookup, and the multi-session sweep (children are fetched from the session that produced the rows).
- A Codex review ran on the diff; its legitimate findings (failedOnly hiding child ids, missing `asBooleanArg` coercion, sweep/cap/failure coverage gaps) are fixed in the second commit.
- **Live validation gap:** the `childExecutions` traversal and `parentTaskExecutionId` linkage are schema-valid (generated SDK types) but could not be probed live — the `.env` `REWST_TEST_TOKEN` cookie is currently expired (all regions return AUTH_ERR). The non-fatal lookup means a live discrepancy degrades to today's behavior plus a note rather than breaking the tool. Worth one live run against a sandbox execution with a sub-workflow once the token is refreshed.

Addresses #127