### PR TITLE
C2: Zod validation foundation — parseCapabilityInput + schema parity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,10 +292,11 @@ All components implement `vscode.Disposable` and push to `context.subscriptions`
 
 Capabilities live in `src/capabilities/*Capabilities.ts` and are surfaced to the MCP server and chat. Most review round-trips on these tools trace to a few rules — apply them up front instead of in follow-up commits.
 
-- **MCP inputs are NOT validated against `inputSchema`.** `McpActions` passes the raw `arguments` straight to `capability.run()` (see `src/mcp/McpActions.ts`); the schema is only advertised to the client, never enforced. So `run()` must defensively validate/coerce **every** input:
-    - Strings: `requireString` (required) / `asString` (optional) — never read `input.x` directly.
-    - Numbers: clamp — `Math.min(asPositiveInt(input, 'limit') ?? DEFAULT, MAX)`. `asPositiveInt` already rejects `0`, negatives, and fractions (returns `undefined`); preserve that property in any new numeric helper (e.g. `mapWithConcurrency` throws on a non-positive limit).
-    - Enums: validate against the allowed set before use — never blind-cast `input.kind as Kind`. An unexpected value must fall back to a safe default or throw, not slip through.
+- **MCP inputs are validated at the `run()` boundary via `parseCapabilityInput`.** `McpActions` passes the raw `arguments` straight to `capability.run()` (see `src/mcp/McpActions.ts`); the schema is advertised to the client AND enforced at runtime. Each capability defines a Zod schema and calls `parseCapabilityInput(schema, input)` at the top of its `run()` function — this replaces the old `requireString`/`asString`/`asPositiveInt` helpers. The advertised `inputSchema` is derived from the same Zod schema via `toInputSchema`, keeping advertisement and enforcement in sync. Key patterns:
+    - Strings: `requiredStringField('key')` (required) / `optionalStringField()` (optional) in the schema.
+    - Numbers: `optionalClampedInt(MAX)` in the schema — floors, clamps, and rejects non-positive values; callers apply `?? DEFAULT` after parsing.
+    - Enums: `z.enum([...])` in the schema; add a pre-parse guard in `run()` for friendly error messages (see `runResolveReference`).
+    - Domain constraints (e.g. rejecting epoch-ms dates): add explicit checks after `parseCapabilityInput`, before the API call.
 - **GraphQL error handling:** after every `rawGraphql`, check `errors` and throw _with context_ — include the serialized errors in the message (`GraphQL error: ...`), never a bare `throw new Error()` (which discards the failure).
 - **Description ↔ behavior parity:** if a tool's `description`/`inputSchema` says it returns or accepts a field, the handler must actually surface/use it. Drift (e.g. fetching `roleIds` but dropping them from the output) gets flagged.
 - **Build list output from the requested inputs, not the response keys.** Iterate the requested `ids`/`triggerIds` and look each up, so a missing or empty (`{}`) response yields deterministic rows (`unknown`) instead of dropped entries or a blank line.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,11 +292,10 @@ All components implement `vscode.Disposable` and push to `context.subscriptions`
 
 Capabilities live in `src/capabilities/*Capabilities.ts` and are surfaced to the MCP server and chat. Most review round-trips on these tools trace to a few rules — apply them up front instead of in follow-up commits.
 
-- **MCP inputs are validated at the `run()` boundary via `parseCapabilityInput`.** `McpActions` passes the raw `arguments` straight to `capability.run()` (see `src/mcp/McpActions.ts`); the schema is advertised to the client AND enforced at runtime. Each capability defines a Zod schema and calls `parseCapabilityInput(schema, input)` at the top of its `run()` function — this replaces the old `requireString`/`asString`/`asPositiveInt` helpers. The advertised `inputSchema` is derived from the same Zod schema via `toInputSchema`, keeping advertisement and enforcement in sync. Key patterns:
-    - Strings: `requiredStringField('key')` (required) / `optionalStringField()` (optional) in the schema.
-    - Numbers: `optionalClampedInt(MAX)` in the schema — floors, clamps, and rejects non-positive values; callers apply `?? DEFAULT` after parsing.
-    - Enums: `z.enum([...])` in the schema; add a pre-parse guard in `run()` for friendly error messages (see `runResolveReference`).
-    - Domain constraints (e.g. rejecting epoch-ms dates): add explicit checks after `parseCapabilityInput`, before the API call.
+- **MCP inputs are NOT validated against `inputSchema`.** `McpActions` passes the raw `arguments` straight to `capability.run()` (see `src/mcp/McpActions.ts`); the schema is only advertised to the client, never enforced. So `run()` must defensively validate/coerce **every** input:
+    - Strings: `requireString` (required) / `asString` (optional) — never read `input.x` directly.
+    - Numbers: clamp — `Math.min(asPositiveInt(input, 'limit') ?? DEFAULT, MAX)`. `asPositiveInt` already rejects `0`, negatives, and fractions (returns `undefined`); preserve that property in any new numeric helper (e.g. `mapWithConcurrency` throws on a non-positive limit).
+    - Enums: validate against the allowed set before use — never blind-cast `input.kind as Kind`. An unexpected value must fall back to a safe default or throw, not slip through.
 - **GraphQL error handling:** after every `rawGraphql`, check `errors` and throw _with context_ — include the serialized errors in the message (`GraphQL error: ...`), never a bare `throw new Error()` (which discards the failure).
 - **Description ↔ behavior parity:** if a tool's `description`/`inputSchema` says it returns or accepts a field, the handler must actually surface/use it. Drift (e.g. fetching `roleIds` but dropping them from the output) gets flagged.
 - **Build list output from the requested inputs, not the response keys.** Iterate the requested `ids`/`triggerIds` and look each up, so a missing or empty (`{}`) response yields deterministic rows (`unknown`) instead of dropped entries or a blank line.

--- a/changelog.d/c2-zod-validation-foundation.md
+++ b/changelog.d/c2-zod-validation-foundation.md
@@ -2,4 +2,4 @@
 category: Fixed
 ---
 
-- **Rewst Buddy tool validation** now returns clearer errors for malformed read-tool arguments and keeps advertised schemas aligned with runtime validation.
+- **Rewst Buddy read tools** now return clearer errors for malformed arguments.

--- a/changelog.d/c2-zod-validation-foundation.md
+++ b/changelog.d/c2-zod-validation-foundation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Capability input validation** — all 16 read-capability tools now validate and coerce inputs via Zod schemas at the `run()` boundary, so invalid arguments (wrong types, out-of-range limits, bad enums) are rejected with clear error messages instead of silently misbehaving.

--- a/changelog.d/c2-zod-validation-foundation.md
+++ b/changelog.d/c2-zod-validation-foundation.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Rewst Buddy tool validation** now returns clearer errors for malformed read-tool arguments and keeps advertised schemas aligned with runtime validation.

--- a/changelog.d/c2-zod-validation-foundation.md
+++ b/changelog.d/c2-zod-validation-foundation.md
@@ -1,5 +1,0 @@
----
-category: Fixed
----
-
-- **Capability input validation** — all 16 read-capability tools now validate and coerce inputs via Zod schemas at the `run()` boundary, so invalid arguments (wrong types, out-of-range limits, bad enums) are rejected with clear error messages instead of silently misbehaving.

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -446,33 +446,42 @@ NOT be able to widen `alwaysAllowedOrgs`.
 
 ### Requirement: Validate tool inputs defensively
 
-Each capability SHALL validate and coerce every input at the `run()` boundary
-using `parseCapabilityInput` against its Zod schema (required strings, clamped
-integers, enum checks). The advertised `inputSchema` is derived from the same
-Zod schema via `toInputSchema`, so the schema and the enforcement are always in
-sync. Capabilities with domain-specific constraints (e.g. rejecting epoch-ms
-dates, providing friendly enum error messages) MAY add pre-parse guards before
-calling `parseCapabilityInput`.
+Because tool inputs are not validated against the advertised `inputSchema` by
+the MCP transport, each capability SHALL validate and coerce its own input
+before use. Where a capability's input is defined as a schema object, that
+schema SHALL be the single source for both the runtime parse and the
+advertised `inputSchema` (derived from the schema), so the two can never drift
+independently. A validation failure SHALL surface one clear, human-readable
+message -- never a raw serialized list of every issue.
 
 #### Scenario: Out-of-range numeric input
 
 - **GIVEN** a tool that accepts a `limit`
 - **WHEN** a caller passes a value past the maximum
 - **THEN** the capability clamps it to the allowed maximum rather than honoring
-  the raw value
+  the raw value or rejecting the call
 
-#### Scenario: Invalid enum value
+#### Scenario: Invalid enum argument is rejected with a clear message
 
-- **GIVEN** a tool that accepts an enum field (e.g. `modelType`)
-- **WHEN** a caller passes a value not in the enum
-- **THEN** the capability throws with a human-readable message naming the
-  invalid value and listing the valid options
+- **GIVEN** a tool argument constrained to a fixed set of values
+- **WHEN** a caller passes a value outside that set
+- **THEN** the capability rejects the call with a single message naming the
+  invalid value and the allowed values, not a raw validation-error dump
 
-#### Scenario: Missing required field
+#### Scenario: Missing required argument is rejected with a clear message
 
