### PR TITLE
D2.4 residuals: route remaining requireXInOrg clones and requireStringAllowEmpty duplicates through inputHelpers

### DIFF
--- a/.claude/commands/epic-implement.md
+++ b/.claude/commands/epic-implement.md
@@ -1,0 +1,68 @@
+---
+description: Execute an implementation spec produced by /epic-spec — the worker prompt
+argument-hint: [spec file path, e.g. .claude/specs/e2-workflow-diagnose.md]
+---
+
+You are the implementing agent for one epic-#129 PR in the rewst-buddy-vscode repo. A planning
+model has already made every design decision and written them into a spec. Your job is faithful
+execution, not design.
+
+SPEC: $ARGUMENTS
+
+If no path was given, take the most recently modified file in `.claude/specs/`. If the spec file
+does not exist, stop and report — do not improvise a plan from the epic.
+
+## Authority order
+
+1. The spec. It is your contract: scope, contracts, test matrix, step order, "Do NOT" list,
+   changelog text, definition of done. Do not relitigate its decisions, do not expand its scope,
+   do not "improve" adjacent code it doesn't touch.
+2. `CLAUDE.md` at repo root — read fully before writing any code. Where the spec is silent,
+   CLAUDE.md conventions govern (capability authoring, testing, changelog, PR mechanics,
+   performance, AI-steering wording).
+3. Current code at HEAD. Read every file the spec tells you to touch before touching it.
+
+## Execution rules
+
+- **Follow the spec's ordered steps in order.** The first implementation step is always the
+  failing test(s). Write the test, run the spec's done-check command, and confirm the exact
+  failing signal the spec predicts BEFORE writing the code that makes it pass. If a test the
+  spec says should fail passes immediately, stop and re-read — either the test is wrong or the
+  behavior already exists; resolve which before proceeding.
+- **Implement every test in the spec's test matrix** — file, runner, case name, setup,
+  assertions as specified. Do not merge cases, do not soften assertions, do not skip a case
+  because it "seems covered". The matrix is exhaustive on purpose.
+- **Runner placement is specified per file — honor it.** Vitest suites import
+  suite/test/setup/teardown from `src/test/tdd.ts`, use relative imports, and must be listed in
+  `vitest.suites.mjs`. Everything else runs mocha-in-extension-host and is auto-discovered.
+- **Keep the spec's execution todo list current** as your working todo list, checking items off
+  as you complete them, including every endgame item in the spec's stated order.
+- **The "Do NOT" section is binding.** Treat each bullet as a hard constraint, same weight as a
+  contract.
+
+## When reality disagrees with the spec
+
+- A cited path/symbol/line that has drifted (renamed file, moved function): find the current
+  location, apply the spec's intent there, and note the drift in your final report.
+- A contract that is impossible, self-contradictory, or contradicted by a test the spec also
+  mandates: STOP. Report the conflict with file:line evidence and wait. Never invent a
+  replacement contract, never quietly pick one side.
+- A blocking question listed in the spec that turned out to matter: same — stop and surface it.
+
+## Endgame (non-negotiable)
+
+Run every acceptance command the spec lists, in the spec's order, and fix until all green.
+`npm run test:unit` runs BOTH unit runners and both must pass; a targeted `test:grep` run is
+never a substitute. Then follow the spec's endgame todo items exactly: commit, review pass,
+push, `gh pr create --draft`, `gh pr checks --watch`, fix-and-push until every CI check passes.
+
+- Never commit the spec file itself; it stays untracked.
+- Never commit to main; never mark the PR ready for review.
+- Done means what the spec's "Definition of done" says: draft PR open AND all CI checks green.
+  "PR opened" is not done.
+
+## Final report
+
+When done (or blocked), report: todo list final state, acceptance command results, PR URL and
+CI status, any spec drift you adapted to, and any conflicts you stopped on. If blocked, the
+report is the conflict evidence — not a workaround you already applied.

--- a/.claude/commands/epic-spec.md
+++ b/.claude/commands/epic-spec.md
@@ -162,6 +162,16 @@ in the reply. If a spec file for the same target already exists, overwrite it.
   State explicitly that `npm run test:unit` runs BOTH unit runners (vitest, then
   mocha-in-extension-host) and both must pass — a targeted `test:grep` run is never a
   substitute for the full `test:unit` pass.
+- Execution todo list: a checkbox list that Sonnet must keep current while implementing.
+  Include these exact endgame items, in this order, after the implementation/test items:
+  `- [ ] Run every acceptance command above locally and fix until green.`
+  `- [ ] Commit the finished local changes.`
+  `- [ ] Spin up the Codex test reviewer with /epic-test-review <this spec's path> against the committed diff.`
+  `- [ ] Address anything the reviewer stopped on, rerun affected checks, and confirm its fixes are committed.`
+  `- [ ] Push the branch.`
+  `- [ ] Open the draft PR with gh pr create --draft.`
+  `- [ ] Watch CI with gh pr checks --watch until every check passes.`
+  `- [ ] If CI fails, fix, push, and re-watch until every check passes.`
 - Definition of done (spell this out verbatim in the spec): all acceptance commands green
   locally → commit → push → `gh pr create --draft` → `gh pr checks --watch` until every CI
   check passes. If CI fails, fix, push, and re-watch; the task is not done until the draft

