### PR TITLE
E2: buddy_workflow_diagnose - one-call failure digest

### DIFF
--- a/changelog.d/e2-workflow-diagnose.md
+++ b/changelog.d/e2-workflow-diagnose.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **One-call failure diagnosis** — the new `buddy_workflow_diagnose` Rewst Buddy tool composes a failed execution's root-cause task, its transition path, any sub-workflow it spawned, and its render context into a single digest, instead of a multi-tool round trip.

--- a/docs/features.md
+++ b/docs/features.md
@@ -128,7 +128,7 @@ Cage-Free Rewsty is still told your VS Code working directory when one is open, 
 
 Rewst-specific actions are exposed through the Rewst Buddy MCP server instead of the chat LM tool surface. MCP exposure uses three switches:
 
-- `rewst-buddy.mcp.enable` exposes all read capabilities: `buddy_list_orgs`, `buddy_list_templates`, `buddy_get_template`, `buddy_list_workflows`, `buddy_get_workflow`, `buddy_graphql_query`, `buddy_graphql_schema`, `buddy_search_template_links`, `buddy_template_link_status`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_render_jinja`, `buddy_action_search`, `buddy_list_jinja_filters`, `buddy_get_jinja_filter_docs`, and `buddy_result_read`.
+- `rewst-buddy.mcp.enable` exposes all read capabilities: `buddy_list_orgs`, `buddy_list_templates`, `buddy_get_template`, `buddy_list_workflows`, `buddy_get_workflow`, `buddy_graphql_query`, `buddy_graphql_schema`, `buddy_search_template_links`, `buddy_template_link_status`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_workflow_diagnose`, `buddy_render_jinja`, `buddy_action_search`, `buddy_list_jinja_filters`, `buddy_get_jinja_filter_docs`, and `buddy_result_read`.
 - `rewst-buddy.mcp.enableWriteTools` adds the write tools that change Rewst data: workflow editing, auto-layout, and runs; workflow create/delete; template create, edit, rename, delete, and sync; and org-variable, tag, and trigger changes.
 - `rewst-buddy.mcp.enableDangerousGraphqlMutation` unlocks only `buddy_graphql_mutate`, the raw GraphQL mutation tool.
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -761,3 +761,59 @@ the risky action, such as running a workflow.
 - **GIVEN** a workflow run was approved previously
 - **WHEN** the same workflow is run again
 - **THEN** the user is prompted again before the run starts
+
+### Requirement: Diagnose a failed execution in one call
+
+The system SHALL expose `buddy_workflow_diagnose`, a read capability that
+composes an execution's failing-task logs, its workflow definition's
+transition path, any sub-workflow executions it spawned, and its merged
+Jinja render context into one ordered digest, so an agent does not need the
+usual `buddy_workflow_executions` → `buddy_execution_logs` →
+`buddy_workflow_get` → `buddy_render_jinja` round trip. It SHALL accept an
+`executionId` directly, or a `workflowId` (with `orgId`) to find that
+workflow's most recent `FAILED` execution. It is `requiresOrg:false` with
+`scopedSessions:true`, and SHALL use the same multi-session sweep semantics
+as `buddy_execution_logs` to locate task logs across active sessions.
+
+#### Scenario: Root cause found
+
+- **GIVEN** an execution with one earlier failing task followed by a later
+  cascading failure
+- **WHEN** `buddy_workflow_diagnose` is called with that execution's id
+- **THEN** the digest names the EARLIEST failing task as the likely root
+  cause, with its message, input, and result
+- **AND** it includes that task's incoming and outgoing transitions from the
+  workflow definition
+
+#### Scenario: No failing task
+
+- **GIVEN** an execution whose task logs contain no failed status
+- **WHEN** `buddy_workflow_diagnose` is called with that execution's id
+- **THEN** the digest reports that no failing task was found instead of
+  erroring
+
+#### Scenario: Failure originates in a sub-workflow call
+
+- **GIVEN** the earliest failing task spawned a child execution that itself
+  failed
+- **WHEN** `buddy_workflow_diagnose` is called
+- **THEN** the digest flags the child execution as the likely deeper cause
+  and names its id for a follow-up `buddy_workflow_diagnose` call
+
+#### Scenario: Diagnose by workflow id
+
+- **GIVEN** no `executionId` is known
+- **WHEN** `buddy_workflow_diagnose` is called with `workflowId` and `orgId`
+- **THEN** it finds and diagnoses that workflow's most recent `FAILED`
+  execution
+- **AND** it reports plainly when no `FAILED` execution exists rather than
+  erroring
+
+#### Scenario: Best-effort supplementary sections
+
+- **GIVEN** the workflow definition or the merged execution context cannot
+  be fetched (e.g. a GraphQL error)
+- **WHEN** `buddy_workflow_diagnose` is called
+- **THEN** the digest still returns the failing task's logs
+- **AND** it notes which supplementary section is unavailable instead of
+  failing the whole call

--- a/src/capabilities/chatToolCapabilities.ts
+++ b/src/capabilities/chatToolCapabilities.ts
@@ -1,18 +1,19 @@
 import {
-	createGraphqlDeps,
-	runGraphqlTool,
-	GRAPHQL_TOOL_SPECS,
-	type GraphqlToolDeps,
-} from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
-import {
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
 	WORKFLOW_SEARCH_TOOL_NAME,
 	WORKFLOW_TOOL_SPECS,
 } from '@workflow';
+import {
+	createGraphqlDeps,
+	GRAPHQL_TOOL_SPECS,
+	runGraphqlTool,
+	type GraphqlToolDeps,
+} from '../ui/chat/tools/graphqlTool';
+import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 import { runToolRequests, WORKSPACE_TOOL_SPECS } from '../ui/chat/tools/workspaceTools';
 import type { Capability, CapabilityAccess, CapabilityContext } from './Capability';
 import { readCapability, writeCapability } from './capabilityFactories';