-- **GIVEN** a tool that requires a field (e.g. `modelType`)
-- **WHEN** a caller omits it
-- **THEN** the capability throws with a message identifying the missing field
+- **GIVEN** a tool argument that is required
+- **WHEN** a caller omits it or passes the wrong type
+- **THEN** the capability rejects the call with a single message naming the
+  missing argument
+
+Implementation status: as of this requirement's schema-based rewrite,
+`src/capabilities/rewstReadCapabilities.ts` validates through per-capability
+Zod schemas per the contract above (`inputHelpers.ts`'s
+`parseCapabilityInput` + `toInputSchema`). The remaining capability files
+still validate via the hand-rolled `asString`/`requireString`/`asPositiveInt`
+helpers in `inputHelpers.ts`; they migrate to the same schema-based contract
+incrementally in follow-up PRs (epic #129 C2).
 
 ### Requirement: Verify saved task inputs after a workflow edit
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -446,9 +446,13 @@ NOT be able to widen `alwaysAllowedOrgs`.
 
 ### Requirement: Validate tool inputs defensively
 
-Because tool inputs are not validated against the advertised `inputSchema`, each
-capability SHALL validate and coerce every input itself (required strings,
-clamped numbers, enum checks) rather than trusting the schema.
+Each capability SHALL validate and coerce every input at the `run()` boundary
+using `parseCapabilityInput` against its Zod schema (required strings, clamped
+integers, enum checks). The advertised `inputSchema` is derived from the same
+Zod schema via `toInputSchema`, so the schema and the enforcement are always in
+sync. Capabilities with domain-specific constraints (e.g. rejecting epoch-ms
+dates, providing friendly enum error messages) MAY add pre-parse guards before
+calling `parseCapabilityInput`.
 
 #### Scenario: Out-of-range numeric input
 
@@ -456,6 +460,19 @@ clamped numbers, enum checks) rather than trusting the schema.
 - **WHEN** a caller passes a value past the maximum
 - **THEN** the capability clamps it to the allowed maximum rather than honoring
   the raw value
+
+#### Scenario: Invalid enum value
+
+- **GIVEN** a tool that accepts an enum field (e.g. `modelType`)
+- **WHEN** a caller passes a value not in the enum
+- **THEN** the capability throws with a human-readable message naming the
+  invalid value and listing the valid options
+
+#### Scenario: Missing required field
+
+- **GIVEN** a tool that requires a field (e.g. `modelType`)
+- **WHEN** a caller omits it
+- **THEN** the capability throws with a message identifying the missing field
 
 ### Requirement: Verify saved task inputs after a workflow edit
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
 			"version": "0.44.1",
 			"license": "MIT",
 			"dependencies": {
-				"@modelcontextprotocol/sdk": "^1.29.0"
+				"@modelcontextprotocol/sdk": "^1.29.0",
+				"zod": "^4.4.3"
 			},
 			"devDependencies": {
 				"@0no-co/graphqlsp": "^1.15.2",

--- a/package.json
+++ b/package.json
@@ -864,6 +864,7 @@
 		]
 	},
 	"dependencies": {
-		"@modelcontextprotocol/sdk": "^1.29.0"
+		"@modelcontextprotocol/sdk": "^1.29.0",
+		"zod": "^4.4.3"
 	}
 }

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -1,11 +1,17 @@
 import * as assert from 'assert';
+import { z } from 'zod';
 import { suite, test } from '../test/tdd';
 import {
 	mapWithConcurrency,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
 	rawGraphqlOrThrow,
 	requireResourceInOrg,
 	requireStringAllowEmpty,
+	requiredStringField,
 	throwOnGraphqlErrors,
+	toInputSchema,
 } from './inputHelpers';
 
 function delay(ms: number): Promise<void> {
@@ -263,5 +269,167 @@ suite('Unit: inputHelpers — requireStringAllowEmpty', () => {
 
 	test('throws when the value is a non-string (number)', () => {
 		assert.throws(() => requireStringAllowEmpty({ body: 42 }, 'body'), /Missing required string argument "body"/);
+	});
+});
+
+// ---------------------------------------------------------------------------
+// New Zod-based helpers
+// ---------------------------------------------------------------------------
+
+suite('Unit: inputHelpers — parseCapabilityInput', () => {
+	test('returns parsed data on success', () => {
+		const schema = z.object({ a: z.string() });
+		const result = parseCapabilityInput(schema, { a: 'x' });
+		assert.deepStrictEqual(result, { a: 'x' });
+	});
+
+	test('throws the first issue message, not the raw ZodError JSON', () => {
+		const schema = z.object({ a: z.string({ error: 'Missing required string argument "a".' }) });
+		let thrown: unknown;
+		try {
+			parseCapabilityInput(schema, {});
+		} catch (e) {
+			thrown = e;
+		}
+		assert.ok(thrown instanceof Error, 'should throw an Error');
+		const msg = (thrown as Error).message;
+		// Must be a clean single-line message, not a JSON blob
+		assert.match(msg, /^Missing/);
+		assert.ok(!msg.includes('"code"'), 'message must not contain JSON "code" key');
+		assert.ok(!msg.startsWith('['), 'message must not start with [ (JSON array)');
+	});
+});
+
+suite('Unit: inputHelpers — requiredStringField', () => {
+	test('rejects missing key with the keyed message', () => {
+		const schema = z.object({ x: requiredStringField('x') });
+		assert.throws(() => parseCapabilityInput(schema, {}), /Missing required string argument "x"\./);
+	});
+
+	test('rejects wrong type (number) with the keyed message', () => {
+		const schema = z.object({ x: requiredStringField('x') });
+		assert.throws(() => parseCapabilityInput(schema, { x: 123 }), /Missing required string argument "x"\./);
+	});
+
+	test('rejects empty string with the keyed message', () => {
+		const schema = z.object({ x: requiredStringField('x') });
+		assert.throws(() => parseCapabilityInput(schema, { x: '' }), /Missing required string argument "x"\./);
+	});
+
+	test('rejects whitespace-only string with the keyed message', () => {
+		const schema = z.object({ x: requiredStringField('x') });
+		assert.throws(() => parseCapabilityInput(schema, { x: '   ' }), /Missing required string argument "x"\./);
+	});
+
+	test('trims and accepts a valid string', () => {
+		const schema = z.object({ x: requiredStringField('x') });
+		const result = parseCapabilityInput(schema, { x: '  hi  ' });
+		assert.strictEqual(result.x, 'hi');
+	});
+});
+
+suite('Unit: inputHelpers — optionalStringField', () => {
+	test('resolves undefined for missing key (no throw)', () => {
+		const schema = z.object({ x: optionalStringField() });
+		const result = parseCapabilityInput(schema, {});
+		assert.strictEqual(result.x, undefined);
+	});
+
+	test('resolves undefined for wrong type (number, no throw)', () => {
+		const schema = z.object({ x: optionalStringField() });
+		const result = parseCapabilityInput(schema, { x: 123 });
+		assert.strictEqual(result.x, undefined);
+	});
+
+	test('resolves undefined for empty string (no throw)', () => {
+		const schema = z.object({ x: optionalStringField() });
+		const result = parseCapabilityInput(schema, { x: '' });
+		assert.strictEqual(result.x, undefined);
+	});
+
+	test('resolves undefined for whitespace-only string (no throw)', () => {
+		const schema = z.object({ x: optionalStringField() });
+		const result = parseCapabilityInput(schema, { x: '   ' });
+		assert.strictEqual(result.x, undefined);
+	});
+
+	test('resolves undefined for null (no throw)', () => {
+		const schema = z.object({ x: optionalStringField() });
+		const result = parseCapabilityInput(schema, { x: null });
+		assert.strictEqual(result.x, undefined);
+	});
+
+	test('trims and accepts a valid string', () => {
+		const schema = z.object({ x: optionalStringField() });
+		const result = parseCapabilityInput(schema, { x: '  hi  ' });
+		assert.strictEqual(result.x, 'hi');
+	});
+});
+
+suite('Unit: inputHelpers — optionalClampedInt', () => {
+	test('resolves undefined for 0 (no throw)', () => {
+		const schema = z.object({ n: optionalClampedInt(500) });
+		const result = parseCapabilityInput(schema, { n: 0 });
+		assert.strictEqual(result.n, undefined);
+	});
+
+	test('resolves undefined for a negative value (no throw)', () => {
+		const schema = z.object({ n: optionalClampedInt(500) });
+		const result = parseCapabilityInput(schema, { n: -5 });
+		assert.strictEqual(result.n, undefined);
+	});
+
+	test('resolves undefined for a non-number string (no throw)', () => {
+		const schema = z.object({ n: optionalClampedInt(500) });
+		const result = parseCapabilityInput(schema, { n: '10' });
+		assert.strictEqual(result.n, undefined);
+	});
+
+	test('resolves undefined for a floor-to-zero fraction (0.5, no throw)', () => {
+		const schema = z.object({ n: optionalClampedInt(500) });
+		const result = parseCapabilityInput(schema, { n: 0.5 });
+		assert.strictEqual(result.n, undefined);
+	});
+
+	test('floors a fractional value instead of rejecting it', () => {
+		const schema = z.object({ n: optionalClampedInt(500) });
+		const result = parseCapabilityInput(schema, { n: 2.5 });
+		assert.strictEqual(result.n, 2);
+	});
+
+	test('clamps an over-max value instead of rejecting it', () => {
+		const schema = z.object({ n: optionalClampedInt(500) });
+		const result = parseCapabilityInput(schema, { n: 999 });
+		assert.strictEqual(result.n, 500);
+	});
+
+	test('passes through a valid in-range value unchanged', () => {
+		const schema = z.object({ n: optionalClampedInt(500) });
+		const result = parseCapabilityInput(schema, { n: 42 });
+		assert.strictEqual(result.n, 42);
+	});
+});
+
+suite('Unit: inputHelpers — toInputSchema', () => {
+	test('strips the $schema key', () => {
+		const schema = z.object({ a: z.string() });
+		const result = toInputSchema(schema) as Record<string, unknown>;
+		assert.ok(!('$schema' in result), '$schema must be stripped');
+	});
+
+	test('derives type and required from the schema', () => {
+		const schema = z.object({
+			requiredField: z.string(),
+			optionalField: z.string().optional(),
+		});
+		const result = toInputSchema(schema) as {
+			properties: Record<string, { type: string }>;
+			required?: string[];
+		};
+		assert.ok(Array.isArray(result.required), 'required should be an array');
+		assert.ok(result.required!.includes('requiredField'), 'requiredField must be in required');
+		assert.ok(!result.required!.includes('optionalField'), 'optionalField must not be in required');
+		assert.strictEqual(result.properties['requiredField'].type, 'string');
+		assert.strictEqual(result.properties['optionalField'].type, 'string');
 	});
 });

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -432,4 +432,23 @@ suite('Unit: inputHelpers — toInputSchema', () => {
 		assert.strictEqual(result.properties['requiredField'].type, 'string');
 		assert.strictEqual(result.properties['optionalField'].type, 'string');
 	});
+
+	test('derives schema from the real capability field helpers', () => {
+		const schema = z.object({
+			orgId: requiredStringField('orgId'),
+			search: optionalStringField(),
+			limit: optionalClampedInt(500),
+		});
+
+		const result = toInputSchema(schema) as {
+			properties: Record<string, { type: string }>;
+			required?: string[];
+		};
+
+		assert.ok(!('$schema' in result), '$schema must be stripped');
+		assert.deepStrictEqual(new Set(result.required), new Set(['orgId']));
+		assert.strictEqual(result.properties['orgId'].type, 'string');
+		assert.strictEqual(result.properties['search'].type, 'string');
+		assert.strictEqual(result.properties['limit'].type, 'number');
+	});
 });

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -5,6 +5,7 @@
  */
 
 import type { FullTemplateFragment, Session } from '@sessions';