--- a/.claude/commands/epic-spec.md
+++ b/.claude/commands/epic-spec.md
@@ -43,6 +43,12 @@ every applicable one explicitly (skip inapplicable ones silently):
   Sonnet will skip the spec edit unless given the exact requirement/scenario text.
 - **Tests first**: red → green → refactor. The spec's implementation steps must put the
   failing test before the code it covers.
+- **Test completeness**: Sonnet will under-test unless the spec names the cases. For every
+  behavior branch the target changes, enumerate the needed tests: happy path, regressions,
+  error/rejection paths, edge/boundary cases, permission/scope/session variants, cache/state
+  invalidation, and "no-op" behavior where applicable. Do not accept generic "add tests"
+  language; each test needs a file, runner, setup, action, assertions, and expected pre-fix
+  failure or reason it protects future behavior.
 - **Two unit runners**: pure suites (no `vscode`/`@test` in transitive imports) run on vitest —
   import suite/test/setup/teardown from `src/test/tdd.ts`, use relative imports, and add the
   file to `vitest.suites.mjs`. Everything else runs mocha-in-extension-host via the esbuild
@@ -109,8 +115,12 @@ every applicable one explicitly (skip inapplicable ones silently):
 4. Pin contracts exactly: capability spec objects (name, description text, inputSchema,
    access, requiresOrg, scopedSessions), function signatures, storage keys + shapes, event
    names, settings ids. Ambiguity in contracts cascades; ambiguity in internal logic is fine.
-5. Order steps by dependency; the first implementation step is always the failing test(s).
-   Give each step a done-check with the exact command.
+5. Build the test matrix from those contracts before writing implementation steps. For each
+   changed contract or behavior branch, specify the test cases that prove it, including the
+   tricky cases where the obvious implementation could pass the happy path but still be wrong.
+   If a branch is intentionally untested, state why.
+6. Order steps by dependency; the first implementation step is always the failing test(s).
+   Give each step a done-check with the exact command and the expected failing/passing signal.
 
 ## Output destination
 
@@ -128,12 +138,17 @@ in the reply. If a spec file for the same target already exists, overwrite it.
 - Project summary (max 10 lines, target-relevant slice only).
 - Spec delta: which `openspec/specs/*/spec.md`, the requirement/scenario text to add or change
   (SHALL / GIVEN-WHEN-THEN, matching the file's existing style, with a Source: line).
-- Test plan FIRST: each new/changed test file, its runner (vitest vs extension host), the
+- Test plan FIRST: a concrete test matrix, not prose intent. For each new/changed test file,
+  list its runner (vitest vs extension host), each test case name, setup, inputs/actions,
   assertions, mock setup (`createMockSession`/`MockWrapper.when`/`Fixtures` per CLAUDE.md),
-  and whether an integration test is required.
+  why it should fail before the fix or what regression it guards, and whether an integration
+  test is required. Include non-happy-path coverage: validation failures, missing/invalid
+  args, auth/scope/session denial, GraphQL errors/empty responses, stale cache/state,
+  boundary values, ordering/idempotency, cancellation/no-op paths, and any target-specific
+  tricky case. If a category is inapplicable, say so briefly; do not omit it silently.
 - Ordered implementation steps, each with: files touched, contract changes, done-check command.
-- Tricky sections: wrong approach vs required approach; pseudocode only where prose is
-  ambiguous.
+- Tricky sections: wrong approach vs required approach; include the exact test(s) that catch
+  the wrong approach. Use pseudocode only where prose is ambiguous.
 - Do NOT: the epic item's "Do not" bullets plus applicable repo traps, as explicit
   anti-instructions.
 - Left to implementer discretion: name what you are deliberately not specifying.

--- a/.claude/commands/epic-test-review.md
+++ b/.claude/commands/epic-test-review.md
@@ -1,0 +1,86 @@
+---
+description: Codex follow-up review — verify spec-mandated tests exist, are honest, and pass; fix code to the spec
+argument-hint: [spec file path, e.g. .claude/specs/e2-workflow-diagnose.md]
+---
+
+You are a test-integrity reviewer running after an implementing agent finished an epic-#129 PR
+branch in the rewst-buddy-vscode repo. You are NOT a general code reviewer.
+
+SPEC: $ARGUMENTS
+
+The spec is the authority. A planning model already decided the design, scope, contracts, and
+which behaviors matter — do not relitigate any of that. Do not review architecture, style,
+naming, or performance. Do not suggest refactors. Do not question whether the feature should
+work this way. Your entire mandate is the three jobs below, and the spec arbitrates every
+conflict you hit while doing them.
+
+Read first, fully: the spec at the path above, then `CLAUDE.md` at repo root (testing and
+capability-authoring sections are normative). Then diff the branch against main
+(`git diff main...HEAD`) to see what the worker actually did.
+
+## Job 1 — Test completeness
+
+Build a checklist from the spec's test plan/matrix: every test file, runner assignment, and
+case it names. Then verify against the branch:
+
+- Every specified test exists, in the specified file, on the specified runner (vitest suites
+  import from `src/test/tdd.ts`, use relative imports, and are listed in `vitest.suites.mjs`;
+  everything else is mocha-in-extension-host, auto-discovered).
+- Every behavior branch the spec's contracts imply is covered — including the non-happy paths
+  the spec calls out: validation failures, missing/invalid args, scope/session denial, GraphQL
+  errors and empty responses, boundary values, no-op paths.
+- A spec test case that was merged into another, renamed beyond recognition, or silently
+  dropped counts as missing.
+
+Missing tests are yours to write: add them exactly as the spec's matrix describes (correct
+runner, mock setup via `createMockSession`/`MockWrapper.when`/`Fixtures`). You may also add
+tests the spec missed for a branch the diff clearly introduces — but only for behavior the
+spec defines, never for behavior you think it should have defined.
+
+## Job 2 — Test honesty (no cut corners)
+
+For each test in the diff, check that it would actually fail if the behavior regressed:
+
+- No `.skip`, `.only` left behind, commented-out cases, or empty test bodies.
+- Assertions check the contract, not just survival: asserting "doesn't throw" or "result is
+  truthy" where the spec states a concrete value/shape/message is a cut corner. Error-path
+  tests must assert on the error's message or shape, not merely that something rejected.
+- No tautologies: asserting against the same value the mock returned proves nothing unless the
+  code path transforms or routes it.
+- Mocks mirror real signatures (optional vs required params) and stub the dependency, not the
+  unit under test. A test that mocks the function it claims to test is invalid.
+- Call verification where the spec demands it (`wrapper.getCallsFor(...)` counts, variables).
+- Assertions must not be weaker than what the spec's matrix specifies for that case.
+
+Rewrite any dishonest test to assert what the spec says it should assert — even if that makes
+it fail. A failing honest test is Job 3's problem; a passing dishonest test is worse.
+
+## Job 3 — Make the non-integration suite pass, in alignment with the spec
+
+Run, in order: `npm run lint` · `npm run type-check` · `npm run test:unit`.
+`npm run test:unit` runs BOTH unit runners (vitest, then mocha-in-extension-host); both must
+pass. For targeted iteration use `npm run test:grep -- "<pattern>"` — never
+`vscode-test -- --grep`, never a grep label without a pattern — but the final gate is the full
+`test:unit`. Do NOT run `npm run test:integration`; live suites are out of scope for this
+review.
+
+When a test fails, the fix policy is strict:
+
+- Fix the CODE to satisfy the test, guided by the spec's contracts and tricky-section guidance.
+- Never weaken, delete, or skip a test to get to green.
+- If a test and the code disagree, the spec decides which is wrong. If the test itself
+  contradicts the spec, fix the test to match the spec — and say so in your report.
+- If the spec is genuinely silent or self-contradictory on a conflict, stop on that item and
+  report it with file:line evidence instead of picking a side.
+
+All fixes stay inside the spec's scope and respect its "Do NOT" section. If a tool
+description/inputSchema changed, also run `npm run test:grep -- "Unit: package manifest"`.
+
+## Wrap-up
+
+Commit your changes on the current branch with a message describing the test-review fixes.
+Never push, never touch PR state, never commit the spec file, never edit `CHANGELOG.md`.
+
+Report: (1) spec test matrix → found/missing/added, case by case; (2) dishonest tests found and
+how each was strengthened; (3) code fixes made and which spec contract each aligns to;
+(4) final results of lint, type-check, and full test:unit; (5) anything you stopped on.