@@ -28,12 +29,14 @@ const workflowAccess: Record<string, CapabilityAccess> = {
 	buddy_workflow_executions: 'read',
 	[WORKFLOW_EXECUTION_LOGS_TOOL_NAME]: 'read',
 	buddy_render_jinja: 'read',
+	[WORKFLOW_DIAGNOSE_TOOL_NAME]: 'read',
 };
 
 const doesNotRequireOrg = new Set<string>([
 	'buddy_search_template_links',
 	WORKFLOW_SEARCH_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 ]);
 
 function workflowAccessFor(spec: ToolSpec): CapabilityAccess {
@@ -93,7 +96,7 @@ export const WORKFLOW_CHAT_CAPABILITIES: Capability[] = WORKFLOW_TOOL_SPECS.map(
 	if (access === 'write') {
 		return writeCapability(spec, (input, ctx) => runWorkflowMutationWithApproval(spec, input, ctx));
 	}
-	if (spec.name === WORKFLOW_EXECUTION_LOGS_TOOL_NAME) {
+	if (spec.name === WORKFLOW_EXECUTION_LOGS_TOOL_NAME || spec.name === WORKFLOW_DIAGNOSE_TOOL_NAME) {
 		return readCapability(
 			spec,
 			async (input, ctx) => runViaChatToolPath(spec, input, ctx, await executionLogsDeps(input, ctx)),

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -159,6 +159,9 @@ suite('Unit: capability registry', () => {
 			]) {
 				assert.strictEqual(getCapability(name)?.requiresOrg, false, `${name} does not require org`);
 			}
+			for (const name of [WORKFLOW_EXECUTION_LOGS_TOOL_NAME, WORKFLOW_DIAGNOSE_TOOL_NAME]) {
+				assert.strictEqual(getCapability(name)?.scopedSessions, true, `${name} keeps scopedSessions`);
+			}
 			for (const name of [
 				'buddy_workflow_get',
 				'buddy_action_search',

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -1,20 +1,21 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { readdirSync, readFileSync } from 'fs';
-import { join } from 'path';
 import { SessionManager } from '@sessions';
 import { initTestEnvironment } from '@test';
-import { CAPABILITY_REGISTRY, getCapability, mcpCapabilities } from './registry';
-import { RESULT_READ_TOOL_NAME } from './resultReadCapability';
 import {
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
 	WORKFLOW_SEARCH_TOOL_NAME,
 	WORKFLOW_TOOL_SPECS,
 } from '@workflow';
+import * as assert from 'assert';
+import { readdirSync, readFileSync } from 'fs';
+import * as Mocha from 'mocha';
+import { join } from 'path';
 import { WORKSPACE_TOOL_SPECS } from '../ui/chat/tools/workspaceTools';
+import { CAPABILITY_REGISTRY, getCapability, mcpCapabilities } from './registry';
+import { RESULT_READ_TOOL_NAME } from './resultReadCapability';
 
 const { suite, test, setup } = Mocha;
 
@@ -151,7 +152,11 @@ suite('Unit: capability registry', () => {
 		});
 
 		test('promoted workflow helpers keep their existing org requirements', () => {
-			for (const name of [WORKFLOW_SEARCH_TOOL_NAME, WORKFLOW_EXECUTION_LOGS_TOOL_NAME]) {
+			for (const name of [
+				WORKFLOW_SEARCH_TOOL_NAME,
+				WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+				WORKFLOW_DIAGNOSE_TOOL_NAME,
+			]) {
 				assert.strictEqual(getCapability(name)?.requiresOrg, false, `${name} does not require org`);
 			}
 			for (const name of [

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -1,18 +1,19 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
 import { MCP_MAX_OUTPUT_CHARS, RESULT_READ_TOOL_NAME, _resetMcpResultCacheForTesting } from '@capabilities';
 import { WorkingScopeManager } from '@models';
 import { SessionManager, type Session } from '@sessions';
-import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import { Fixtures, createMockSession, initTestEnvironment } from '@test';
 import { log } from '@utils';
-import { _resetMcpMutationApproverForTesting, setMcpMutationApprover } from '../capabilities/graphqlMutateCapability';
-import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import {
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
 } from '@workflow';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { _resetMcpMutationApproverForTesting, setMcpMutationApprover } from '../capabilities/graphqlMutateCapability';
+import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import { McpError, _resetMcpThrottleForTesting, callTool, listResources, listTools, readResource } from './McpActions';
 import type { McpSettings } from './settings';
 
@@ -618,6 +619,51 @@ suite('Unit: McpActions', () => {
 
 			const result = await callTool(
 				{ name: WORKFLOW_EXECUTION_LOGS_TOOL_NAME, arguments: { executionId: 'exec-1' } },
+				settings(),
+			);
+
+			assert.ok(result.text.includes('other_org_task'), 'the alternate session recovers the logs');
+			assert.match(result.text, /found via another active session/);
+			assert.ok(calls['org-2'] > 0, 'the sweep reaches the other session');
+		});
+
+		test('buddy_workflow_diagnose with an out-of-scope orgId is rejected under strict scope', async () => {
+			const { calls } = useTaskLogSessions({ 'org-1': [], 'org-2': [OTHER_ORG_ROW] });
+			WorkingScopeManager.setOrgs(['org-1']);
+
+			await assert.rejects(
+				callTool(
+					{
+						name: WORKFLOW_DIAGNOSE_TOOL_NAME,
+						arguments: { executionId: 'exec-1', orgId: 'org-2' },
+					},
+					settings(),
+				),
+				(error: unknown) => error instanceof McpError && error.code === 'org_out_of_scope',
+			);
+			assert.strictEqual(calls['org-2'] ?? 0, 0, 'no traffic to the out-of-scope org');
+		});
+
+		test('the buddy_workflow_diagnose sweep skips sessions outside the working scope under strict scope', async () => {
+			const { calls } = useTaskLogSessions({ 'org-1': [], 'org-2': [OTHER_ORG_ROW] });
+			WorkingScopeManager.setOrgs(['org-1']);
+
+			const result = await callTool(
+				{ name: WORKFLOW_DIAGNOSE_TOOL_NAME, arguments: { executionId: 'exec-1' } },
+				settings({ alwaysAllowedOrgs: ['org-1'] }),
+			);
+
+			assert.ok(!result.isError, 'call succeeds for the in-scope session');
+			assert.strictEqual(calls['org-2'] ?? 0, 0, 'out-of-scope session is not swept');
+			assert.ok(!result.text.includes('other_org_task'), 'out-of-scope task row is not returned');
+		});
+
+		test('the buddy_workflow_diagnose sweep stays cross-session when no working org is pinned', async () => {
+			const failedOtherOrgRow = { ...OTHER_ORG_ROW, status: 'failed' };
+			const { calls } = useTaskLogSessions({ 'org-1': [], 'org-2': [failedOtherOrgRow] });
+
+			const result = await callTool(
+				{ name: WORKFLOW_DIAGNOSE_TOOL_NAME, arguments: { executionId: 'exec-1' } },
 				settings(),
 			);
 

--- a/src/mcp/instructions.test.ts
+++ b/src/mcp/instructions.test.ts
@@ -68,7 +68,7 @@ suite('Unit: mcpInstructions', () => {
 	test('contains WORKFLOW_DIAGNOSE_TOOL_NAME', () => {
 		const instructions = buildMcpInstructions();
 		assert.ok(
-			instructions.includes(WORKFLOW_DIAGNOSE_TOOL_NAME),
+			instructions.includes(`in one call with ${WORKFLOW_DIAGNOSE_TOOL_NAME}`),
 			`instructions must reference ${WORKFLOW_DIAGNOSE_TOOL_NAME}`,
 		);
 	});

--- a/src/mcp/instructions.test.ts
+++ b/src/mcp/instructions.test.ts
@@ -1,6 +1,7 @@
 import {
 	RENDER_VERIFY_STEERING,
 	WORKFLOW_COMPOSITION_STEERING,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
@@ -61,6 +62,14 @@ suite('Unit: mcpInstructions', () => {
 		assert.ok(
 			instructions.includes(WORKFLOW_EXECUTION_LOGS_TOOL_NAME),
 			`instructions must reference ${WORKFLOW_EXECUTION_LOGS_TOOL_NAME}`,
+		);
+	});
+
+	test('contains WORKFLOW_DIAGNOSE_TOOL_NAME', () => {
+		const instructions = buildMcpInstructions();
+		assert.ok(
+			instructions.includes(WORKFLOW_DIAGNOSE_TOOL_NAME),
+			`instructions must reference ${WORKFLOW_DIAGNOSE_TOOL_NAME}`,
 		);
 	});
 
@@ -139,6 +148,15 @@ suite('Unit: mcpInstructions', () => {
 			`rendered text must reference ${WORKFLOW_EXECUTION_LOGS_TOOL_NAME}`,
 		);
 		assert.ok(text.includes(WORKFLOW_EDIT_TOOL_NAME), `rendered text must reference ${WORKFLOW_EDIT_TOOL_NAME}`);
+	});
+
+	test('debug-execution step 1 uses buddy_workflow_diagnose', () => {
+		const text = renderRegisteredPrompt('debug-execution', { executionId: 'e-1' });
+		assert.ok(
+			text.includes(`1. Call \`${WORKFLOW_DIAGNOSE_TOOL_NAME}\``),
+			`step 1 must instruct callers to use ${WORKFLOW_DIAGNOSE_TOOL_NAME}`,
+		);
+		assert.ok(text.includes('e-1'), 'step 1 path must keep the executionId');
 	});
 
 	test('debug-execution without executionId renders the generic execution path', () => {

--- a/src/mcp/instructions.ts
+++ b/src/mcp/instructions.ts
@@ -14,6 +14,7 @@
 import {
 	RENDER_VERIFY_STEERING,
 	WORKFLOW_COMPOSITION_STEERING,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
@@ -44,11 +45,11 @@ export function buildMcpInstructions(): string {
 		RENDER_VERIFY_STEERING,
 		'',
 		'## Run-and-check-logs loop',
-		`After editing, run the workflow with ${WORKFLOW_RUN_TOOL_NAME} (wait:true),` +
-			` then inspect the result with ${WORKFLOW_EXECUTION_LOGS_TOOL_NAME}.` +
-			' If a task failed, read its message, input, and result before making further edits.' +
+		`After editing, run the workflow with ${WORKFLOW_RUN_TOOL_NAME} (wait:true), then diagnose a failure` +
+			` in one call with ${WORKFLOW_DIAGNOSE_TOOL_NAME} (root cause, transition path, sub-executions, context).` +
+			` For the full task-by-task list instead, use ${WORKFLOW_EXECUTION_LOGS_TOOL_NAME}.` +
 			' For sub-workflow failures, drill into the sub-execution id with a second' +
-			` ${WORKFLOW_EXECUTION_LOGS_TOOL_NAME} call.`,
+			` ${WORKFLOW_DIAGNOSE_TOOL_NAME} or ${WORKFLOW_EXECUTION_LOGS_TOOL_NAME} call.`,
 		'',
 		'## Oversized results',
 		'When a tool result is truncated, use buddy_result_read with the returned cache id' +
@@ -134,12 +135,14 @@ export function renderMcpPrompt(name: string, args: Record<string, string>): str
 			return [
 				`Debug ${target} using the following tool sequence:`,
 				'',
-				`1. Call \`${WORKFLOW_EXECUTION_LOGS_TOOL_NAME}\`${
+				`1. Call \`${WORKFLOW_DIAGNOSE_TOOL_NAME}\`${
 					executionId ? ` with executionId "${executionId}"` : ''
-				} to list all task statuses.`,
-				'2. For each failed task, read its message, input, and result.',
+				} for a one-call root-cause digest.`,
+				`2. Call \`${WORKFLOW_EXECUTION_LOGS_TOOL_NAME}\`${
+					executionId ? ` with executionId "${executionId}"` : ''
+				} for the full task-by-task list.`,
 				'3. If a task spawned a sub-execution, call ' +
-					`\`${WORKFLOW_EXECUTION_LOGS_TOOL_NAME}\` again with the sub-execution id.`,
+					`\`${WORKFLOW_DIAGNOSE_TOOL_NAME}\` again with the sub-execution id.`,
 				'4. Use `buddy_render_jinja` to verify any suspect Jinja expressions against the execution context.',
 				`5. Propose a targeted fix and apply it with \`${WORKFLOW_EDIT_TOOL_NAME}\`.`,
 			].join('\n');

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -3304,7 +3304,7 @@ suite('Unit: workflowTools', () => {
 				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
 				deps,
 			);
-			assert.match(output, /likely deeper cause/);
+			assert.match(output, /Likely deeper cause/);
 			assert.match(output, /exec-child/);
 			assert.match(output, /buddy_workflow_diagnose \{"executionId": "exec-child"\}/);
 		});
@@ -3328,7 +3328,7 @@ suite('Unit: workflowTools', () => {
 			);
 			assert.match(output, /Other sub-workflow execution/);
 			assert.match(output, /exec-orphan/);
-			assert.ok(!output.includes('likely deeper cause'), 'orphan is not described as the deeper cause');
+			assert.ok(!output.includes('Likely deeper cause'), 'orphan is not described as the deeper cause');
 		});
 
 		test('includes the merged execution context top-level keys', async () => {

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -1,33 +1,34 @@
+import { SessionManager } from '@sessions';
+import { initTestEnvironment } from '@test';
+import {
+	ADD_TASK_FIELD_NAMES,
+	ADVANCED_TASK_FIELD_TABLE,
+	UPDATE_TASK_SET_FIELD_NAMES,
+	workflowEditOperationGrammar,
+} from '@workflow';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
-import { SessionManager } from '@sessions';
 import { _resetApprovedMutationScopes, approveMutationScope, type GraphqlToolDeps } from './graphqlTool';
 import {
+	_resetWorkflowIndexForTesting,
 	applyOperations,
 	autoLayout,
 	isWorkflowTool,
 	normalizePublish,
 	runWorkflowTool,
+	sentValueDivergences,
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
 	WORKFLOW_SEARCH_TOOL_NAME,
 	WORKFLOW_TOOL_SPECS,
-	_resetWorkflowIndexForTesting,
-	sentValueDivergences,
 	workflowEditConfirmation,
 	workflowEditScope,
 	workflowToInput,
 	type WorkflowOperation,
 } from './workflowTools';
-import {
-	ADVANCED_TASK_FIELD_TABLE,
-	ADD_TASK_FIELD_NAMES,
-	UPDATE_TASK_SET_FIELD_NAMES,
-	workflowEditOperationGrammar,
-} from '@workflow';
 
 const { suite, test, setup } = Mocha;
 
@@ -3119,6 +3120,402 @@ suite('Unit: workflowTools', () => {
 					),
 				/requires non-empty/,
 			);
+		});
+	});
+
+	suite('buddy_workflow_diagnose', () => {
+		function makeDiagnoseDeps(
+			over: Partial<{
+				taskLogs: unknown[];
+				findExecutions: unknown[];
+				childExecutions: unknown[];
+				childExecutionsWorkflow: { id: string; name: string; orgId: string } | null;
+				childExecutionsOrgId: string;
+				childExecutionsError: string;
+				workflow: unknown;
+				workflowError: string;
+				contexts: Record<string, unknown>[];
+				contextsError: string;
+			}> = {},
+		): { deps: GraphqlToolDeps; calls: { query: string; variables?: Record<string, unknown> }[] } {
+			const calls: { query: string; variables?: Record<string, unknown> }[] = [];
+			const execute: GraphqlToolDeps['execute'] = async (query, variables) => {
+				calls.push({ query, variables });
+				if (query.includes('RewstBuddyTaskLogs')) return { data: { taskLogs: over.taskLogs ?? [] } };
+				if (query.includes('RewstBuddyExecutions')) {
+					return { data: { workflowExecutions: over.findExecutions ?? [] } };
+				}
+				if (query.includes('RewstBuddyChildExecutions')) {
+					if (over.childExecutionsError) return { errors: [{ message: over.childExecutionsError }] };
+					return {
+						data: {
+							workflowExecution: {
+								id: 'exec-1',
+								status: 'FAILED',
+								orgId: over.childExecutionsOrgId,
+								workflow: over.childExecutionsWorkflow,
+								childExecutions: over.childExecutions ?? [],
+							},
+						},
+					};
+				}
+				if (query.includes('RewstBuddyWorkflowGet')) {
+					if (over.workflowError) return { errors: [{ message: over.workflowError }] };
+					return { data: { workflow: over.workflow } };
+				}
+				if (query.includes('RewstBuddyExecutionContexts')) {
+					if (over.contextsError) return { errors: [{ message: over.contextsError }] };
+					return { data: { workflowExecutionContexts: over.contexts ?? [{ some_key: 1 }] } };
+				}
+				return { data: {} };
+			};
+			const deps: GraphqlToolDeps = { isEnabled: () => true, confirmMutation: async () => true, execute };
+			return { deps, calls };
+		}
+
+		const diagnoseWorkflow = () => ({
+			...sampleWorkflow(),
+			tasks: [
+				{
+					id: 'task-a',
+					name: 'start',
+					actionId: 'noop-id',
+					action: { ref: 'core.noop' },
+					input: {},
+					next: [{ when: '{{ SUCCEEDED }}', do: ['task-b'] }],
+				},
+				{
+					id: 'task-b',
+					name: 'the_failer',
+					actionId: 'noop-id',
+					action: { ref: 'core.http' },
+					input: {},
+					next: [{ when: '{{ SUCCEEDED }}', do: [] }],
+				},
+			],
+		});
+
+		const failingTaskLogs = [
+			{ originalWorkflowTaskName: 'start', status: 'succeeded' },
+			{
+				originalWorkflowTaskName: 'the_failer',
+				status: 'failed',
+				message: 'boom',
+				input: { x: 1 },
+				result: { e: 1 },
+				taskExecutionId: 'te-1',
+			},
+		];
+
+		test('finds the earliest failing task and its transition path', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: failingTaskLogs,
+				childExecutionsWorkflow: { id: 'wf-1', name: 'Sample', orgId: 'org-1' },
+				childExecutionsOrgId: 'org-1',
+				workflow: diagnoseWorkflow(),
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /the_failer: failed/);
+			assert.match(output, /message: boom/);
+			assert.match(output, /Transition path/);
+			assert.match(output, /in:\s+start --\[\{\{ SUCCEEDED \}\}\]--> the_failer/);
+			assert.match(output, /out:\s+\(none — terminal task\)/);
+		});
+
+		test('diagnoses by workflowId when executionId is unknown', async () => {
+			const { deps, calls } = makeDiagnoseDeps({
+				findExecutions: [{ id: 'exec-9', status: 'FAILED', createdAt: '1000' }],
+				taskLogs: failingTaskLogs,
+				childExecutionsWorkflow: { id: 'wf-1', name: 'Sample', orgId: 'org-1' },
+				childExecutionsOrgId: 'org-1',
+				workflow: diagnoseWorkflow(),
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { workflowId: 'wf-1', orgId: 'org-1' } },
+				deps,
+			);
+			assert.match(output, /exec-9/);
+			assert.match(output, /the_failer: failed/);
+			const execCall = calls.find(c => c.query.includes('RewstBuddyExecutions'));
+			assert.ok(execCall, 'made a RewstBuddyExecutions call');
+			assert.deepStrictEqual((execCall.variables as { where?: unknown })?.where, {
+				workflowId: 'wf-1',
+				orgId: 'org-1',
+				status: 'FAILED',
+			});
+		});
+
+		test('reports no failed executions for a workflow instead of erroring', async () => {
+			const { deps, calls } = makeDiagnoseDeps({ findExecutions: [] });
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { workflowId: 'wf-1', orgId: 'org-1' } },
+				deps,
+			);
+			assert.match(output, /No FAILED executions found for workflow wf-1/);
+			assert.ok(!calls.some(c => c.query.includes('RewstBuddyTaskLogs')), 'no task log query fired');
+		});
+
+		test('requires orgId together with workflowId', async () => {
+			const { deps } = makeDiagnoseDeps();
+			await assert.rejects(
+				() => runWorkflowTool({ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { workflowId: 'wf-1' } }, deps),
+				/requires "orgId" together with "workflowId"/,
+			);
+		});
+
+		test('requires executionId or workflowId', async () => {
+			const { deps } = makeDiagnoseDeps();
+			await assert.rejects(
+				() => runWorkflowTool({ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: {} }, deps),
+				/requires "executionId", or "workflowId"/,
+			);
+		});
+
+		test('reports no failing task when the execution succeeded', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: [{ originalWorkflowTaskName: 'start', status: 'succeeded' }],
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /No failing task found/);
+			assert.ok(!output.includes('Transition path'), 'no transition path section for a non-failing run');
+			assert.ok(!/Execution context/i.test(output), 'execution context is not fetched after a non-failing run');
+		});
+
+		test('flags a failed child execution as the likely deeper cause', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: failingTaskLogs,
+				childExecutions: [
+					{
+						id: 'exec-child',
+						status: 'failed',
+						parentTaskExecutionId: 'te-1',
+						workflow: { id: 'wf-sub', name: 'Sub Flow' },
+					},
+				],
+				childExecutionsOrgId: 'org-1',
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /likely deeper cause/);
+			assert.match(output, /exec-child/);
+			assert.match(output, /buddy_workflow_diagnose \{"executionId": "exec-child"\}/);
+		});
+
+		test('lists sub-executions not tied to the failing task separately', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: failingTaskLogs,
+				childExecutions: [
+					{
+						id: 'exec-orphan',
+						status: 'running',
+						parentTaskExecutionId: null,
+						workflow: { id: 'wf-sub', name: 'Sub Flow' },
+					},
+				],
+				childExecutionsOrgId: 'org-1',
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /Other sub-workflow execution/);
+			assert.match(output, /exec-orphan/);
+			assert.ok(!output.includes('likely deeper cause'), 'orphan is not described as the deeper cause');
+		});
+
+		test('includes the merged execution context top-level keys', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: failingTaskLogs,
+				childExecutionsOrgId: 'org-1',
+				contexts: [{ a: 1 }, { b: 2 }],
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /top-level keys: a, b/);
+			assert.match(output, /merged from 2 snapshot\(s\)/);
+		});
+
+		test('treats only the earliest failing row as the root cause when a later task also failed', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: [...failingTaskLogs, { originalWorkflowTaskName: 'downstream', status: 'failed' }],
+				childExecutionsOrgId: 'org-1',
+				workflow: diagnoseWorkflow(),
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /Failing task \(likely root cause\)[\s\S]*the_failer: failed/);
+			const rootCauseSection = output.split('\n\n')[1] ?? '';
+			assert.ok(!rootCauseSection.includes('downstream'), 'downstream failure is not the root cause section');
+		});
+
+		test('keeps the digest when the execution context lookup fails', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: failingTaskLogs,
+				childExecutionsOrgId: 'org-1',
+				contextsError: 'context resolver broke',
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /the_failer: failed/);
+			assert.match(output, /Execution context unavailable:.*context resolver broke/);
+		});
+
+		test('keeps the digest when the workflow definition fetch errors', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: failingTaskLogs,
+				childExecutionsWorkflow: { id: 'wf-1', name: 'Sample', orgId: 'org-1' },
+				childExecutionsOrgId: 'org-1',
+				workflowError: 'schema broke',
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /the_failer: failed/);
+			assert.match(output, /Workflow definition unavailable:.*schema broke/);
+		});
+
+		test('omits the transition path section when no workflow or org is resolvable', async () => {
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: failingTaskLogs,
+				childExecutionsWorkflow: null,
+				// no childExecutionsOrgId, no orgId arg
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /the_failer: failed/);
+			assert.ok(!output.includes('Transition path'), 'no transition path when workflow/org unavailable');
+		});
+
+		test('verifies an explicit orgId owns the execution before reading task logs', async () => {
+			const calls: { query: string; variables?: Record<string, unknown> }[] = [];
+			const execute: GraphqlToolDeps['execute'] = async (query, variables) => {
+				calls.push({ query, variables });
+				if (query.includes('RewstBuddyExecutions')) return { data: { workflowExecutions: [] } };
+				if (query.includes('RewstBuddyTaskLogs')) {
+					throw new Error('task logs must not be read before org ownership is proven');
+				}
+				return { data: {} };
+			};
+			const deps: GraphqlToolDeps = { isEnabled: () => true, confirmMutation: async () => true, execute };
+
+			await assert.rejects(
+				() =>
+					runWorkflowTool(
+						{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1', orgId: 'org-1' } },
+						deps,
+					),
+				/execution exec-1.*org org-1/i,
+			);
+			assert.ok(!calls.some(c => c.query.includes('RewstBuddyTaskLogs')), 'task logs were never queried');
+		});
+
+		test('sweeps alternate sessions when the primary sees no rows', async () => {
+			const primaryCalls: string[] = [];
+			const alternateCalls: string[] = [];
+			const primaryExecute: GraphqlToolDeps['execute'] = async query => {
+				primaryCalls.push(query);
+				if (query.includes('RewstBuddyTaskLogs')) return { data: { taskLogs: [] } };
+				if (query.includes('RewstBuddyChildExecutions'))
+					return {
+						data: {
+							workflowExecution: {
+								id: 'exec-1',
+								status: 'FAILED',
+								orgId: 'org-1',
+								workflow: { id: 'wf-1', name: 'Sample', orgId: 'org-1' },
+								childExecutions: [],
+							},
+						},
+					};
+				if (query.includes('RewstBuddyExecutionContexts'))
+					return { data: { workflowExecutionContexts: [{ ctx_key: 1 }] } };
+				return { data: {} };
+			};
+			const alternateExecute: GraphqlToolDeps['execute'] = async query => {
+				alternateCalls.push(query);
+				if (query.includes('RewstBuddyTaskLogs'))
+					return {
+						data: {
+							taskLogs: [
+								{
+									originalWorkflowTaskName: 'alt_task',
+									status: 'failed',
+									message: 'alt error',
+								},
+							],
+						},
+					};
+				return { data: {} };
+			};
+			const alternateDeps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: alternateExecute,
+			};
+			const primaryDeps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: primaryExecute,
+				alternates: [alternateDeps],
+			};
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				primaryDeps,
+			);
+			assert.match(output, /alt_task: failed/);
+			assert.match(output, /found via another active session/i);
+		});
+
+		test('explains visibility when no session can see the execution', async () => {
+			const emptyExecute: GraphqlToolDeps['execute'] = async query => {
+				if (query.includes('RewstBuddyTaskLogs')) return { data: { taskLogs: [] } };
+				if (query.includes('RewstBuddyChildExecutions'))
+					return {
+						data: {
+							workflowExecution: {
+								id: 'exec-1',
+								status: null,
+								orgId: null,
+								workflow: null,
+								childExecutions: [],
+							},
+						},
+					};
+				return { data: {} };
+			};
+			const alternateDeps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: emptyExecute,
+			};
+			const primaryDeps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: emptyExecute,
+				alternates: [alternateDeps],
+			};
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				primaryDeps,
+			);
+			assert.match(output, /None of the 2 active session\(s\) can see task logs/i);
 		});
 	});
 });

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -3,6 +3,7 @@ import { initTestEnvironment } from '@test';
 import {
 	ADD_TASK_FIELD_NAMES,
 	ADVANCED_TASK_FIELD_TABLE,
+	type RawWorkflow,
 	UPDATE_TASK_SET_FIELD_NAMES,
 	workflowEditOperationGrammar,
 } from '@workflow';