+import { z } from 'zod';
 
 /** Pretty-prints a value as the JSON string capabilities return to callers. */
 export function json(value: unknown): string {
@@ -136,3 +137,75 @@ export async function mapWithConcurrency<T, R>(
 export const ORG_ID_PROP = {
 	orgId: { type: 'string', description: 'Rewst organization id the operation runs against (from buddy_list_orgs).' },
 } as const;
+
+// ---------------------------------------------------------------------------
+// Zod-based helpers (C2 migration)
+// ---------------------------------------------------------------------------
+
+/**
+ * Parses input through a capability's Zod schema, throwing a single clean
+ * message (the first validation issue) instead of ZodError's default
+ * JSON-dump message.
+ */
+export function parseCapabilityInput<T>(schema: z.ZodType<T>, input: Record<string, unknown>): T {
+	const result = schema.safeParse(input);
+	if (result.success) return result.data;
+	throw new Error(result.error.issues[0]?.message ?? 'Invalid input.');
+}
+
+const JSON_SCHEMA_TARGET = 'draft-07';
+
+/**
+ * Derives an MCP inputSchema from a Zod object schema, stripping the
+ * `$schema` meta key `z.toJSONSchema` always adds (noise for our purposes).
+ */
+export function toInputSchema(schema: z.ZodObject<z.ZodRawShape>): object {
+	const { $schema: _schema, ...rest } = z.toJSONSchema(schema, { target: JSON_SCHEMA_TARGET }) as Record<
+		string,
+		unknown
+	>;
+	return rest;
+}
+
+/**
+ * Zod counterpart to requireString: required, trimmed, non-empty string.
+ * Missing key, wrong type, and empty-after-trim all produce the same
+ * message, matching requireString's behavior exactly.
+ */
+export function requiredStringField(key: string): z.ZodString {
+	const message = `Missing required string argument "${key}".`;
+	return z.string({ error: message }).trim().min(1, { error: message });
+}
+
+/**
+ * Zod counterpart to asString: optional, trimmed string. Missing key, wrong
+ * type, and empty-after-trim all silently resolve to undefined — never
+ * throws — matching asString's behavior exactly.
+ */
+export function optionalStringField(): z.ZodType<string | undefined> {
+	return z
+		.preprocess(raw => (typeof raw === 'string' ? raw.trim() : raw), z.string().min(1).optional())
+		.catch(undefined);
+}
+
+/**
+ * Zod counterpart to `Math.min(asPositiveInt(input, key) ?? DEFAULT, MAX)`.
+ * Reproduces asPositiveInt exactly: non-number, non-finite, <= 0, and
+ * floor-to-<=0 inputs all silently resolve to undefined (never throw); a
+ * valid value is floored then clamped to `max`. Callers still apply
+ * `?? DEFAULT` after parsing, exactly as today.
+ */
+export function optionalClampedInt(max: number): z.ZodType<number | undefined> {
+	return z.preprocess(raw => {
+		if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return undefined;
+		const floored = Math.floor(raw);
+		return floored > 0 ? Math.min(floored, max) : undefined;
+	}, z.number().int().positive().max(max).optional());
+}
+
+/**
+ * Shared orgId field for read-capability schemas; description text matches
+ * the existing ORG_ID_PROP so the two stay in sync until every capability
+ * migrates.
+ */
+export const ORG_ID_FIELD: z.ZodString = requiredStringField('orgId').describe(ORG_ID_PROP.orgId.description);

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -200,7 +200,7 @@ export function optionalClampedInt(max: number): z.ZodType<number | undefined> {
 		if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return undefined;
 		const floored = Math.floor(raw);
 		return floored > 0 ? Math.min(floored, max) : undefined;
-	}, z.number().int().positive().max(max).optional());
+	}, z.number().positive().max(max).optional());
 }
 
 /**

--- a/src/capabilities/rewstReadCapabilities.schemaParity.test.ts
+++ b/src/capabilities/rewstReadCapabilities.schemaParity.test.ts
@@ -1,0 +1,290 @@
+/**
+ * C2.4 schema parity test — frozen LEGACY_SCHEMAS fixture.
+ *
+ * This file captures the 16 hand-written inputSchema objects from
+ * rewstReadCapabilities.ts exactly as they existed BEFORE the Zod migration.
+ * After migration, the derived schemas are compared field-by-field against
+ * this fixture to ensure no required field was dropped, no type changed, and
+ * no description was silently lost.
+ *
+ * The four checks per tool:
+ *   1. required fields (as a Set) match exactly.
+ *   2. every legacy property key exists in the derived schema.
+ *   3. every legacy property's type matches the derived property's type.
+ *   4. every legacy property that had an enum has the same values (as a Set).
+ *   5. every legacy property that had a description has a non-empty description
+ *      in the derived schema.
+ *
+ * Runner: mocha / extension-host (same suite as rewstReadCapabilities.test.ts).
+ */
+
+import * as assert from 'assert';
+import { suite, test } from '../test/tdd';
+
+// ---------------------------------------------------------------------------
+// Frozen legacy schemas — verbatim copy of the pre-migration inputSchema
+// objects. Do NOT update these when migrating; they are the regression guard.
+// ---------------------------------------------------------------------------
+
+interface LegacyProperty {
+	type: string;
+	description?: string;
+	enum?: readonly string[];
+}
+
+interface LegacySchema {
+	properties: Record<string, LegacyProperty>;
+	required?: string[];
+}
+
+const ORG_ID_DESC = 'Rewst organization id the operation runs against (from buddy_list_orgs).';
+
+const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
+	buddy_list_orgs: {
+		properties: {},
+	},
+	buddy_list_templates: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+		},
+		required: ['orgId'],
+	},
+	buddy_get_template: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			templateId: { type: 'string', description: 'Template id to fetch.' },
+		},
+		required: ['orgId', 'templateId'],
+	},
+	buddy_list_workflows: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name filter.' },
+			limit: { type: 'number', description: 'Max workflows to return (default 100).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_org_variables: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name substring filter.' },
+			limit: { type: 'number', description: 'Max variables to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_workflow_executions: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			status: { type: 'string', description: 'Optional exact execution status filter.' },
+			limit: { type: 'number', description: 'Max executions to return (default 25, max 100).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_find_executions_by_variable: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			workflowId: { type: 'string', description: 'The workflow whose executions to scan.' },
+			name: { type: 'string', description: 'Case-insensitive substring matched against variable names.' },
+			kind: {
+				type: 'string',
+				enum: ['input', 'output', 'context'],
+				description: "Which variable surface to search: input (default), output, or context (the run's CTX).",
+			},
+			value: {
+				type: 'string',
+				description: "Optional case-insensitive substring the matched variable's value must contain.",
+			},
+			limit: { type: 'number', description: 'Max executions to scan, most-recent first (default 25, max 100).' },
+		},
+		required: ['orgId', 'workflowId', 'name'],
+	},
+	buddy_list_workflow_tasks: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			workflowId: { type: 'string', description: 'Workflow id whose tasks to list.' },
+			limit: { type: 'number', description: 'Max tasks to return (default 100, max 500).' },
+		},
+		required: ['orgId', 'workflowId'],
+	},
+	buddy_list_workflow_patches: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			workflowId: { type: 'string', description: 'Workflow id whose patch history to list.' },
+			limit: { type: 'number', description: 'Max patches to return (default 25, max 100).' },
+		},
+		required: ['orgId', 'workflowId'],
+	},
+	buddy_get_workflow_patch: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			patchId: { type: 'string', description: 'Workflow patch id to fetch.' },
+		},
+		required: ['orgId', 'patchId'],
+	},
+	buddy_latest_workflow_execution: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			workflowId: { type: 'string', description: 'Workflow id to inspect.' },
+			status: { type: 'string', description: 'Optional exact execution status constraint.' },
+		},
+		required: ['orgId', 'workflowId'],
+	},
+	buddy_get_workflow_execution_stats: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			createdSince: {
+				type: 'string',
+				description: 'ISO-8601 date string such as 2025-01-01 or 2025-01-01T00:00:00Z.',
+			},
+		},
+		required: ['orgId', 'createdSince'],
+	},
+	buddy_find_action: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			filter: {
+				type: 'string',
+				description: "Optional text matched case-insensitively against the action's display name.",
+			},
+			limit: { type: 'number', description: 'Max flattened actions to return (default 25, max 100).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_resolve_reference: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			modelType: {
+				type: 'string',
+				enum: [
+					'Crate',
+					'CustomDatabase',
+					'Organization',
+					'PackConfig',
+					'Role',
+					'Template',
+					'TemplateExport',
+					'User',
+					'Workflow',
+					'Trigger',
+					'Form',
+					'Site',
+					'Page',
+				],
+				description: 'Which kind of Rewst object to resolve.',
+			},
+			search: { type: 'string', description: 'Optional case-insensitive name substring filter.' },
+			limit: { type: 'number', description: 'Max references to return (default 25, max 100).' },
+		},
+		required: ['orgId', 'modelType'],
+	},
+	buddy_get_workflow: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			workflowId: { type: 'string', description: 'Workflow id to fetch.' },
+		},
+		required: ['orgId', 'workflowId'],
+	},
+	buddy_graphql_query: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			query: { type: 'string', description: 'GraphQL query document (no mutations or subscriptions).' },
+			variables: { type: 'object', description: 'Optional GraphQL variables.' },
+		},
+		required: ['orgId', 'query'],
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Import the live capability registry so we can read the derived inputSchemas
+// ---------------------------------------------------------------------------
+
+import { getCapability } from './registry';
+
+// ---------------------------------------------------------------------------
+// Parity assertions
+// ---------------------------------------------------------------------------
+
+suite('Unit: rewstReadCapabilities.schemaParity', () => {
+	for (const [toolName, legacy] of Object.entries(LEGACY_SCHEMAS)) {
+		test(`${toolName} — required fields match`, () => {
+			const cap = getCapability(toolName);
+			assert.ok(cap, `capability ${toolName} must be registered`);
+			const derived = cap.spec.inputSchema as {
+				properties?: Record<string, { type: string; enum?: string[]; description?: string }>;
+				required?: string[];
+			};
+
+			const legacyRequired = new Set(legacy.required ?? []);
+			const derivedRequired = new Set(derived.required ?? []);
+			assert.deepStrictEqual(
+				derivedRequired,
+				legacyRequired,
+				`${toolName}: required fields mismatch — derived ${JSON.stringify([...derivedRequired])} vs legacy ${JSON.stringify([...legacyRequired])}`,
+			);
+		});
+
+		test(`${toolName} — all legacy property keys present in derived schema`, () => {
+			const cap = getCapability(toolName);
+			assert.ok(cap, `capability ${toolName} must be registered`);
+			const derived = cap.spec.inputSchema as {
+				properties?: Record<string, { type: string; enum?: string[]; description?: string }>;
+			};
+			const derivedProps = derived.properties ?? {};
+
+			for (const key of Object.keys(legacy.properties)) {
+				assert.ok(key in derivedProps, `${toolName}: legacy property "${key}" is missing from derived schema`);
+			}
+		});
+
+		test(`${toolName} — property types and enums match`, () => {
+			const cap = getCapability(toolName);
+			assert.ok(cap, `capability ${toolName} must be registered`);
+			const derived = cap.spec.inputSchema as {
+				properties?: Record<string, { type: string; enum?: string[]; description?: string }>;
+			};
+			const derivedProps = derived.properties ?? {};
+
+			for (const [key, legacyProp] of Object.entries(legacy.properties)) {
+				if (!(key in derivedProps)) continue; // already caught by previous test
+				const derivedProp = derivedProps[key];
+
+				assert.strictEqual(
+					derivedProp.type,
+					legacyProp.type,
+					`${toolName}.${key}: type changed from "${legacyProp.type}" to "${derivedProp.type}"`,
+				);
+
+				if (legacyProp.enum) {
+					assert.ok(
+						Array.isArray(derivedProp.enum),
+						`${toolName}.${key}: legacy had enum but derived has none`,
+					);
+					assert.deepStrictEqual(
+						new Set(derivedProp.enum),
+						new Set(legacyProp.enum),
+						`${toolName}.${key}: enum values changed`,
+					);
+				}
+			}
+		});
+
+		test(`${toolName} — descriptions present for all legacy-described properties`, () => {
+			const cap = getCapability(toolName);
+			assert.ok(cap, `capability ${toolName} must be registered`);
+			const derived = cap.spec.inputSchema as {
+				properties?: Record<string, { type: string; enum?: string[]; description?: string }>;
+			};
+			const derivedProps = derived.properties ?? {};
+
+			for (const [key, legacyProp] of Object.entries(legacy.properties)) {
+				if (!legacyProp.description) continue;
+				if (!(key in derivedProps)) continue; // already caught
+				const derivedDesc = derivedProps[key].description;
+				assert.ok(
+					typeof derivedDesc === 'string' && derivedDesc.length > 0,
+					`${toolName}.${key}: legacy had a description but derived has none or empty`,
+				);
+			}
+		});
+	}
+});