--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,7 @@ scripts/wf-backups/
 
 # Claude Code local files
 .claude/settings.*
+.claude/specs/
 .claudeignore
 .LOCAL
 .vscode/settings.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -45,5 +45,6 @@
 	"git.allowNoVerifyCommit": true,
 	"chat.extensionUnification.enabled": false,
 	"chat.disableAIFeatures": false,
-	"chat.editing.autoAccept": true
+	"chat.editing.autoAcceptDelay": 0.01,
+	"chat.editing.revealNextChangeOnResolve": false
 }

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -1,7 +1,6 @@
 import * as assert from 'assert';
 import { suite, test } from '../test/tdd';
 import {
-	asPositiveInt,
 	mapWithConcurrency,
 	rawGraphqlOrThrow,
 	requireResourceInOrg,
@@ -133,6 +132,20 @@ suite('Unit: inputHelpers — requireResourceInOrg', () => {
 		);
 	});
 
+	test('throws when the resource row has no orgId field (default inOrg predicate)', async () => {
+		const row = { id: 'w1' };
+		await assert.rejects(
+			() =>
+				requireResourceInOrg({
+					label: 'Workflow',
+					id: 'w1',
+					orgId: 'org1',
+					fetch: async () => row,
+				}),
+			/Workflow w1 is not in org org1/,
+		);
+	});
+
 	test('uses custom inOrg predicate when provided', async () => {
 		const row = { id: 'w1', orgId: 'org2' };
 		// inOrg: () => true bypasses the orgId check (e.g. query is already org-filtered)
@@ -250,23 +263,5 @@ suite('Unit: inputHelpers — requireStringAllowEmpty', () => {
 
 	test('throws when the value is a non-string (number)', () => {
 		assert.throws(() => requireStringAllowEmpty({ body: 42 }, 'body'), /Missing required string argument "body"/);
-	});
-});
-
-suite('Unit: inputHelpers — asPositiveInt', () => {
-	test('returns positive integers unchanged', () => {
-		assert.strictEqual(asPositiveInt({ limit: 3 }, 'limit'), 3);
-	});
-
-	test('rejects zero, negatives, and fractions', () => {
-		assert.strictEqual(asPositiveInt({ limit: 0 }, 'limit'), undefined);
-		assert.strictEqual(asPositiveInt({ limit: -1 }, 'limit'), undefined);
-		assert.strictEqual(asPositiveInt({ limit: 1.5 }, 'limit'), undefined);
-	});
-
-	test('rejects non-numeric and non-finite values', () => {
-		assert.strictEqual(asPositiveInt({ limit: '3' }, 'limit'), undefined);
-		assert.strictEqual(asPositiveInt({ limit: Number.POSITIVE_INFINITY }, 'limit'), undefined);
-		assert.strictEqual(asPositiveInt({}, 'limit'), undefined);
 	});
 });

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import { suite, test } from '../test/tdd';
 import {
+	asPositiveInt,
 	mapWithConcurrency,
 	rawGraphqlOrThrow,
 	requireResourceInOrg,
@@ -249,5 +250,23 @@ suite('Unit: inputHelpers — requireStringAllowEmpty', () => {
 
 	test('throws when the value is a non-string (number)', () => {
 		assert.throws(() => requireStringAllowEmpty({ body: 42 }, 'body'), /Missing required string argument "body"/);
+	});
+});
+
+suite('Unit: inputHelpers — asPositiveInt', () => {
+	test('returns positive integers unchanged', () => {
+		assert.strictEqual(asPositiveInt({ limit: 3 }, 'limit'), 3);
+	});
+
+	test('rejects zero, negatives, and fractions', () => {
+		assert.strictEqual(asPositiveInt({ limit: 0 }, 'limit'), undefined);
+		assert.strictEqual(asPositiveInt({ limit: -1 }, 'limit'), undefined);
+		assert.strictEqual(asPositiveInt({ limit: 1.5 }, 'limit'), undefined);
+	});
+
+	test('rejects non-numeric and non-finite values', () => {
+		assert.strictEqual(asPositiveInt({ limit: '3' }, 'limit'), undefined);
+		assert.strictEqual(asPositiveInt({ limit: Number.POSITIVE_INFINITY }, 'limit'), undefined);
+		assert.strictEqual(asPositiveInt({}, 'limit'), undefined);
 	});
 });

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -106,9 +106,10 @@ export function requireStringAllowEmpty(input: Record<string, unknown>, key: str
 
 export function asPositiveInt(input: Record<string, unknown>, key: string): number | undefined {
 	const value = input[key];
-	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
-	const normalized = Math.floor(value);
-	return normalized > 0 ? normalized : undefined;
+	if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+		return undefined;
+	}
+	return value;
 }
 
 export async function mapWithConcurrency<T, R>(

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -106,10 +106,9 @@ export function requireStringAllowEmpty(input: Record<string, unknown>, key: str
 
 export function asPositiveInt(input: Record<string, unknown>, key: string): number | undefined {
 	const value = input[key];
-	if (typeof value !== 'number' || !Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
-		return undefined;
-	}
-	return value;
+	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
+	const normalized = Math.floor(value);
+	return normalized > 0 ? normalized : undefined;
 }
 
 export async function mapWithConcurrency<T, R>(

--- a/src/capabilities/mutationApproval.ts
+++ b/src/capabilities/mutationApproval.ts
@@ -1,7 +1,6 @@
 import { approveMutationScope, isMutationScopeApproved, type MutationScope } from '../ui/chat/tools/graphqlTool';
 import type { CapabilityContext } from './Capability';
 import { requestMcpMutationApproval } from './graphqlMutateCapability';
-export { throwOnGraphqlErrors } from './inputHelpers';
 
 /**
  * Shared plumbing for the org-scoped write capabilities (templates, org

--- a/src/capabilities/orgVariableMutateCapabilities.test.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.test.ts
@@ -1,6 +1,3 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
 import {
 	_resetMcpMutationApproverForTesting,
 	setMcpMutationApprover,
@@ -8,6 +5,9 @@ import {
 	type CapabilityContext,
 } from '@capabilities';
 import type { Session } from '@sessions';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
 import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import { ORG_VARIABLE_MUTATE_CAPABILITIES } from './orgVariableMutateCapabilities';
 
@@ -355,6 +355,31 @@ suite('Unit: orgVariableMutateCapabilities', () => {
 				() => cap('buddy_delete_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1' }, ctx),
 				/returned no id/,
 			);
+		});
+
+		test('surfaces GraphQL errors from the org-variable lookup instead of treating them as not-found', async () => {
+			// The byId lookup returns an errors-carrying response (not a thrown error).
+			// A wrong migration that returns undefined from fetch() on errors would
+			// convert this into the misleading "not in org" message, masking an auth/outage.
+			// This test forces rawGraphqlOrThrow (or equivalent) to be used inside fetch.
+			const { ctx, calls } = makeCtx({ byId: { data: undefined, errors: [{ message: 'denied' }] } });
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() => cap('buddy_update_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1', value: 'x' }, ctx),
+				(err: unknown) => {
+					const msg = err instanceof Error ? err.message : String(err);
+					assert.ok(/GraphQL error/i.test(msg), `expected GraphQL error, got: ${msg}`);
+					assert.ok(msg.includes('denied'), `expected 'denied' in message, got: ${msg}`);
+					return true;
+				},
+			);
+			assert.strictEqual(approverCalled, false, 'approver must not be called before org check');
+			assert.strictEqual(callsFor(calls, 'update').length, 0);
 		});
 	});
 });

--- a/src/capabilities/orgVariableMutateCapabilities.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.ts
@@ -8,7 +8,6 @@ import {
 	requireResourceInOrg,
 	requireString,
 	requireStringAllowEmpty,
-	throwOnGraphqlErrors,
 } from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
@@ -123,10 +122,9 @@ async function runCreateOrgVariable(input: Record<string, unknown>, ctx: Capabil
 	const scope: MutationScope = { scopeId: orgId, scopeName: `new variable "${name}"`, orgId, orgName };
 	const summary = `Create ${category} variable "${name}" in org "${orgName}" (${orgId})`;
 	return withMutationApproval(scope, summary, async () => {
-		const { data, errors } = await ctx.session.rawGraphql(CREATE_ORG_VARIABLE, {
+		const data = await rawGraphqlOrThrow(ctx.session, CREATE_ORG_VARIABLE, {
 			orgVariable: { orgId, name, value, category, cascade },
 		});
-		throwOnGraphqlErrors(errors);
 		const created = (data as { createOrgVariable?: OrgVariableRow } | undefined)?.createOrgVariable;
 		if (!created?.id) throw new Error('createOrgVariable returned no variable; the mutation may have failed.');
 		return JSON.stringify({ status: 'created', id: created.id, name: created.name ?? name }, null, 2);
@@ -170,10 +168,9 @@ async function runUpdateOrgVariable(input: Record<string, unknown>, ctx: Capabil
 	const scope: MutationScope = { scopeId: variableId, scopeName: name, orgId, orgName };
 	const summary = `Update variable "${name}" (${variableId}) in org "${orgName}" (${orgId})`;
 	return withMutationApproval(scope, summary, async () => {
-		const { data, errors } = await ctx.session.rawGraphql(UPDATE_ORG_VARIABLES, {
+		const data = await rawGraphqlOrThrow(ctx.session, UPDATE_ORG_VARIABLES, {
 			orgVariables: [{ id: variableId, orgId, name, value, category, cascade }],
 		});
-		throwOnGraphqlErrors(errors);
 		const rows = ((data as { updateOrgVariables?: OrgVariableRow[] } | undefined)?.updateOrgVariables ??
 			[]) as OrgVariableRow[];
 		const updated = rows.find(r => r.id === variableId) ?? rows[0];
@@ -206,8 +203,7 @@ async function runDeleteOrgVariable(input: Record<string, unknown>, ctx: Capabil
 	const scope: MutationScope = { scopeId: variableId, scopeName: name, orgId, orgName };
 	const summary = `Delete variable "${name}" (${variableId}) in org "${orgName}" (${orgId})`;
 	return withMutationApproval(scope, summary, async () => {
-		const { data, errors } = await ctx.session.rawGraphql(DELETE_ORG_VARIABLE, { id: variableId });
-		throwOnGraphqlErrors(errors);
+		const data = await rawGraphqlOrThrow(ctx.session, DELETE_ORG_VARIABLE, { id: variableId });
 		const deletedId = (data as { deleteOrgVariable?: string | null } | undefined)?.deleteOrgVariable;
 		if (!deletedId) throw new Error('deleteOrgVariable returned no id; the mutation may have failed.');
 		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);

--- a/src/capabilities/orgVariableMutateCapabilities.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.ts
@@ -2,8 +2,15 @@ import type { MutationScope } from '../ui/chat/tools/graphqlTool';
 import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, requireString } from './inputHelpers';
-import { orgDisplayName, throwOnGraphqlErrors, withMutationApproval } from './mutationApproval';
+import {
+	ORG_ID_PROP,
+	rawGraphqlOrThrow,
+	requireResourceInOrg,
+	requireString,
+	requireStringAllowEmpty,
+	throwOnGraphqlErrors,
+} from './inputHelpers';
+import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
  * Org-variable write capabilities. createOrgVariable carries orgId in its input
@@ -59,13 +66,6 @@ function optionalBoolean(input: Record<string, unknown>, key: string): boolean |
 	return value;
 }
 
-/** Requires a string argument that may be empty (a variable value can be blank). */
-function requireStringAllowEmpty(input: Record<string, unknown>, key: string): string {
-	const value = input[key];
-	if (typeof value !== 'string') throw new Error(`Missing required string argument "${key}".`);
-	return value;
-}
-
 /**
  * Fetches a variable by id and fails closed unless it belongs to the requested
  * org. Returns the fields needed to build a safe update payload. The value is
@@ -76,12 +76,19 @@ async function requireOrgVariableInOrg(
 	variableId: string,
 	orgId: string,
 ): Promise<OrgVariableRow> {
-	const { data, errors } = await ctx.session.rawGraphql(ORG_VARIABLE_BY_ID, { orgId, id: variableId });
-	throwOnGraphqlErrors(errors);
-	const rows = ((data as { orgVariables?: OrgVariableRow[] } | undefined)?.orgVariables ?? []) as OrgVariableRow[];
-	const row = rows.find(r => r.id === variableId);
-	if (!row) throw new Error(`Org variable ${variableId} is not in org ${orgId}.`);
-	return row;
+	return requireResourceInOrg({
+		label: 'Org variable',
+		id: variableId,
+		orgId,
+		fetch: async () => {
+			const data = await rawGraphqlOrThrow(ctx.session, ORG_VARIABLE_BY_ID, { orgId, id: variableId });
+			const rows = ((data as { orgVariables?: OrgVariableRow[] } | undefined)?.orgVariables ??
+				[]) as OrgVariableRow[];
+			return rows.find(r => r.id === variableId);
+		},
+		// The query is already org-filtered, so a returned row is in-org by construction.
+		inOrg: () => true,
+	});
 }
 
 const createOrgVariableSpec: ToolSpec = {

--- a/src/capabilities/rewstReadCapabilities.test.ts
+++ b/src/capabilities/rewstReadCapabilities.test.ts
@@ -352,13 +352,11 @@ suite('Unit: rewstReadCapabilities', () => {
 		assert.strictEqual(contextCalls.length, 3, 'issues one context fetch per scanned execution');
 	});
 
-	test('buddy_find_executions_by_variable counts an errors-carrying context response as skipped, not as a match', async () => {
+	test('buddy_find_executions_by_variable counts an errors-carrying context response as skipped, not fatal', async () => {
 		// Pins residual 4: the inline `if (res.errors)` check must be replaced with
 		// throwOnGraphqlErrors (or rawGraphqlOrThrow) so an errors-carrying response
 		// throws inside the per-execution try/catch and is counted as skipped rather
-		// than silently treated as empty data. A wrong migration that hoists the throw
-		// outside the try would cause the whole call to reject — this test catches that
-		// by asserting the call resolves (with a skip note) rather than rejects.
+		// than silently treated as empty data or made fatal to the whole tool call.
 		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
 		useRawGraphqlWrapper(session, wrapper);
 		wrapper.when('rawGraphql', (arg: { query: string; variables: Record<string, unknown> }): { data?: unknown } => {
@@ -366,7 +364,16 @@ suite('Unit: rewstReadCapabilities', () => {
 				// The MockWrapper returns response.data as the rawGraphql result, so the
 				// { data, errors } envelope that rawGraphql returns must be nested inside
 				// the outer `data` field here.
-				return { data: { data: undefined, errors: [{ message: 'permission denied' }] } };
+				const id = arg.variables.workflowExecutionId;
+				if (id === 'exec-1') {
+					return {
+						data: { data: { workflowExecutionContexts: [{ ticket_id: '12345' }, { stage: 'done' }] } },
+					};
+				}
+				if (id === 'exec-2') {
+					return { data: { data: { workflowExecutionContexts: [{ unrelated: 'x' }] } } };
+				}
+				return { data: { data: undefined, errors: [{ message: 'boom' }] } };
 			}
 			return {
 				data: {
@@ -376,6 +383,18 @@ suite('Unit: rewstReadCapabilities', () => {
 								id: 'exec-1',
 								status: 'succeeded',
 								createdAt: '1700000000000',
+								conductor: { input: {}, output: {} },
+							},
+							{
+								id: 'exec-2',
+								status: 'succeeded',
+								createdAt: '1700000001000',
+								conductor: { input: {}, output: {} },
+							},
+							{
+								id: 'exec-3',
+								status: 'failed',
+								createdAt: '1700000002000',
 								conductor: { input: {}, output: {} },
 							},
 						],
@@ -390,13 +409,8 @@ suite('Unit: rewstReadCapabilities', () => {
 		// Must resolve (not reject) — the errors-carrying response is caught per-execution.
 		const out = await findExec.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'ticket', kind: 'context' }, ctx);
 
-		// The execution produced no match (context fetch failed), and the skip is reported.
+		assert.ok(out.includes('exec-1') && out.includes('ticket_id=12345'), 'matches a context variable');
 		assert.ok(/1 execution context fetch/.test(out), `expected skip note, got: ${out}`);
-		// The call must not have matched the variable (errors ≠ data).
-		assert.ok(
-			!out.includes('exec-1') || out.startsWith('No executions'),
-			`must not match on error response, got: ${out}`,
-		);
 	});
 
 	test('buddy_latest_workflow_execution uses latestWorkflowExecution query, forwards workflowId, and handles missing execution', async () => {

--- a/src/capabilities/rewstReadCapabilities.test.ts
+++ b/src/capabilities/rewstReadCapabilities.test.ts
@@ -1,7 +1,7 @@
+import type { Session } from '@sessions';
+import { createMockSession, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createMockSession, initTestEnvironment } from '@test';
-import type { Session } from '@sessions';
 import type { CapabilityContext } from './Capability';
 import { getCapability } from './registry';
 
@@ -352,6 +352,53 @@ suite('Unit: rewstReadCapabilities', () => {
 		assert.strictEqual(contextCalls.length, 3, 'issues one context fetch per scanned execution');
 	});
 
+	test('buddy_find_executions_by_variable counts an errors-carrying context response as skipped, not as a match', async () => {
+		// Pins residual 4: the inline `if (res.errors)` check must be replaced with
+		// throwOnGraphqlErrors (or rawGraphqlOrThrow) so an errors-carrying response
+		// throws inside the per-execution try/catch and is counted as skipped rather
+		// than silently treated as empty data. A wrong migration that hoists the throw
+		// outside the try would cause the whole call to reject — this test catches that
+		// by asserting the call resolves (with a skip note) rather than rejects.
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', (arg: { query: string; variables: Record<string, unknown> }): { data?: unknown } => {
+			if (arg.query.includes('workflowExecutionContexts')) {
+				// The MockWrapper returns response.data as the rawGraphql result, so the
+				// { data, errors } envelope that rawGraphql returns must be nested inside
+				// the outer `data` field here.
+				return { data: { data: undefined, errors: [{ message: 'permission denied' }] } };
+			}
+			return {
+				data: {
+					data: {
+						workflowExecutions: [
+							{
+								id: 'exec-1',
+								status: 'succeeded',
+								createdAt: '1700000000000',
+								conductor: { input: {}, output: {} },
+							},
+						],
+					},
+				},
+			};
+		});
+		const findExec = getCapability('buddy_find_executions_by_variable');
+		assert.ok(findExec, 'buddy_find_executions_by_variable is registered');
+		const ctx = { session, orgId: 'org-1', sessions: [session] } satisfies CapabilityContext;
+
+		// Must resolve (not reject) — the errors-carrying response is caught per-execution.
+		const out = await findExec.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'ticket', kind: 'context' }, ctx);
+
+		// The execution produced no match (context fetch failed), and the skip is reported.
+		assert.ok(/1 execution context fetch/.test(out), `expected skip note, got: ${out}`);
+		// The call must not have matched the variable (errors ≠ data).
+		assert.ok(
+			!out.includes('exec-1') || out.startsWith('No executions'),
+			`must not match on error response, got: ${out}`,
+		);
+	});
+
 	test('buddy_latest_workflow_execution uses latestWorkflowExecution query, forwards workflowId, and handles missing execution', async () => {
 		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
 		useRawGraphqlWrapper(session, wrapper);
@@ -531,7 +578,10 @@ suite('Unit: rewstReadCapabilities', () => {
 			listWorkflowTasks.spec.description.includes('mocked marker only when a task is mocked'),
 			'tool description explains that mocked output is conditional',
 		);
-		assert.ok(!listWorkflowTasks.spec.description.includes('isMocked,'), 'description does not imply isMocked is always listed');
+		assert.ok(
+			!listWorkflowTasks.spec.description.includes('isMocked,'),
+			'description does not imply isMocked is always listed',
+		);
 	});
 
 	test('buddy_list_workflow_patches uses workflowPatches query, forwards workflowId, and formats patches', async () => {

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -671,13 +671,11 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 		}
 	});
 
-	let result: string;
 	if (lines.length === 0) {
 		const valuePart = valueArg ? ` with value containing "${valueArg}"` : '';
-		result = `No executions of this workflow (scanned ${executions.length}) had a ${kind} variable matching "${rawName}"${valuePart}.`;
-	} else {
-		result = lines.join('\n');
+		return `No executions of this workflow (scanned ${executions.length}) had a ${kind} variable matching "${rawName}"${valuePart}.`;
 	}
+	let result = lines.join('\n');
 	if (skipped > 0) result += `\n\n(${skipped} execution context fetch(es) failed and were skipped.)`;
 	if (executions.length >= limit) {
 		result += `\n\n(Scanned the ${limit} most-recent executions; raise limit — max ${MAX_EXECUTION_LIMIT} — to scan more.)`;

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -3,12 +3,13 @@ import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
 import {
-	asString,
-	requireString,
 	asPositiveInt,
+	asString,
 	mapWithConcurrency,
-	rawGraphqlOrThrow,
 	ORG_ID_PROP,
+	rawGraphqlOrThrow,
+	requireString,
+	throwOnGraphqlErrors,
 } from './inputHelpers';
 
 /**
@@ -652,10 +653,7 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 			const res = await ctx.session.rawGraphql(EXECUTION_CONTEXTS_QUERY, {
 				workflowExecutionId: execution.id,
 			});
-			if (Array.isArray(res.errors) ? res.errors.length > 0 : res.errors != null) {
-				skipped += 1;
-				return {};
-			}
+			throwOnGraphqlErrors(res.errors);
 			return flattenExecutionContextFrames(
 				(res.data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts,
 			);

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -9,7 +9,6 @@ import {
 	ORG_ID_PROP,
 	rawGraphqlOrThrow,
 	requireString,
-	throwOnGraphqlErrors,
 } from './inputHelpers';
 
 /**
@@ -650,12 +649,11 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 			return raw && typeof raw === 'object' ? (raw as Record<string, unknown>) : {};
 		}
 		try {
-			const res = await ctx.session.rawGraphql(EXECUTION_CONTEXTS_QUERY, {
+			const data = await rawGraphqlOrThrow(ctx.session, EXECUTION_CONTEXTS_QUERY, {
 				workflowExecutionId: execution.id,
 			});
-			throwOnGraphqlErrors(res.errors);
 			return flattenExecutionContextFrames(
-				(res.data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts,
+				(data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts,
 			);
 		} catch {
 			skipped += 1;
@@ -673,11 +671,13 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 		}
 	});
 
+	let result: string;
 	if (lines.length === 0) {
 		const valuePart = valueArg ? ` with value containing "${valueArg}"` : '';
-		return `No executions of this workflow (scanned ${executions.length}) had a ${kind} variable matching "${rawName}"${valuePart}.`;
+		result = `No executions of this workflow (scanned ${executions.length}) had a ${kind} variable matching "${rawName}"${valuePart}.`;
+	} else {
+		result = lines.join('\n');
 	}
-	let result = lines.join('\n');
 	if (skipped > 0) result += `\n\n(${skipped} execution context fetch(es) failed and were skipped.)`;
 	if (executions.length >= limit) {
 		result += `\n\n(Scanned the ${limit} most-recent executions; raise limit — max ${MAX_EXECUTION_LIMIT} — to scan more.)`;

--- a/src/capabilities/templateMutateCapabilities.test.ts
+++ b/src/capabilities/templateMutateCapabilities.test.ts
@@ -1,12 +1,12 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import {
 	_resetMcpMutationApproverForTesting,
 	setMcpMutationApprover,
 	type Capability,
 	type CapabilityContext,
 } from '@capabilities';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
 import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
 import { TEMPLATE_MUTATE_CAPABILITIES } from './templateMutateCapabilities';
 
@@ -451,6 +451,34 @@ suite('Unit: templateMutateCapabilities', () => {
 				() => cap('buddy_delete_template').run({ orgId: 'org-sandbox', templateId: 't-1' }, ctx),
 				/returned no id/,
 			);
+		});
+	});
+
+	suite('requireTemplateInOrg — membership edge cases', () => {
+		test('refuses to mutate when the fetched template has no orgId field', async () => {
+			// Build a getTemplate response where the template node has orgId stripped.
+			// This pins the equivalence between the old `typeof templateOrgId !== 'string'`
+			// check and requireResourceInOrg's default predicate (row.orgId === orgId),
+			// so a sloppy migration that uses `inOrg: () => true` will fail this test.
+			const { ctx, wrapper } = sandboxCtx();
+			const templateWithoutOrgId = Fixtures.fullTemplate({ id: 't-1', name: 'NoOrg' });
+			delete (templateWithoutOrgId as Record<string, unknown>).orgId;
+			wrapper.when('getTemplate', {
+				data: { __typename: 'Query' as const, template: templateWithoutOrgId },
+			});
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await assert.rejects(
+				() =>
+					cap('buddy_update_template_body').run({ orgId: 'org-sandbox', templateId: 't-1', body: 'x' }, ctx),
+				/Template t-1 is not in org org-sandbox/,
+			);
+			assert.strictEqual(approverCalled, false, 'approver must not be called before org check');
+			assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 0);
 		});
 	});
 });

--- a/src/capabilities/templateMutateCapabilities.ts
+++ b/src/capabilities/templateMutateCapabilities.ts
@@ -2,7 +2,7 @@ import type { MutationScope } from '../ui/chat/tools/graphqlTool';
 import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, requireString } from './inputHelpers';
+import { ORG_ID_PROP, requireResourceInOrg, requireString, requireStringAllowEmpty } from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -14,15 +14,6 @@ import { orgDisplayName, withMutationApproval } from './mutationApproval';
  * every mutation is gated by the same per-call VS Code approval the other write
  * tools use. Exposure is additionally gated by rewst-buddy.mcp.enableWriteTools.
  */
-
-/** Requires a string argument that may be empty (e.g. a blank template body). */
-function requireStringAllowEmpty(input: Record<string, unknown>, key: string): string {
-	const value = input[key];
-	if (typeof value !== 'string') {
-		throw new Error(`Missing required string argument "${key}".`);
-	}
-	return value;
-}
 
 /**
  * Fetches a template by id and fails closed unless it belongs to the requested
@@ -36,11 +27,15 @@ async function requireTemplateInOrg(
 	templateId: string,
 	orgId: string,
 ): Promise<{ name: string }> {
-	const template = await ctx.session.getTemplate(templateId);
-	const templateOrgId = (template as { orgId?: unknown }).orgId;
-	if (typeof templateOrgId !== 'string' || templateOrgId !== orgId) {
-		throw new Error(`Template ${templateId} is not in org ${orgId}.`);
-	}
+	const template = await requireResourceInOrg({
+		label: 'Template',
+		id: templateId,
+		orgId,
+		fetch: async () => {
+			const t = await ctx.session.getTemplate(templateId);
+			return t as { orgId?: unknown; name?: unknown };
+		},
+	});
 	const name = (template as { name?: unknown }).name;
 	return { name: typeof name === 'string' && name.length > 0 ? name : '(unnamed)' };
 }


### PR DESCRIPTION
## Summary
- Route the remaining template/org-variable helper residuals through inputHelpers.
- Add guard tests for missing orgId rows, org-variable lookup GraphQL errors, and context-fetch errors-in-envelope skip behavior.
- Remove the stale mutationApproval throwOnGraphqlErrors re-export.

## Verification
- npm run lint
- npm run type-check
- npm run test:unit
- npm run test:grep -- "counts an errors-carrying context response"
- npm run test:grep -- "Unit: package manifest"
- npm run changelog:check -- --base main (expected local skip-changelog failure until PR label is applied)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of org-scoped resources so missing or malformed org data is reported more accurately.
  * GraphQL lookup and mutation failures now surface clearer errors instead of being misclassified.
  * Fixed execution context fetching so partial failures are skipped gracefully while still returning available results.

* **Tests**
  * Added coverage for org membership edge cases, GraphQL error handling, and skipped execution-context fetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->