@@ -3173,7 +3174,7 @@ suite('Unit: workflowTools', () => {
 			return { deps, calls };
 		}
 
-		const diagnoseWorkflow = () => ({
+		const diagnoseWorkflow = (): RawWorkflow => ({
 			...sampleWorkflow(),
 			tasks: [
 				{
@@ -3223,6 +3224,31 @@ suite('Unit: workflowTools', () => {
 			assert.match(output, /Transition path/);
 			assert.match(output, /in:\s+start --\[\{\{ SUCCEEDED \}\}\]--> the_failer/);
 			assert.match(output, /out:\s+\(none — terminal task\)/);
+		});
+
+		test('includes publish expressions on the transition path', async () => {
+			const workflow = diagnoseWorkflow();
+			workflow.tasks[0].next = [
+				{
+					when: '{{ SUCCEEDED }}',
+					do: ['task-b'],
+					publish: [{ key: 'customer_org_id', value: '{{ RESULT.result.org_id }}' }],
+				},
+			];
+			const { deps } = makeDiagnoseDeps({
+				taskLogs: failingTaskLogs,
+				childExecutionsWorkflow: { id: 'wf-1', name: 'Sample', orgId: 'org-1' },
+				childExecutionsOrgId: 'org-1',
+				workflow,
+			});
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(
+				output,
+				/in:\s+start --\[\{\{ SUCCEEDED \}\}\]--> the_failer \(publish: customer_org_id=\{\{ RESULT\.result\.org_id \}\}\)/,
+			);
 		});
 
 		test('diagnoses by workflowId when executionId is unknown', async () => {

--- a/src/ui/chat/tools/workflowTools.ts
+++ b/src/ui/chat/tools/workflowTools.ts
@@ -14,8 +14,8 @@
  * See epic issue #129 (D1) for the full split rationale.
  */
 
-import { workflowEditScope, type WorkflowMutationScope } from '../../../workflow/mutationScope';
 import { type WorkflowOperation } from '../../../workflow/graphMutations';
+import { workflowEditScope, type WorkflowMutationScope } from '../../../workflow/mutationScope';
 import { workflowToolAlwaysPrompts } from '../../../workflow/specs';
 import { asObject, str } from '../../../workflow/types';
 import { isMutationScopeApproved } from './graphqlTool';
@@ -24,14 +24,15 @@ import { isMutationScopeApproved } from './graphqlTool';
 // Re-exports: specs
 // ---------------------------------------------------------------------------
 export {
+	isWorkflowTool,
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
 	WORKFLOW_SEARCH_TOOL_NAME,
 	WORKFLOW_TOOL_NAMES,
 	WORKFLOW_TOOL_SPECS,
-	isWorkflowTool,
 	workflowToolAlwaysPrompts,
 } from '../../../workflow/specs';
 
@@ -73,6 +74,7 @@ export {
 	isFailedStatus,
 	runExecutionLogs,
 	runRenderJinja,
+	runWorkflowDiagnose,
 	runWorkflowExecutions,
 	runWorkflowRun,
 } from '../../../workflow/executions';
@@ -80,8 +82,8 @@ export {
 // ---------------------------------------------------------------------------
 // Re-exports: adapter (workflow_get + action_search)
 // ---------------------------------------------------------------------------
-export { runActionSearch, runWorkflowGet, summarizeWorkflow } from '../../../workflow/workflowAdapter';
 export { runWorkflowTool } from '../../../workflow/toolRunner';
+export { runActionSearch, runWorkflowGet, summarizeWorkflow } from '../../../workflow/workflowAdapter';
 
 // ---------------------------------------------------------------------------
 // workflowEditConfirmation — approval prompt text for the UI adapter

--- a/src/workflow/executions.ts
+++ b/src/workflow/executions.ts
@@ -8,7 +8,7 @@
 import { type GraphqlToolDeps } from '../ui/chat/tools/graphqlTool';
 import { asBooleanArg, asStringArg, type ToolRequest } from '../ui/chat/tools/toolProtocol';
 import { fetchWorkflow } from './graphMutations';
-import { type ExecResult, firstErrorMessage, isPlainObject } from './types';
+import { firstErrorMessage, isPlainObject, type ExecResult, type RawTask, type RawWorkflow } from './types';
 
 // ---------------------------------------------------------------------------
 // GraphQL
@@ -45,7 +45,8 @@ const TASK_LOGS_QUERY = `query RewstBuddyTaskLogs($where: TaskLogWhereInput) {
 // points back at the spawning task's taskExecutionId.
 const CHILD_EXECUTIONS_QUERY = `query RewstBuddyChildExecutions($where: WorkflowExecutionWhereInput) {
 	workflowExecution(where: $where) {
-		id
+		id status orgId
+		workflow { id name orgId }
 		childExecutions { id status createdAt parentTaskExecutionId workflow { id name } }
 	}
 }`;
@@ -54,7 +55,7 @@ const CHILD_EXECUTIONS_QUERY = `query RewstBuddyChildExecutions($where: Workflow
 // Types
 // ---------------------------------------------------------------------------
 
-interface TaskLogRow {
+export interface TaskLogRow {
 	id?: string | null;
 	originalWorkflowTaskName?: string | null;
 	status?: string | null;
@@ -65,7 +66,7 @@ interface TaskLogRow {
 	taskExecutionId?: string | null;
 }
 
-interface ChildExecutionRow {
+export interface ChildExecutionRow {
 	id?: string | null;
 	status?: string | null;
 	createdAt?: string | null;
@@ -81,6 +82,13 @@ export interface ExecutionRow {
 	orgId?: string | null;
 	originatingExecutionId?: string | null;
 	parentExecutionId?: string | null;
+}
+
+export interface ExecutionDetail {
+	id?: string | null;
+	status?: string | null;
+	orgId?: string | null;
+	workflow?: { id?: string | null; name?: string | null; orgId?: string | null } | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -110,23 +118,31 @@ export async function fetchTaskLogs(deps: GraphqlToolDeps, executionId: string):
 	);
 }
 
-async function fetchChildExecutions(
+export async function fetchChildExecutions(
 	deps: GraphqlToolDeps,
 	executionId: string,
-): Promise<{ children: ChildExecutionRow[]; error?: string }> {
+): Promise<{ execution?: ExecutionDetail; children: ChildExecutionRow[]; error?: string }> {
 	try {
 		const result = await deps.execute(CHILD_EXECUTIONS_QUERY, { where: { id: executionId } });
 		const error = firstErrorMessage(result as ExecResult);
 		if (error) return { children: [], error };
-		const parent = (result.data as { workflowExecution?: { childExecutions?: (ChildExecutionRow | null)[] } })
-			?.workflowExecution;
-		return { children: (parent?.childExecutions ?? []).filter((row): row is ChildExecutionRow => !!row) };
+		const parent = (
+			result.data as
+				| { workflowExecution?: (ExecutionDetail & { childExecutions?: (ChildExecutionRow | null)[] }) | null }
+				| undefined
+		)?.workflowExecution;
+		return {
+			execution: parent
+				? { id: parent.id, status: parent.status, orgId: parent.orgId, workflow: parent.workflow }
+				: undefined,
+			children: (parent?.childExecutions ?? []).filter((row): row is ChildExecutionRow => !!row),
+		};
 	} catch (error) {
 		return { children: [], error: error instanceof Error ? error.message : String(error) };
 	}
 }
 
-function describeChildExecution(child: ChildExecutionRow): string {
+export function describeChildExecution(child: ChildExecutionRow): string {
 	return `${child.workflow?.name ?? '(unknown workflow)'} (${child.id ?? '?'}, ${child.status ?? '?'})`;
 }
 
@@ -149,12 +165,13 @@ export async function assertExecutionBelongsToOrg(
 	}
 }
 
-async function fetchTaskLogsForVisibleExecution(
+function fetchTaskLogsForVisibleExecution(
 	deps: GraphqlToolDeps,
 	executionId: string,
 	orgId: string | undefined,
 ): Promise<TaskLogRow[]> {
-	if (orgId) await assertExecutionBelongsToOrg(deps, executionId, orgId);
+	if (orgId)
+		return assertExecutionBelongsToOrg(deps, executionId, orgId).then(() => fetchTaskLogs(deps, executionId));
 	return fetchTaskLogs(deps, executionId);
 }
 
@@ -219,12 +236,7 @@ export async function runRenderJinja(request: ToolRequest, deps: GraphqlToolDeps
 	const executionId = asStringArg(request.args, 'executionId');
 	if (executionId) {
 		await assertExecutionBelongsToOrg(deps, executionId, orgId);
-		const result = await deps.execute(EXECUTION_CONTEXTS_QUERY, { id: executionId });
-		const error = firstErrorMessage(result as ExecResult);
-		if (error) throw new Error(`Failed to read execution context: ${error}`);
-		const raw = (result.data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts;
-		const snapshots = Array.isArray(raw) ? raw : raw ? [raw] : [];
-		if (snapshots.length === 0) throw new Error(`Execution ${executionId} has no context to render against.`);
+		const snapshots = await fetchExecutionContextSnapshots(deps, executionId);
 		if (typeof request.args.contextIndex === 'number') {
 			// Coerce to integer before indexing: a non-integer like 2.5 would survive
 			// Math.max/min and produce snapshots[2.5] === undefined, causing a
@@ -263,16 +275,36 @@ export async function runRenderJinja(request: ToolRequest, deps: GraphqlToolDeps
 }
 
 // ---------------------------------------------------------------------------
-// buddy_execution_logs runner
+// Shared context-snapshot fetcher
 // ---------------------------------------------------------------------------
 
-export async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Promise<string> {
-	const executionId = asStringArg(request.args, 'executionId');
-	if (!executionId) throw new Error('buddy_execution_logs requires "executionId".');
-	const orgId = asStringArg(request.args, 'orgId');
-	const failedOnly = asBooleanArg(request.args, 'failedOnly') ?? false;
-	const includeResult = asBooleanArg(request.args, 'includeResult') ?? false;
-	const includeSubExecutions = asBooleanArg(request.args, 'includeSubExecutions') ?? false;
+export async function fetchExecutionContextSnapshots(deps: GraphqlToolDeps, executionId: string): Promise<unknown[]> {
+	const result = await deps.execute(EXECUTION_CONTEXTS_QUERY, { id: executionId });
+	const error = firstErrorMessage(result as ExecResult);
+	if (error) throw new Error(`Failed to read execution context: ${error}`);
+	const raw = (result.data as { workflowExecutionContexts?: unknown } | undefined)?.workflowExecutionContexts;
+	const snapshots = Array.isArray(raw) ? raw : raw ? [raw] : [];
+	if (snapshots.length === 0) throw new Error(`Execution ${executionId} has no context to render against.`);
+	return snapshots;
+}
+
+// ---------------------------------------------------------------------------
+// Multi-session sweep helper
+// ---------------------------------------------------------------------------
+
+export interface TaskLogSweepResult {
+	rows: TaskLogRow[];
+	sourceDeps: GraphqlToolDeps;
+	sourceNote: string;
+	hadVisibleSession: boolean;
+	firstError?: unknown;
+}
+
+export async function sweepTaskLogs(
+	deps: GraphqlToolDeps,
+	executionId: string,
+	orgId: string | undefined,
+): Promise<TaskLogSweepResult> {
 	let rows: TaskLogRow[] = [];
 	let sourceDeps = deps;
 	let sourceNote = '';
@@ -302,6 +334,23 @@ export async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDe
 			}
 		}
 	}
+	return { rows, sourceDeps, sourceNote, hadVisibleSession, firstError };
+}
+
+// ---------------------------------------------------------------------------
+// buddy_execution_logs runner
+// ---------------------------------------------------------------------------
+
+export async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDeps): Promise<string> {
+	const executionId = asStringArg(request.args, 'executionId');
+	if (!executionId) throw new Error('buddy_execution_logs requires "executionId".');
+	const orgId = asStringArg(request.args, 'orgId');
+	const failedOnly = asBooleanArg(request.args, 'failedOnly') ?? false;
+	const includeResult = asBooleanArg(request.args, 'includeResult') ?? false;
+	const includeSubExecutions = asBooleanArg(request.args, 'includeSubExecutions') ?? false;
+	const sweep = await sweepTaskLogs(deps, executionId, orgId);
+	const { rows, sourceDeps, sourceNote, hadVisibleSession, firstError } = sweep;
+	const alternates = deps.alternates ?? [];
 	if (rows.length === 0 && !hadVisibleSession && firstError) {
 		throw firstError instanceof Error ? firstError : new Error(String(firstError));
 	}
@@ -430,7 +479,7 @@ export async function runWorkflowRun(request: ToolRequest, deps: GraphqlToolDeps
 	const head = `Run of "${name}" finished: ${(status ?? 'unknown').toUpperCase()}. executionId: ${executionId}`;
 	if (isFailedStatus(status)) {
 		const rows = await fetchTaskLogs(deps, executionId);
-		return `${head}\n\nFailing task(s):\n${formatTaskLogs(rows, { failedOnly: true })}\n\nFull logs: buddy_execution_logs {"executionId": "${executionId}"}.`;
+		return `${head}\n\nFailing task(s):\n${formatTaskLogs(rows, { failedOnly: true })}\n\nFull logs: buddy_execution_logs {"executionId": "${executionId}"}. For a one-call root-cause digest (transition path + sub-executions + context), use buddy_workflow_diagnose {"executionId": "${executionId}"}.`;
 	}
 	return `${head}\n\nInspect what it produced with buddy_execution_logs {"executionId": "${executionId}", "includeResult": true} or buddy_render_jinja {"executionId": "${executionId}", "template": "{{ CTX.<field> }}"}. `;
 }
@@ -470,6 +519,168 @@ export async function runWorkflowExecutions(request: ToolRequest, deps: GraphqlT
 		return `- ${e.id}  ${e.status}  ${when}  (${e.numSuccessfulTasks ?? '?'} task(s) ok)${links ? `  ${links}` : ''}`;
 	};
 	return `${rows.length} ${status ?? 'recent'} execution(s), newest first:\n${rows.map(fmt).join('\n')}\n\nInspect one with buddy_render_jinja {"executionId": "<id>", "template": "{{ CTX.<field> }}"}. `;
+}
+
+// ---------------------------------------------------------------------------
+// buddy_workflow_diagnose runner
+// ---------------------------------------------------------------------------
+
+async function findLatestFailedExecutionId(
+	deps: GraphqlToolDeps,
+	workflowId: string,
+	orgId: string,
+): Promise<string | undefined> {
+	const result = await deps.execute(WORKFLOW_EXECUTIONS_QUERY, {
+		where: { workflowId, orgId, status: 'FAILED' },
+		order: [['createdAt', 'desc']],
+		limit: 1,
+	});
+	const error = firstErrorMessage(result as ExecResult);
+	if (error) throw new Error(`Failed to find a failed execution for workflow ${workflowId}: ${error}`);
+	const row = (
+		(result.data as { workflowExecutions?: (ExecutionRow | null)[] } | undefined)?.workflowExecutions ?? []
+	).find((entry): entry is ExecutionRow => !!entry);
+	return row?.id ?? undefined;
+}
+
+function describeTransitionsInto(workflow: RawWorkflow, task: RawTask): string[] {
+	const lines: string[] = [];
+	for (const candidate of workflow.tasks) {
+		for (const transition of candidate.next ?? []) {
+			if ((transition.do ?? []).includes(task.id)) {
+				lines.push(`${candidate.name} --[${transition.when ?? '{{ SUCCEEDED }}'}]--> ${task.name}`);
+			}
+		}
+	}
+	return lines;
+}
+
+function describeTransitionsOut(workflow: RawWorkflow, task: RawTask): string[] {
+	const nameById = new Map(workflow.tasks.map(t => [t.id, t.name]));
+	return (task.next ?? []).flatMap(transition => {
+		const targets = (transition.do ?? []).map(id => nameById.get(id) ?? id);
+		if (targets.length === 0) return [];
+		return [`${task.name} --[${transition.when ?? '{{ SUCCEEDED }}'}]--> ${targets.join(', ')}`];
+	});
+}
+
+export async function runWorkflowDiagnose(request: ToolRequest, deps: GraphqlToolDeps): Promise<string> {
+	const explicitExecutionId = asStringArg(request.args, 'executionId');
+	const workflowIdArg = asStringArg(request.args, 'workflowId');
+	const orgIdArg = asStringArg(request.args, 'orgId');
+	if (!explicitExecutionId && !workflowIdArg) {
+		throw new Error(
+			'buddy_workflow_diagnose requires "executionId", or "workflowId" (with "orgId") to find its latest failed execution.',
+		);
+	}
+
+	let executionId = explicitExecutionId;
+	if (!executionId) {
+		if (!orgIdArg) throw new Error('buddy_workflow_diagnose requires "orgId" together with "workflowId".');
+		const found = await findLatestFailedExecutionId(deps, workflowIdArg as string, orgIdArg);
+		if (!found) return `No FAILED executions found for workflow ${workflowIdArg} in org ${orgIdArg}.`;
+		executionId = found;
+	}
+
+	const sweep = await sweepTaskLogs(deps, executionId, orgIdArg);
+	if (sweep.rows.length === 0 && !sweep.hadVisibleSession && sweep.firstError) {
+		throw sweep.firstError instanceof Error ? sweep.firstError : new Error(String(sweep.firstError));
+	}
+	const { rows, sourceDeps, sourceNote } = sweep;
+	const alternates = deps.alternates ?? [];
+	const failedCount = rows.filter(r => isFailedStatus(r.status)).length;
+	const sections: string[] = [
+		`Diagnosis for execution ${executionId}: ${rows.length} task(s), ${failedCount} failed.${sourceNote}`,
+	];
+	if (rows.length === 0 && alternates.length > 0) {
+		sections.push(
+			`None of the ${alternates.length + 1} active session(s) can see task logs for this execution — check the execution id, or sign in to the Rewst account whose org owns it.`,
+		);
+	}
+
+	const failingTask = rows.find(r => isFailedStatus(r.status));
+	const {
+		execution: detail,
+		children,
+		error: childLookupError,
+	} = await fetchChildExecutions(sourceDeps, executionId);
+
+	if (!failingTask) {
+		const statusNote = detail?.status ? ` (execution status: ${detail.status})` : '';
+		sections.push(
+			`No failing task found in this execution${statusNote}. If the run is still in progress, retry once it finishes.`,
+		);
+		return sections.join('\n\n');
+	}
+
+	const childrenOfFailingTask = failingTask.taskExecutionId
+		? children.filter(child => child.parentTaskExecutionId === failingTask.taskExecutionId)
+		: [];
+	const otherChildren = children.filter(child => !childrenOfFailingTask.includes(child));
+	const childrenByTask = new Map<string, ChildExecutionRow[]>();
+	if (failingTask.taskExecutionId && childrenOfFailingTask.length > 0) {
+		childrenByTask.set(failingTask.taskExecutionId, childrenOfFailingTask);
+	}
+	sections.push(
+		`Failing task (likely root cause):\n${formatTaskLogs([failingTask], { includeResult: true }, childrenByTask)}`,
+	);
+
+	if (childLookupError) sections.push(`Sub-workflow executions could not be checked: ${childLookupError}`);
+	const failedChild = childrenOfFailingTask.find(child => isFailedStatus(child.status));
+	if (failedChild) {
+		sections.push(
+			`likely deeper cause: sub-execution ${describeChildExecution(failedChild)} — drill in with buddy_workflow_diagnose {"executionId": "${failedChild.id}"}.`,
+		);
+	}
+	if (otherChildren.length > 0) {
+		sections.push(
+			`Other sub-workflow execution(s) not tied to the failing task: ${otherChildren.map(describeChildExecution).join(', ')}`,
+		);
+	}
+
+	const workflowId = workflowIdArg ?? detail?.workflow?.id ?? undefined;
+	const orgId = orgIdArg ?? detail?.orgId ?? detail?.workflow?.orgId ?? undefined;
+	if (workflowId && orgId) {
+		try {
+			const workflow = await fetchWorkflow(sourceDeps, workflowId, orgId);
+			const task = workflow.tasks.find(t => t.name === failingTask.originalWorkflowTaskName);
+			if (task) {
+				const incoming = describeTransitionsInto(workflow, task);
+				const outgoing = describeTransitionsOut(workflow, task);
+				sections.push(
+					[
+						`Transition path (action ${task.action?.ref ?? task.actionId ?? '?'}):`,
+						incoming.length > 0
+							? incoming.map(l => `  in:  ${l}`).join('\n')
+							: '  in:  (none — start task)',
+						outgoing.length > 0
+							? outgoing.map(l => `  out: ${l}`).join('\n')
+							: '  out: (none — terminal task)',
+					].join('\n'),
+				);
+			} else {
+				sections.push(
+					`Workflow definition unavailable: task "${failingTask.originalWorkflowTaskName}" not found in workflow ${workflowId}.`,
+				);
+			}
+		} catch (error) {
+			sections.push(`Workflow definition unavailable: ${error instanceof Error ? error.message : String(error)}`);
+		}
+	}
+
+	try {
+		const snapshots = await fetchExecutionContextSnapshots(sourceDeps, executionId);
+		const merged = Object.assign({}, ...snapshots.filter(isPlainObject)) as Record<string, unknown>;
+		const keys = Object.keys(merged).sort();
+		sections.push(
+			`Execution context (merged from ${snapshots.length} snapshot(s)), top-level keys: ${keys.join(', ') || '(none)'}. Inspect one with buddy_render_jinja {"executionId": "${executionId}", "template": "{{ CTX.<key> }}"}.`,
+		);
+	} catch (error) {
+		sections.push(`Execution context unavailable: ${error instanceof Error ? error.message : String(error)}`);
+	}
+
+	sections.push(`Full task-by-task list: buddy_execution_logs {"executionId": "${executionId}"}.`);
+	return sections.join('\n\n');
 }
 
 // Re-export fetchWorkflow for use by runWorkflowGet in the adapter

--- a/src/workflow/executions.ts
+++ b/src/workflow/executions.ts
@@ -8,7 +8,15 @@
 import { type GraphqlToolDeps } from '../ui/chat/tools/graphqlTool';
 import { asBooleanArg, asStringArg, type ToolRequest } from '../ui/chat/tools/toolProtocol';
 import { fetchWorkflow } from './graphMutations';
-import { firstErrorMessage, isPlainObject, type ExecResult, type RawTask, type RawWorkflow } from './types';
+import {
+	firstErrorMessage,
+	isPlainObject,
+	normalizePublish,
+	type ExecResult,
+	type RawTask,
+	type RawTransition,
+	type RawWorkflow,
+} from './types';
 
 // ---------------------------------------------------------------------------
 // GraphQL
@@ -543,12 +551,26 @@ async function findLatestFailedExecutionId(
 	return row?.id ?? undefined;
 }
 
+// Transition crashes are frequently in the publish expression (e.g. reading a
+// field off a null RESULT), not the `when` condition, so the digest surfaces
+// both instead of sending the caller back to buddy_workflow_get for it.
+function describePublish(transition: RawTransition): string {
+	const entries = normalizePublish(transition.publish);
+	if (entries.length === 0) return '';
+	const rendered = entries.map(
+		({ key, value }) => `${key}=${typeof value === 'string' ? value : JSON.stringify(value)}`,
+	);
+	return ` (publish: ${rendered.join(', ')})`;
+}
+
 function describeTransitionsInto(workflow: RawWorkflow, task: RawTask): string[] {
 	const lines: string[] = [];
 	for (const candidate of workflow.tasks) {
 		for (const transition of candidate.next ?? []) {
 			if ((transition.do ?? []).includes(task.id)) {
-				lines.push(`${candidate.name} --[${transition.when ?? '{{ SUCCEEDED }}'}]--> ${task.name}`);
+				lines.push(
+					`${candidate.name} --[${transition.when ?? '{{ SUCCEEDED }}'}]--> ${task.name}${describePublish(transition)}`,
+				);
 			}
 		}
 	}
@@ -560,7 +582,9 @@ function describeTransitionsOut(workflow: RawWorkflow, task: RawTask): string[] 
 	return (task.next ?? []).flatMap(transition => {
 		const targets = (transition.do ?? []).map(id => nameById.get(id) ?? id);
 		if (targets.length === 0) return [];
-		return [`${task.name} --[${transition.when ?? '{{ SUCCEEDED }}'}]--> ${targets.join(', ')}`];
+		return [
+			`${task.name} --[${transition.when ?? '{{ SUCCEEDED }}'}]--> ${targets.join(', ')}${describePublish(transition)}`,
+		];
 	});
 }
 

--- a/src/workflow/executions.ts
+++ b/src/workflow/executions.ts
@@ -629,7 +629,7 @@ export async function runWorkflowDiagnose(request: ToolRequest, deps: GraphqlToo
 	const failedChild = childrenOfFailingTask.find(child => isFailedStatus(child.status));
 	if (failedChild) {
 		sections.push(
-			`likely deeper cause: sub-execution ${describeChildExecution(failedChild)} — drill in with buddy_workflow_diagnose {"executionId": "${failedChild.id}"}.`,
+			`Likely deeper cause: sub-execution ${describeChildExecution(failedChild)} — drill in with buddy_workflow_diagnose {"executionId": "${failedChild.id}"}.`,
 		);
 	}
 	if (otherChildren.length > 0) {
@@ -640,44 +640,41 @@ export async function runWorkflowDiagnose(request: ToolRequest, deps: GraphqlToo
 
 	const workflowId = workflowIdArg ?? detail?.workflow?.id ?? undefined;
 	const orgId = orgIdArg ?? detail?.orgId ?? detail?.workflow?.orgId ?? undefined;
-	if (workflowId && orgId) {
+
+	const workflowSection = (async (): Promise<string | undefined> => {
+		if (!(workflowId && orgId)) return undefined;
 		try {
 			const workflow = await fetchWorkflow(sourceDeps, workflowId, orgId);
 			const task = workflow.tasks.find(t => t.name === failingTask.originalWorkflowTaskName);
-			if (task) {
-				const incoming = describeTransitionsInto(workflow, task);
-				const outgoing = describeTransitionsOut(workflow, task);
-				sections.push(
-					[
-						`Transition path (action ${task.action?.ref ?? task.actionId ?? '?'}):`,
-						incoming.length > 0
-							? incoming.map(l => `  in:  ${l}`).join('\n')
-							: '  in:  (none — start task)',
-						outgoing.length > 0
-							? outgoing.map(l => `  out: ${l}`).join('\n')
-							: '  out: (none — terminal task)',
-					].join('\n'),
-				);
-			} else {
-				sections.push(
-					`Workflow definition unavailable: task "${failingTask.originalWorkflowTaskName}" not found in workflow ${workflowId}.`,
-				);
+			if (!task) {
+				return `Workflow definition unavailable: task "${failingTask.originalWorkflowTaskName}" not found in workflow ${workflowId}.`;
 			}
+			const incoming = describeTransitionsInto(workflow, task);
+			const outgoing = describeTransitionsOut(workflow, task);
+			return [
+				`Transition path (action ${task.action?.ref ?? task.actionId ?? '?'}):`,
+				incoming.length > 0 ? incoming.map(l => `  in:  ${l}`).join('\n') : '  in:  (none — start task)',
+				outgoing.length > 0 ? outgoing.map(l => `  out: ${l}`).join('\n') : '  out: (none — terminal task)',
+			].join('\n');
 		} catch (error) {
-			sections.push(`Workflow definition unavailable: ${error instanceof Error ? error.message : String(error)}`);
+			return `Workflow definition unavailable: ${error instanceof Error ? error.message : String(error)}`;
 		}
-	}
+	})();
 
-	try {
-		const snapshots = await fetchExecutionContextSnapshots(sourceDeps, executionId);
-		const merged = Object.assign({}, ...snapshots.filter(isPlainObject)) as Record<string, unknown>;
-		const keys = Object.keys(merged).sort();
-		sections.push(
-			`Execution context (merged from ${snapshots.length} snapshot(s)), top-level keys: ${keys.join(', ') || '(none)'}. Inspect one with buddy_render_jinja {"executionId": "${executionId}", "template": "{{ CTX.<key> }}"}.`,
-		);
-	} catch (error) {
-		sections.push(`Execution context unavailable: ${error instanceof Error ? error.message : String(error)}`);
-	}
+	const contextSection = (async (): Promise<string> => {
+		try {
+			const snapshots = await fetchExecutionContextSnapshots(sourceDeps, executionId);
+			const merged = Object.assign({}, ...snapshots.filter(isPlainObject)) as Record<string, unknown>;
+			const keys = Object.keys(merged).sort();
+			return `Execution context (merged from ${snapshots.length} snapshot(s)), top-level keys: ${keys.join(', ') || '(none)'}. Inspect one with buddy_render_jinja {"executionId": "${executionId}", "template": "{{ CTX.<key> }}"}.`;
+		} catch (error) {
+			return `Execution context unavailable: ${error instanceof Error ? error.message : String(error)}`;
+		}
+	})();
+
+	const [resolvedWorkflowSection, resolvedContextSection] = await Promise.all([workflowSection, contextSection]);
+	if (resolvedWorkflowSection) sections.push(resolvedWorkflowSection);
+	sections.push(resolvedContextSection);
 
 	sections.push(`Full task-by-task list: buddy_execution_logs {"executionId": "${executionId}"}.`);
 	return sections.join('\n\n');

--- a/src/workflow/specs.ts
+++ b/src/workflow/specs.ts
@@ -11,6 +11,7 @@ export const WORKFLOW_EDIT_TOOL_NAME = 'buddy_workflow_edit';
 export const WORKFLOW_AUTOLAYOUT_TOOL_NAME = 'buddy_workflow_autolayout';
 export const WORKFLOW_RUN_TOOL_NAME = 'buddy_workflow_run';
 export const WORKFLOW_EXECUTION_LOGS_TOOL_NAME = 'buddy_execution_logs';
+export const WORKFLOW_DIAGNOSE_TOOL_NAME = 'buddy_workflow_diagnose';
 export const WORKFLOW_SEARCH_TOOL_NAME = 'buddy_workflow_search';
 
 /**
@@ -210,6 +211,41 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = withGeneratedArgsForAll([
 				},
 			},
 			required: ['executionId'],
+		},
+	},
+	{
+		name: WORKFLOW_DIAGNOSE_TOOL_NAME,
+		description:
+			'One-call root-cause digest for a failed workflow execution — use this BEFORE the ' +
+			'buddy_workflow_executions → buddy_execution_logs → buddy_workflow_get → buddy_render_jinja ' +
+			"round trip. Pass executionId directly, or workflowId (with orgId) to diagnose that workflow's " +
+			'most recent FAILED execution. Returns, in one response: the EARLIEST failing task (the likely ' +
+			'root cause — a later failure can just be a cascading effect) with its message, input, and ' +
+			"result; that task's transition path from the workflow definition (which task(s) lead into it " +
+			'and what it was set to do next); a flag if it spawned a sub-workflow execution that itself ' +
+			'failed (the deeper cause may be there — call this tool again with that execution id); and the ' +
+			"merged execution context's top-level keys so you know what CTX.<field> paths are available. " +
+			"Each signed-in Rewst session only sees its own org hierarchy: if the first session can't see " +
+			'the execution, other active sessions are checked automatically, same as buddy_execution_logs; ' +
+			'pass orgId to route directly. For the full task-by-task list instead of just the failing task, ' +
+			'use buddy_execution_logs.',
+		inputSchema: {
+			type: 'object',
+			properties: {
+				executionId: { type: 'string', description: 'The workflow execution id to diagnose.' },
+				workflowId: {
+					type: 'string',
+					description:
+						"A workflow id — used with orgId to find and diagnose that workflow's most recent " +
+						'FAILED execution when executionId is not known.',
+				},
+				orgId: {
+					type: 'string',
+					description:
+						'Required together with workflowId. Optional together with executionId: routes the ' +
+						'lookup to the session managing that org (useful with several signed-in accounts).',
+				},
+			},
 		},
 	},
 	{

--- a/src/workflow/toolRunner.ts
+++ b/src/workflow/toolRunner.ts
@@ -1,10 +1,17 @@
 import { type GraphqlToolDeps } from '../ui/chat/tools/graphqlTool';
 import { asStringArg, type ToolRequest } from '../ui/chat/tools/toolProtocol';
-import { runExecutionLogs, runRenderJinja, runWorkflowExecutions, runWorkflowRun } from './executions';
+import {
+	runExecutionLogs,
+	runRenderJinja,
+	runWorkflowDiagnose,
+	runWorkflowExecutions,
+	runWorkflowRun,
+} from './executions';
 import { applyWorkflowMutation, requireScopeFields, type WorkflowOperation } from './graphMutations';
 import { runWorkflowSearch } from './searchIndex';
 import {
 	WORKFLOW_AUTOLAYOUT_TOOL_NAME,
+	WORKFLOW_DIAGNOSE_TOOL_NAME,
 	WORKFLOW_EDIT_TOOL_NAME,
 	WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 	WORKFLOW_RUN_TOOL_NAME,
@@ -48,6 +55,8 @@ export async function runWorkflowTool(request: ToolRequest, deps: GraphqlToolDep
 			return runWorkflowExecutions(request, bound);
 		case WORKFLOW_EXECUTION_LOGS_TOOL_NAME:
 			return runExecutionLogs(request, bound);
+		case WORKFLOW_DIAGNOSE_TOOL_NAME:
+			return runWorkflowDiagnose(request, bound);
 		case WORKFLOW_SEARCH_TOOL_NAME:
 			return runWorkflowSearch(request, bound);
 		default:


### PR DESCRIPTION
## Summary
- Adds buddy_workflow_diagnose as a one-call root-cause digest for failed workflow executions.
- Wires the tool through workflow specs, runner dispatch, MCP/chat capability scoping, instructions, docs, OpenSpec, and changelog.
- Hardens the spec-mandated test matrix for validation, scope denial, cross-session sweeps, child executions, context/workflow fallback, and earliest-failure ordering.

## Test Plan
- npm run lint
- npm run type-check
- npm run test:unit
- npm run test:grep -- "buddy_workflow_diagnose"
- npm run test:grep -- "Unit: mcpInstructions"
- npm run test:grep -- "Unit: capability registry"
- npm run test:grep -- "Unit: package manifest"
- npm run changelog:check -- --base main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a one-call workflow diagnosis tool that helps identify failed executions, root causes, transition paths, sub-workflows, and relevant execution context.
  * Updated chat and MCP instructions so workflow debugging now starts with diagnosis before full log review.

* **Bug Fixes**
  * Improved workflow failure handling with better cross-session log lookup and clearer results when access is limited or data is unavailable.
  * Added support for locating the latest failed execution by workflow and org when an execution ID isn’t provided.

* **Documentation**
  * Updated feature docs and changelog entries to reflect the new workflow diagnosis capability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->