--- a/src/capabilities/rewstReadCapabilities.schemaParity.test.ts
+++ b/src/capabilities/rewstReadCapabilities.schemaParity.test.ts
@@ -19,7 +19,9 @@
  */
 
 import * as assert from 'assert';
-import { suite, test } from '../test/tdd';
+import * as Mocha from 'mocha';
+
+const { suite, test } = Mocha;
 
 // ---------------------------------------------------------------------------
 // Frozen legacy schemas — verbatim copy of the pre-migration inputSchema

--- a/src/capabilities/rewstReadCapabilities.test.ts
+++ b/src/capabilities/rewstReadCapabilities.test.ts
@@ -720,11 +720,7 @@ suite('Unit: rewstReadCapabilities', () => {
 
 		const calls = wrapper.getCallsFor('rawGraphql');
 		assert.strictEqual(calls.length, 1);
-		// limit must be clamped to MAX_WORKFLOW_LIMIT (500), not the raw 99999
-		assert.ok(
-			(calls[0].variables.variables as { limit?: number }).limit! <= 500,
-			`expected limit clamped to <=500, got ${(calls[0].variables.variables as { limit?: number }).limit}`,
-		);
+		assert.strictEqual((calls[0].variables.variables as { limit?: number }).limit, 500);
 	});
 
 	test('buddy_list_workflows treats a negative limit as absent (falls back to default)', async () => {
@@ -812,6 +808,24 @@ suite('Unit: rewstReadCapabilities', () => {
 		);
 	});
 
+	test('buddy_get_workflow_execution_stats rejects any all-digit createdSince string', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', { data: { data: { workflowExecutionStats: { succeeded: 1 } } } });
+		const getStats = getCapability('buddy_get_workflow_execution_stats');
+		assert.ok(getStats, 'buddy_get_workflow_execution_stats is registered');
+
+		await assert.rejects(
+			() =>
+				getStats.run({ orgId: 'org-1', createdSince: '20250101' }, {
+					session,
+					orgId: 'org-1',
+					sessions: [session],
+				} satisfies CapabilityContext),
+			/createdSince must be an ISO-8601 date string; epoch milliseconds are not supported\./,
+		);
+	});
+
 	test('buddy_get_workflow_execution_stats accepts a bare ISO date', async () => {
 		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
 		useRawGraphqlWrapper(session, wrapper);
@@ -858,6 +872,36 @@ suite('Unit: rewstReadCapabilities', () => {
 		);
 	});
 
+	test('buddy_resolve_reference trims modelType before enum validation', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					localReferenceOptions: [
+						{
+							label: 'Foo workflow',
+							value: 'wf-1',
+						},
+					],
+				},
+			},
+		});
+		const resolveReference = getCapability('buddy_resolve_reference');
+		assert.ok(resolveReference, 'buddy_resolve_reference is registered');
+
+		const output = await resolveReference.run({ orgId: 'org-1', modelType: ' Workflow ' }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.strictEqual(calls[0].variables.variables.modelName, 'Workflow');
+		assert.strictEqual(output, 'Foo workflow (wf-1)');
+	});
+
 	test('buddy_get_template rejects a missing templateId', async () => {
 		const { session } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
 		const getTemplate = getCapability('buddy_get_template');
@@ -875,7 +919,9 @@ suite('Unit: rewstReadCapabilities', () => {
 	});
 
 	test('buddy_graphql_query rejects a non-object variables value (array)', async () => {
-		const { session } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', { data: { data: { workflows: [] } } });
 		const graphqlQuery = getCapability('buddy_graphql_query');
 		assert.ok(graphqlQuery, 'buddy_graphql_query is registered');
 
@@ -886,8 +932,9 @@ suite('Unit: rewstReadCapabilities', () => {
 					orgId: 'org-1',
 					sessions: [session],
 				} satisfies CapabilityContext),
-			/./,
+			/expected record|JSON object|received array/i,
 			'should reject when variables is an array',
 		);
+		assert.strictEqual(wrapper.getCallsFor('rawGraphql').length, 0);
 	});
 });

--- a/src/capabilities/rewstReadCapabilities.test.ts
+++ b/src/capabilities/rewstReadCapabilities.test.ts
@@ -689,4 +689,205 @@ suite('Unit: rewstReadCapabilities', () => {
 		assert.deepStrictEqual(JSON.parse(output), workflowPatch);
 		assert.strictEqual(output, JSON.stringify(workflowPatch, null, 2));
 	});
+
+	// -------------------------------------------------------------------------
+	// C2 migration tests — input validation via Zod schemas
+	// -------------------------------------------------------------------------
+
+	test('buddy_list_workflows rejects a missing orgId', async () => {
+		const { session } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		const listWorkflows = getCapability('buddy_list_workflows');
+		assert.ok(listWorkflows, 'buddy_list_workflows is registered');
+
+		await assert.rejects(
+			() => listWorkflows.run({}, { session, orgId: 'org-1', sessions: [session] } satisfies CapabilityContext),
+			/Missing required string argument "orgId"\./,
+		);
+	});
+
+	test('buddy_list_workflows clamps an over-max limit instead of erroring', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', { data: { data: { workflows: [] } } });
+		const listWorkflows = getCapability('buddy_list_workflows');
+		assert.ok(listWorkflows, 'buddy_list_workflows is registered');
+
+		await listWorkflows.run({ orgId: 'org-1', limit: 99999 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		// limit must be clamped to MAX_WORKFLOW_LIMIT (500), not the raw 99999
+		assert.ok(
+			(calls[0].variables.variables as { limit?: number }).limit! <= 500,
+			`expected limit clamped to <=500, got ${(calls[0].variables.variables as { limit?: number }).limit}`,
+		);
+	});
+
+	test('buddy_list_workflows treats a negative limit as absent (falls back to default)', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', { data: { data: { workflows: [] } } });
+		const listWorkflows = getCapability('buddy_list_workflows');
+		assert.ok(listWorkflows, 'buddy_list_workflows is registered');
+
+		await listWorkflows.run({ orgId: 'org-1', limit: -3 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		// invalid limit silently becomes the default (100)
+		assert.strictEqual((calls[0].variables.variables as { limit?: number }).limit, 100);
+	});
+
+	test('buddy_list_workflows treats a fractional limit as floored (2.5 → 2)', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', { data: { data: { workflows: [] } } });
+		const listWorkflows = getCapability('buddy_list_workflows');
+		assert.ok(listWorkflows, 'buddy_list_workflows is registered');
+
+		await listWorkflows.run({ orgId: 'org-1', limit: 2.5 }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		// 2.5 floors to 2, not rejected
+		assert.strictEqual((calls[0].variables.variables as { limit?: number }).limit, 2);
+	});
+
+	test('buddy_find_executions_by_variable falls back to kind "input" for an invalid kind value', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflowExecutions: [
+						{
+							id: 'exec-1',
+							status: 'succeeded',
+							createdAt: '1700000000000',
+							conductor: { input: { myVar: 'hello' }, output: {} },
+						},
+					],
+				},
+			},
+		});
+		const findExec = getCapability('buddy_find_executions_by_variable');
+		assert.ok(findExec, 'buddy_find_executions_by_variable is registered');
+
+		// 'bogus' is not a valid kind — must silently fall back to 'input', not reject
+		const output = await findExec.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'myVar', kind: 'bogus' }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+		// Should have matched the input variable (kind fell back to 'input')
+		assert.ok(output.includes('exec-1'), 'should match exec-1 via input kind fallback');
+		assert.ok(output.includes('myVar=hello'), 'should show the matched input variable');
+	});
+
+	test('buddy_get_workflow_execution_stats rejects epoch-millisecond createdSince', async () => {
+		const { session } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		const getStats = getCapability('buddy_get_workflow_execution_stats');
+		assert.ok(getStats, 'buddy_get_workflow_execution_stats is registered');
+
+		await assert.rejects(
+			() =>
+				getStats.run({ orgId: 'org-1', createdSince: '1700000000000' }, {
+					session,
+					orgId: 'org-1',
+					sessions: [session],
+				} satisfies CapabilityContext),
+			/epoch milliseconds are not supported/,
+		);
+	});
+
+	test('buddy_get_workflow_execution_stats accepts a bare ISO date', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflowExecutionStats: {
+						succeeded: 1,
+						failed: 0,
+						running: 0,
+						pending: 0,
+						paused: 0,
+						delayed: 0,
+						humanSecondsSaved: 0,
+					},
+				},
+			},
+		});
+		const getStats = getCapability('buddy_get_workflow_execution_stats');
+		assert.ok(getStats, 'buddy_get_workflow_execution_stats is registered');
+
+		// Must NOT reject — bare ISO date is a valid input
+		const output = await getStats.run({ orgId: 'org-1', createdSince: '2025-01-01' }, {
+			session,
+			orgId: 'org-1',
+			sessions: [session],
+		} satisfies CapabilityContext);
+		assert.ok(output.includes('succeeded: 1'), 'should return stats output');
+	});
+
+	test('buddy_resolve_reference rejects a missing modelType with the generic message', async () => {
+		const { session } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		const resolveReference = getCapability('buddy_resolve_reference');
+		assert.ok(resolveReference, 'buddy_resolve_reference is registered');
+
+		await assert.rejects(
+			() =>
+				resolveReference.run({ orgId: 'org-1' }, {
+					session,
+					orgId: 'org-1',
+					sessions: [session],
+				} satisfies CapabilityContext),
+			/Missing required string argument "modelType"\./,
+		);
+	});
+
+	test('buddy_get_template rejects a missing templateId', async () => {
+		const { session } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		const getTemplate = getCapability('buddy_get_template');
+		assert.ok(getTemplate, 'buddy_get_template is registered');
+
+		await assert.rejects(
+			() =>
+				getTemplate.run({ orgId: 'org-1' }, {
+					session,
+					orgId: 'org-1',
+					sessions: [session],
+				} satisfies CapabilityContext),
+			/Missing required string argument "templateId"\./,
+		);
+	});
+
+	test('buddy_graphql_query rejects a non-object variables value (array)', async () => {
+		const { session } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		const graphqlQuery = getCapability('buddy_graphql_query');
+		assert.ok(graphqlQuery, 'buddy_graphql_query is registered');
+
+		await assert.rejects(
+			() =>
+				graphqlQuery.run({ orgId: 'org-1', query: '{ workflows { id } }', variables: ['a'] }, {
+					session,
+					orgId: 'org-1',
+					sessions: [session],
+				} satisfies CapabilityContext),
+			/./,
+			'should reject when variables is an array',
+		);
+	});
 });

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -1,14 +1,17 @@
+import { z } from 'zod';
 import { runReadonlyGraphql } from '../ui/chat/tools/graphqlTool';
 import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
 import {
-	asPositiveInt,
-	asString,
 	mapWithConcurrency,
-	ORG_ID_PROP,
+	optionalClampedInt,
+	optionalStringField,
+	ORG_ID_FIELD,
+	parseCapabilityInput,
 	rawGraphqlOrThrow,
-	requireString,
+	requiredStringField,
+	toInputSchema,
 } from './inputHelpers';
 
 /**
@@ -56,279 +59,228 @@ const LOCAL_REFERENCE_MODELS = [
 ] as const;
 
 /** Lists every org reachable through the active sessions; needs no org id. */
+const listOrgsInputSchema = z.object({});
 const listOrgsSpec: ToolSpec = {
 	name: 'buddy_list_orgs',
 	args: '{}',
 	description:
 		'List the Rewst organizations reachable through the signed-in VS Code sessions, with their ids and names. Call this first to learn which orgId to pass to the other tools.',
-	inputSchema: { type: 'object', properties: {} },
+	inputSchema: toInputSchema(listOrgsInputSchema),
 };
 
+const listTemplatesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
 const listTemplatesSpec: ToolSpec = {
 	name: 'buddy_list_templates',
 	args: '{"orgId": string}',
 	description: 'List the templates in one Rewst organization (id and name). Use buddy_get_template for a full body.',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listTemplatesInputSchema),
 };
 
+const getTemplateInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	templateId: requiredStringField('templateId').describe('Template id to fetch.'),
+});
 const getTemplateSpec: ToolSpec = {
 	name: 'buddy_get_template',
 	args: '{"orgId": string, "templateId": string}',
 	description: 'Get one Rewst template, including its body, by org and template id.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			templateId: { type: 'string', description: 'Template id to fetch.' },
-		},
-		required: ['orgId', 'templateId'],
-	},
+	inputSchema: toInputSchema(getTemplateInputSchema),
 };
 
+const listWorkflowsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional case-insensitive name filter.'),
+	limit: optionalClampedInt(MAX_WORKFLOW_LIMIT).describe(
+		`Max workflows to return (default ${DEFAULT_WORKFLOW_LIMIT}).`,
+	),
+});
 const listWorkflowsSpec: ToolSpec = {
 	name: 'buddy_list_workflows',
 	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'List workflows in one Rewst organization (id, name, description). Optionally filter by a name search and cap the count.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional case-insensitive name filter.' },
-			limit: { type: 'number', description: `Max workflows to return (default ${DEFAULT_WORKFLOW_LIMIT}).` },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listWorkflowsInputSchema),
 };
 
+const listOrgVariablesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional case-insensitive name substring filter.'),
+	limit: optionalClampedInt(MAX_ORG_VARIABLE_LIMIT).describe(
+		`Max variables to return (default ${DEFAULT_ORG_VARIABLE_LIMIT}, max ${MAX_ORG_VARIABLE_LIMIT}).`,
+	),
+});
 const listOrgVariablesSpec: ToolSpec = {
 	name: 'buddy_list_org_variables',
 	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'List configuration variables for one Rewst organization (name, value, category, cascade). Secret-category values are returned masked. Optionally filter by a case-insensitive name substring.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional case-insensitive name substring filter.' },
-			limit: {
-				type: 'number',
-				description: `Max variables to return (default ${DEFAULT_ORG_VARIABLE_LIMIT}, max ${MAX_ORG_VARIABLE_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listOrgVariablesInputSchema),
 };
 
+const listWorkflowExecutionsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	status: optionalStringField().describe('Optional exact execution status filter.'),
+	limit: optionalClampedInt(MAX_EXECUTION_LIMIT).describe(
+		`Max executions to return (default ${DEFAULT_EXECUTION_LIMIT}, max ${MAX_EXECUTION_LIMIT}).`,
+	),
+});
 const listWorkflowExecutionsSpec: ToolSpec = {
 	name: 'buddy_list_workflow_executions',
 	args: '{"orgId": string, "status"?: string, "limit"?: number}',
 	description:
 		'List recent workflow executions for one Rewst organization (id, status, workflowId, createdAt, numSuccessfulTasks), newest first. Optionally filter by an exact status (e.g. succeeded, failed, running). createdAt is an epoch-millisecond string.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			status: { type: 'string', description: 'Optional exact execution status filter.' },
-			limit: {
-				type: 'number',
-				description: `Max executions to return (default ${DEFAULT_EXECUTION_LIMIT}, max ${MAX_EXECUTION_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listWorkflowExecutionsInputSchema),
 };
 
+const findExecutionsByVariableInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: requiredStringField('workflowId').describe('The workflow whose executions to scan.'),
+	name: requiredStringField('name').describe('Case-insensitive substring matched against variable names.'),
+	kind: z
+		.enum(['input', 'output', 'context'])
+		.catch('input')
+		.describe("Which variable surface to search: input (default), output, or context (the run's CTX)."),
+	value: optionalStringField().describe(
+		"Optional case-insensitive substring the matched variable's value must contain.",
+	),
+	limit: optionalClampedInt(MAX_EXECUTION_LIMIT).describe(
+		`Max executions to scan, most-recent first (default ${DEFAULT_EXECUTION_LIMIT}, max ${MAX_EXECUTION_LIMIT}). For kind=context this is also the number of extra context requests issued.`,
+	),
+});
 const findExecutionsByVariableSpec: ToolSpec = {
 	name: 'buddy_find_executions_by_variable',
 	args: '{"orgId": string, "workflowId": string, "name": string, "kind"?: "input"|"output"|"context", "value"?: string, "limit"?: number}',
 	description:
 		"Find executions of ONE Rewst workflow whose input, output, or context variable matches a name (and optionally a value). Scans the most-recently-created executions of the given workflow and filters client-side. kind selects which variable surface to search: input (the values the run was started with), output (the values it produced — absent until a run completes), or context (the run's CTX). name is matched case-insensitively as a substring against variable names; pass value to also require the variable's value to contain that text. Returns one line per matching execution with its id, status, created time, and the matched variable(s). Both orgId and workflowId are required — there is no way to search executions across a whole org by variable, and kind=context issues one extra request per scanned execution.",
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			workflowId: { type: 'string', description: 'The workflow whose executions to scan.' },
-			name: { type: 'string', description: 'Case-insensitive substring matched against variable names.' },
-			kind: {
-				type: 'string',
-				enum: ['input', 'output', 'context'],
-				description: "Which variable surface to search: input (default), output, or context (the run's CTX).",
-			},
-			value: {
-				type: 'string',
-				description: "Optional case-insensitive substring the matched variable's value must contain.",
-			},
-			limit: {
-				type: 'number',
-				description: `Max executions to scan, most-recent first (default ${DEFAULT_EXECUTION_LIMIT}, max ${MAX_EXECUTION_LIMIT}). For kind=context this is also the number of extra context requests issued.`,
-			},
-		},
-		required: ['orgId', 'workflowId', 'name'],
-	},
+	inputSchema: toInputSchema(findExecutionsByVariableInputSchema),
 };
 
+const listWorkflowTasksInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: requiredStringField('workflowId').describe('Workflow id whose tasks to list.'),
+	limit: optionalClampedInt(MAX_TASK_LIMIT).describe(
+		`Max tasks to return (default ${DEFAULT_TASK_LIMIT}, max ${MAX_TASK_LIMIT}).`,
+	),
+});
 const listWorkflowTasksSpec: ToolSpec = {
 	name: 'buddy_list_workflow_tasks',
 	args: '{"orgId": string, "workflowId": string, "limit"?: number}',
 	description:
 		'List the tasks (steps) in one Rewst workflow (id, name, actionId, mocked marker only when a task is mocked, timeout, description). Task ids are dash-less hex strings.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			workflowId: { type: 'string', description: 'Workflow id whose tasks to list.' },
-			limit: {
-				type: 'number',
-				description: `Max tasks to return (default ${DEFAULT_TASK_LIMIT}, max ${MAX_TASK_LIMIT}).`,
-			},
-		},
-		required: ['orgId', 'workflowId'],
-	},
+	inputSchema: toInputSchema(listWorkflowTasksInputSchema),
 };
 
+const listWorkflowPatchesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: requiredStringField('workflowId').describe('Workflow id whose patch history to list.'),
+	limit: optionalClampedInt(MAX_PATCH_LIMIT).describe(
+		`Max patches to return (default ${DEFAULT_PATCH_LIMIT}, max ${MAX_PATCH_LIMIT}).`,
+	),
+});
 const listWorkflowPatchesSpec: ToolSpec = {
 	name: 'buddy_list_workflow_patches',
 	args: '{"orgId": string, "workflowId": string, "limit"?: number}',
 	description:
 		'List the revision history (patch metadata) for one Rewst workflow, newest first (id, patchType, comment, createdAt). Use buddy_get_workflow_patch with a patch id to see the actual change. createdAt is an epoch-millisecond string.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			workflowId: { type: 'string', description: 'Workflow id whose patch history to list.' },
-			limit: {
-				type: 'number',
-				description: `Max patches to return (default ${DEFAULT_PATCH_LIMIT}, max ${MAX_PATCH_LIMIT}).`,
-			},
-		},
-		required: ['orgId', 'workflowId'],
-	},
+	inputSchema: toInputSchema(listWorkflowPatchesInputSchema),
 };
 
+const getWorkflowPatchInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	patchId: requiredStringField('patchId').describe('Workflow patch id to fetch.'),
+});
 const getWorkflowPatchSpec: ToolSpec = {
 	name: 'buddy_get_workflow_patch',
 	args: '{"orgId": string, "patchId": string}',
 	description:
 		'Get one Rewst workflow patch by id, including `patch` — the actual change as an RFC-6902 JSON Patch array. Pair with buddy_list_workflow_patches to find a patch id.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			patchId: { type: 'string', description: 'Workflow patch id to fetch.' },
-		},
-		required: ['orgId', 'patchId'],
-	},
+	inputSchema: toInputSchema(getWorkflowPatchInputSchema),
 };
 
+const latestWorkflowExecutionInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: requiredStringField('workflowId').describe('Workflow id to inspect.'),
+	status: optionalStringField().describe('Optional exact execution status constraint.'),
+});
 const latestWorkflowExecutionSpec: ToolSpec = {
 	name: 'buddy_latest_workflow_execution',
 	args: '{"orgId": string, "workflowId": string, "status"?: string}',
 	description:
 		'Get the most recent execution of one workflow in a Rewst organization (id, status, createdAt, task counts). Optionally constrain to a specific status.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			workflowId: { type: 'string', description: 'Workflow id to inspect.' },
-			status: { type: 'string', description: 'Optional exact execution status constraint.' },
-		},
-		required: ['orgId', 'workflowId'],
-	},
+	inputSchema: toInputSchema(latestWorkflowExecutionInputSchema),
 };
 
+const getWorkflowExecutionStatsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	createdSince: requiredStringField('createdSince').describe(
+		'ISO-8601 date string such as 2025-01-01 or 2025-01-01T00:00:00Z.',
+	),
+});
 const getWorkflowExecutionStatsSpec: ToolSpec = {
 	name: 'buddy_get_workflow_execution_stats',
 	args: '{"orgId": string, "createdSince": string}',
 	description:
 		'Get aggregate workflow-execution status counts for one Rewst organization since a date (succeeded, failed, running, pending, paused, delayed, humanSecondsSaved). createdSince must be an ISO-8601 date string (e.g. 2025-01-01 or 2025-01-01T00:00:00Z) — epoch milliseconds are rejected.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			createdSince: {
-				type: 'string',
-				description: 'ISO-8601 date string such as 2025-01-01 or 2025-01-01T00:00:00Z.',
-			},
-		},
-		required: ['orgId', 'createdSince'],
-	},
+	inputSchema: toInputSchema(getWorkflowExecutionStatsInputSchema),
 };
 
+const findActionInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	filter: optionalStringField().describe(
+		"Optional text matched case-insensitively against the action's display name.",
+	),
+	limit: optionalClampedInt(MAX_ACTION_LIMIT).describe(
+		`Max flattened actions to return (default ${DEFAULT_ACTION_LIMIT}, max ${MAX_ACTION_LIMIT}).`,
+	),
+});
 const findActionSpec: ToolSpec = {
 	name: 'buddy_find_action',
 	args: '{"orgId": string, "filter"?: string, "limit"?: number}',
 	description:
 		"Search the actions available in one Rewst organization's installed packs. The filter is matched case-insensitively against each action's display name. Returns one line per match — `<ref> (<id>) — <pack>: <description>` — where `<id>` is the action id and `<ref>` is its callable reference; rows with no ref (workflow-as-action entries) show the action name in place of the ref. Capped to `limit`; omitting the filter returns many results, so prefer a filter. For the platform-wide action catalog rather than this org's installed packs, use buddy_action_search.",
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			filter: {
-				type: 'string',
-				description: "Optional text matched case-insensitively against the action's display name.",
-			},
-			limit: {
-				type: 'number',
-				description: `Max flattened actions to return (default ${DEFAULT_ACTION_LIMIT}, max ${MAX_ACTION_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(findActionInputSchema),
 };
 
+const resolveReferenceInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	modelType: z.enum(LOCAL_REFERENCE_MODELS).describe('Which kind of Rewst object to resolve.'),
+	search: optionalStringField().describe('Optional case-insensitive name substring filter.'),
+	limit: optionalClampedInt(MAX_REFERENCE_LIMIT).describe(
+		`Max references to return (default ${DEFAULT_REFERENCE_LIMIT}, max ${MAX_REFERENCE_LIMIT}).`,
+	),
+});
 const resolveReferenceSpec: ToolSpec = {
 	name: 'buddy_resolve_reference',
 	args: '{"orgId": string, "modelType": string, "search"?: string, "limit"?: number}',
 	description:
 		'Resolve Rewst object names to ids for one organization and a model type (Workflow, Template, Trigger, Form, Organization, User, Role, PackConfig, Site, Page, Crate, CustomDatabase, TemplateExport). Optionally filter by a case-insensitive name substring. Returns matching options as name (id). Use this when you have a name and need the id.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			modelType: {
-				type: 'string',
-				enum: LOCAL_REFERENCE_MODELS,
-				description: 'Which kind of Rewst object to resolve.',
-			},
-			search: { type: 'string', description: 'Optional case-insensitive name substring filter.' },
-			limit: {
-				type: 'number',
-				description: `Max references to return (default ${DEFAULT_REFERENCE_LIMIT}, max ${MAX_REFERENCE_LIMIT}).`,
-			},
-		},
-		required: ['orgId', 'modelType'],
-	},
+	inputSchema: toInputSchema(resolveReferenceInputSchema),
 };
 
+const getWorkflowInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: requiredStringField('workflowId').describe('Workflow id to fetch.'),
+});
 const getWorkflowSpec: ToolSpec = {
 	name: 'buddy_get_workflow',
 	args: '{"orgId": string, "workflowId": string}',
 	description: 'Get one Rewst workflow (metadata and triggers) by org and workflow id.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			workflowId: { type: 'string', description: 'Workflow id to fetch.' },
-		},
-		required: ['orgId', 'workflowId'],
-	},
+	inputSchema: toInputSchema(getWorkflowInputSchema),
 };
 
+const graphqlQueryInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	query: requiredStringField('query').describe('GraphQL query document (no mutations or subscriptions).'),
+	variables: z.record(z.string(), z.unknown()).optional().describe('Optional GraphQL variables.'),
+});
 const graphqlQuerySpec: ToolSpec = {
 	name: 'buddy_graphql_query',
 	args: '{"orgId": string, "query": string, "variables"?: object}',
 	description:
 		"Run a read-only GraphQL query against one Rewst organization with the user's session. Only query operations are allowed; mutations and subscriptions are rejected. Use this for data the dedicated read tools do not cover (executions, integrations, variables, and so on).",
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			query: { type: 'string', description: 'GraphQL query document (no mutations or subscriptions).' },
-			variables: { type: 'object', description: 'Optional GraphQL variables.' },
-		},
-		required: ['orgId', 'query'],
-	},
+	inputSchema: toInputSchema(graphqlQueryInputSchema),
 };
 
 // GraphQL for workflow reads: the typed SDK has no workflow operations, so these
@@ -489,7 +441,7 @@ async function runListOrgs(_input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListTemplates(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listTemplatesInputSchema, input);
 	const response = await ctx.session.sdk?.listTemplates({ orgId });
 	const templates = response?.templates ?? [];
 	if (templates.length === 0) return 'No templates found for this organization.';
@@ -502,8 +454,7 @@ async function runListTemplates(input: Record<string, unknown>, ctx: CapabilityC
 }
 
 async function runGetTemplate(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const templateId = requireString(input, 'templateId');
+	const { orgId, templateId } = parseCapabilityInput(getTemplateInputSchema, input);
 	const template = await ctx.session.getTemplate(templateId);
 	// A session can manage several orgs, so a bare id lookup can cross org
 	// boundaries; enforce the requested orgId against the returned resource.
@@ -516,9 +467,8 @@ async function runGetTemplate(input: Record<string, unknown>, ctx: CapabilityCon
 }
 
 async function runListWorkflows(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_WORKFLOW_LIMIT, MAX_WORKFLOW_LIMIT);
+	const { orgId, search, limit: rawLimit } = parseCapabilityInput(listWorkflowsInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_WORKFLOW_LIMIT;
 	const variables: Record<string, unknown> = { orgId, limit };
 	if (search) variables.search = { name: { _ilike: `%${search}%` } };
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOWS_QUERY, variables);
@@ -537,9 +487,8 @@ async function runListWorkflows(input: Record<string, unknown>, ctx: CapabilityC
 }
 
 async function runListOrgVariables(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_ORG_VARIABLE_LIMIT, MAX_ORG_VARIABLE_LIMIT);
+	const { orgId, search, limit: rawLimit } = parseCapabilityInput(listOrgVariablesInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_ORG_VARIABLE_LIMIT;
 	const variables: Record<string, unknown> = { orgId, limit };
 	if (search) variables.search = { name: { _ilike: `%${search}%` } };
 	const data = await rawGraphqlOrThrow(ctx.session, ORG_VARIABLES_QUERY, variables);
@@ -559,9 +508,8 @@ async function runListOrgVariables(input: Record<string, unknown>, ctx: Capabili
 }
 
 async function runListWorkflowExecutions(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_EXECUTION_LIMIT, MAX_EXECUTION_LIMIT);
-	const status = asString(input, 'status');
+	const { orgId, status, limit: rawLimit } = parseCapabilityInput(listWorkflowExecutionsInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_EXECUTION_LIMIT;
 	const variables: Record<string, unknown> = { orgId, limit };
 	if (status) variables.search = { status: { _eq: status } };
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_EXECUTIONS_QUERY, variables);
@@ -624,15 +572,17 @@ function matchExecutionVariables(
 }
 
 async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const workflowId = requireString(input, 'workflowId');
-	const rawName = requireString(input, 'name');
+	const {
+		orgId,
+		workflowId,
+		name: rawName,
+		kind,
+		value: valueArg,
+		limit: rawLimit,
+	} = parseCapabilityInput(findExecutionsByVariableInputSchema, input);
 	const nameNeedle = rawName.toLowerCase();
-	const valueArg = asString(input, 'value');
 	const valueNeedle = valueArg ? valueArg.toLowerCase() : undefined;
-	const rawKind = asString(input, 'kind') ?? 'input';
-	const kind: ExecutionVariableKind = rawKind === 'output' || rawKind === 'context' ? rawKind : 'input';
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_EXECUTION_LIMIT, MAX_EXECUTION_LIMIT);
+	const limit = rawLimit ?? DEFAULT_EXECUTION_LIMIT;
 
 	const data = await rawGraphqlOrThrow(ctx.session, EXECUTIONS_WITH_IO_QUERY, { orgId, workflowId, limit });
 	const executions = ((data as { workflowExecutions?: unknown[] } | undefined)?.workflowExecutions ?? []) as {
@@ -685,9 +635,8 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 
 // orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by workflow id alone.
 async function runListWorkflowTasks(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const workflowId = requireString(input, 'workflowId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_TASK_LIMIT, MAX_TASK_LIMIT);
+	const { workflowId, limit: rawLimit } = parseCapabilityInput(listWorkflowTasksInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_TASK_LIMIT;
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_TASKS_QUERY, { workflowId, limit });
 	const workflowTasks = ((data as { workflowTasks?: unknown[] } | undefined)?.workflowTasks ?? []) as {
 		id?: string;
@@ -711,9 +660,8 @@ async function runListWorkflowTasks(input: Record<string, unknown>, ctx: Capabil
 
 // orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by workflow id alone.
 async function runListWorkflowPatches(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const workflowId = requireString(input, 'workflowId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_PATCH_LIMIT, MAX_PATCH_LIMIT);
+	const { workflowId, limit: rawLimit } = parseCapabilityInput(listWorkflowPatchesInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_PATCH_LIMIT;
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_PATCHES_QUERY, { workflowId, limit });
 	const workflowPatches = ((data as { workflowPatches?: unknown[] } | undefined)?.workflowPatches ?? []) as {
 		id?: string;
@@ -736,8 +684,7 @@ async function runListWorkflowPatches(input: Record<string, unknown>, ctx: Capab
 
 // orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by patch id alone.
 async function runGetWorkflowPatch(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const patchId = requireString(input, 'patchId');
+	const { patchId } = parseCapabilityInput(getWorkflowPatchInputSchema, input);
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_PATCH_QUERY, { id: patchId });
 	const workflowPatch = (data as { workflowPatch?: unknown | null } | undefined)?.workflowPatch;
 	if (!workflowPatch) return `No workflow patch found for patch id ${patchId}.`;
@@ -745,9 +692,7 @@ async function runGetWorkflowPatch(input: Record<string, unknown>, ctx: Capabili
 }
 
 async function runLatestWorkflowExecution(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const workflowId = requireString(input, 'workflowId');
-	const status = asString(input, 'status');
+	const { orgId, workflowId, status } = parseCapabilityInput(latestWorkflowExecutionInputSchema, input);
 	const variables: Record<string, unknown> = { orgId, workflowId };
 	if (status) variables.status = status;
 	const data = await rawGraphqlOrThrow(ctx.session, LATEST_WORKFLOW_EXECUTION_QUERY, variables);
@@ -771,11 +716,7 @@ async function runLatestWorkflowExecution(input: Record<string, unknown>, ctx: C
 }
 
 async function runGetWorkflowExecutionStats(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const createdSince = requireString(input, 'createdSince');
-	if (/^\d+$/.test(createdSince)) {
-		throw new Error('createdSince must be an ISO-8601 date string; epoch milliseconds are not supported.');
-	}
+	const { orgId, createdSince } = parseCapabilityInput(getWorkflowExecutionStatsInputSchema, input);
 	const variables = { orgId, createdSince };
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_EXECUTION_STATS_QUERY, variables);
 	const stats = (
@@ -806,9 +747,8 @@ async function runGetWorkflowExecutionStats(input: Record<string, unknown>, ctx:
 }
 
 async function runFindAction(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const filter = asString(input, 'filter');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_ACTION_LIMIT, MAX_ACTION_LIMIT);
+	const { orgId, filter, limit: rawLimit } = parseCapabilityInput(findActionInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_ACTION_LIMIT;
 	const variables: Record<string, unknown> = { orgId };
 	if (filter) variables.filter = filter;
 	const data = await rawGraphqlOrThrow(ctx.session, FIND_ACTION_QUERY, variables);
@@ -851,15 +791,8 @@ async function runFindAction(input: Record<string, unknown>, ctx: CapabilityCont
 }
 
 async function runResolveReference(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const modelType = requireString(input, 'modelType');
-	if (!LOCAL_REFERENCE_MODELS.includes(modelType as (typeof LOCAL_REFERENCE_MODELS)[number])) {
-		throw new Error(
-			`Invalid modelType "${modelType}". Valid modelType values: ${LOCAL_REFERENCE_MODELS.join(', ')}`,
-		);
-	}
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_REFERENCE_LIMIT, MAX_REFERENCE_LIMIT);
+	const { orgId, modelType, search, limit: rawLimit } = parseCapabilityInput(resolveReferenceInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_REFERENCE_LIMIT;
 	const variables: Record<string, unknown> = { orgId, modelName: modelType, limit };
 	if (search) variables.search = search;
 	const data = await rawGraphqlOrThrow(ctx.session, RESOLVE_REFERENCE_QUERY, variables);
@@ -874,8 +807,7 @@ async function runResolveReference(input: Record<string, unknown>, ctx: Capabili
 }
 
 async function runGetWorkflow(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const workflowId = requireString(input, 'workflowId');
+	const { orgId, workflowId } = parseCapabilityInput(getWorkflowInputSchema, input);
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_QUERY, { id: workflowId });
 	const workflow = (data as { workflow?: { orgId?: unknown } } | undefined)?.workflow;
 	if (!workflow) throw new Error(`Workflow not found: ${workflowId}`);
@@ -888,8 +820,7 @@ async function runGetWorkflow(input: Record<string, unknown>, ctx: CapabilityCon
 }
 
 async function runGraphqlQuery(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const query = requireString(input, 'query');
+	const { orgId, query, variables: parsedVariables } = parseCapabilityInput(graphqlQueryInputSchema, input);
 	const rawVariables = input.variables;
 	if (
 		rawVariables !== undefined &&

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -140,8 +140,11 @@ const findExecutionsByVariableInputSchema = z.object({
 	name: requiredStringField('name').describe('Case-insensitive substring matched against variable names.'),
 	kind: z
 		.enum(['input', 'output', 'context'])
-		.catch('input')
+		.optional()
+		.catch('input' as 'input' | 'output' | 'context')
 		.describe("Which variable surface to search: input (default), output, or context (the run's CTX)."),
+	// Note: .optional() before .catch() keeps 'kind' out of the JSON Schema
+	// required array while still defaulting to 'input' at runtime via .catch().
 	value: optionalStringField().describe(
 		"Optional case-insensitive substring the matched variable's value must contain.",
 	),
@@ -576,10 +579,11 @@ async function runFindExecutionsByVariable(input: Record<string, unknown>, ctx: 
 		orgId,
 		workflowId,
 		name: rawName,
-		kind,
+		kind: rawKind,
 		value: valueArg,
 		limit: rawLimit,
 	} = parseCapabilityInput(findExecutionsByVariableInputSchema, input);
+	const kind: ExecutionVariableKind = rawKind ?? 'input';
 	const nameNeedle = rawName.toLowerCase();
 	const valueNeedle = valueArg ? valueArg.toLowerCase() : undefined;
 	const limit = rawLimit ?? DEFAULT_EXECUTION_LIMIT;
@@ -717,6 +721,12 @@ async function runLatestWorkflowExecution(input: Record<string, unknown>, ctx: C
 
 async function runGetWorkflowExecutionStats(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	const { orgId, createdSince } = parseCapabilityInput(getWorkflowExecutionStatsInputSchema, input);
+	// Reject epoch-millisecond strings (all-digit, 13+ chars) — the API only accepts ISO-8601.
+	if (/^\d{13,}$/.test(createdSince)) {
+		throw new Error(
+			'epoch milliseconds are not supported; use an ISO-8601 date string such as 2025-01-01 or 2025-01-01T00:00:00Z.',
+		);
+	}
 	const variables = { orgId, createdSince };
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_EXECUTION_STATS_QUERY, variables);
 	const stats = (
@@ -791,6 +801,16 @@ async function runFindAction(input: Record<string, unknown>, ctx: CapabilityCont
 }
 
 async function runResolveReference(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	// Provide friendly errors for missing/invalid modelType before Zod's generic enum message.
+	const rawModelType = input.modelType;
+	if (rawModelType === undefined || rawModelType === null || rawModelType === '') {
+		throw new Error('Missing required string argument "modelType".');
+	}
+	if (!LOCAL_REFERENCE_MODELS.includes(rawModelType as (typeof LOCAL_REFERENCE_MODELS)[number])) {
+		throw new Error(
+			`Invalid modelType "${rawModelType}". Valid modelType values: ${LOCAL_REFERENCE_MODELS.join(', ')}`,
+		);
+	}
 	const { orgId, modelType, search, limit: rawLimit } = parseCapabilityInput(resolveReferenceInputSchema, input);
 	const limit = rawLimit ?? DEFAULT_REFERENCE_LIMIT;
 	const variables: Record<string, unknown> = { orgId, modelName: modelType, limit };

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -58,6 +58,11 @@ const LOCAL_REFERENCE_MODELS = [
 	'Page',
 ] as const;
 
+const modelTypeMessage = (received: unknown) =>
+	received === undefined || received === null || received === ''
+		? 'Missing required string argument "modelType".'
+		: `Invalid modelType "${String(received)}". Valid modelType values: ${LOCAL_REFERENCE_MODELS.join(', ')}`;
+
 /** Lists every org reachable through the active sessions; needs no org id. */
 const listOrgsInputSchema = z.object({});
 const listOrgsSpec: ToolSpec = {
@@ -217,9 +222,11 @@ const latestWorkflowExecutionSpec: ToolSpec = {
 
 const getWorkflowExecutionStatsInputSchema = z.object({
 	orgId: ORG_ID_FIELD,
-	createdSince: requiredStringField('createdSince').describe(
-		'ISO-8601 date string such as 2025-01-01 or 2025-01-01T00:00:00Z.',
-	),
+	createdSince: requiredStringField('createdSince')
+		.refine(value => !/^\d+$/.test(value), {
+			error: 'createdSince must be an ISO-8601 date string; epoch milliseconds are not supported.',
+		})
+		.describe('ISO-8601 date string such as 2025-01-01 or 2025-01-01T00:00:00Z.'),
 });
 const getWorkflowExecutionStatsSpec: ToolSpec = {
 	name: 'buddy_get_workflow_execution_stats',
@@ -248,7 +255,12 @@ const findActionSpec: ToolSpec = {
 
 const resolveReferenceInputSchema = z.object({
 	orgId: ORG_ID_FIELD,
-	modelType: z.enum(LOCAL_REFERENCE_MODELS).describe('Which kind of Rewst object to resolve.'),
+	modelType: z
+		.preprocess(
+			raw => (typeof raw === 'string' ? raw.trim() : raw),
+			z.enum(LOCAL_REFERENCE_MODELS, { error: issue => modelTypeMessage(issue.input) }),
+		)
+		.describe('Which kind of Rewst object to resolve.'),
 	search: optionalStringField().describe('Optional case-insensitive name substring filter.'),
 	limit: optionalClampedInt(MAX_REFERENCE_LIMIT).describe(
 		`Max references to return (default ${DEFAULT_REFERENCE_LIMIT}, max ${MAX_REFERENCE_LIMIT}).`,
@@ -721,12 +733,6 @@ async function runLatestWorkflowExecution(input: Record<string, unknown>, ctx: C
 
 async function runGetWorkflowExecutionStats(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	const { orgId, createdSince } = parseCapabilityInput(getWorkflowExecutionStatsInputSchema, input);
-	// Reject epoch-millisecond strings (all-digit, 13+ chars) — the API only accepts ISO-8601.
-	if (/^\d{13,}$/.test(createdSince)) {
-		throw new Error(
-			'epoch milliseconds are not supported; use an ISO-8601 date string such as 2025-01-01 or 2025-01-01T00:00:00Z.',
-		);
-	}
 	const variables = { orgId, createdSince };
 	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_EXECUTION_STATS_QUERY, variables);
 	const stats = (
@@ -801,16 +807,6 @@ async function runFindAction(input: Record<string, unknown>, ctx: CapabilityCont
 }
 
 async function runResolveReference(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	// Provide friendly errors for missing/invalid modelType before Zod's generic enum message.
-	const rawModelType = input.modelType;
-	if (rawModelType === undefined || rawModelType === null || rawModelType === '') {
-		throw new Error('Missing required string argument "modelType".');
-	}
-	if (!LOCAL_REFERENCE_MODELS.includes(rawModelType as (typeof LOCAL_REFERENCE_MODELS)[number])) {
-		throw new Error(
-			`Invalid modelType "${rawModelType}". Valid modelType values: ${LOCAL_REFERENCE_MODELS.join(', ')}`,
-		);
-	}
 	const { orgId, modelType, search, limit: rawLimit } = parseCapabilityInput(resolveReferenceInputSchema, input);
 	const limit = rawLimit ?? DEFAULT_REFERENCE_LIMIT;
 	const variables: Record<string, unknown> = { orgId, modelName: modelType, limit };


### PR DESCRIPTION
## Summary

Migrates all 16 read-capability `run()` functions from ad-hoc `requireString`/`asString`/`asPositiveInt` helpers to a unified `parseCapabilityInput(schema, input)` pattern backed by Zod schemas. The advertised `inputSchema` is now derived from the same Zod schema via `toInputSchema`, so advertisement and enforcement are always in sync.

## Changes

- **`inputHelpers.ts`**: adds `parseCapabilityInput`, `toInputSchema`, `requiredStringField`, `optionalStringField`, `optionalClampedInt`, `ORG_ID_FIELD` exports; drops `.int()` from `optionalClampedInt` to keep JSON Schema type as `"number"` (matching legacy)
- **`rewstReadCapabilities.ts`**: all 16 capabilities migrated; custom pre-parse guards for `modelType` (friendly enum errors) and `createdSince` (epoch-ms rejection)
- **`rewstReadCapabilities.schemaParity.test.ts`**: new frozen-fixture parity test (16 tools × 4 checks = 64 assertions) — switched from `tdd.ts` to Mocha directly so it runs on the electron runner
- **`rewstReadCapabilities.test.ts`**: new capability-level tests covering happy paths, error messages, and edge cases
- **`openspec/specs/mcp-bridge/spec.md`**: updated "Validate tool inputs defensively" requirement to reflect schema-driven approach; added invalid-enum and missing-field scenarios
- **`CLAUDE.md`**: updated capability authoring guidance to document `parseCapabilityInput` pattern
- **`changelog.d/c2-zod-validation-foundation.md`**: changelog entry

## Test results

- vitest: 175 passing (9 files)
- electron unit grep `Unit: rewstReadCapabilities`: 90 passing
- type-check: clean
- changelog: valid

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Tool input validation is now more consistent across read-only tools, with clearer, human-readable error messages when arguments are missing or invalid.
  * Numeric inputs are now handled more predictably, including automatic clamping and safer defaults for out-of-range values.

* **Bug Fixes**
  * Fixed several cases where malformed inputs could produce confusing validation output.
  * Improved handling of string trimming, enum checks, dates, and query variables so tools behave more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->