### PR TITLE
Fix managed-org scope regression: index union of managedOrgs and sub-org tree

### DIFF
--- a/changelog.d/managed-org-scope-union.md
+++ b/changelog.d/managed-org-scope-union.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Restored access to all directly managed orgs.** The recent sub-org scoping fix accidentally replaced the managed-org list instead of extending it, so tools could no longer find orgs outside your own org's tree. Sessions now index the union of both sets.

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -173,10 +173,13 @@ reloaded. A successful refresh SHALL reset the consecutive-failure counter.
 
 ### Requirement: Manage multiple organizations per session
 
-The system SHALL treat one login as managing a primary organization plus all of
-its managed sub-organizations, including nested descendants, and SHALL resolve
-the correct session for any given organization id by checking both the primary
-org and all managed orgs. When a base URL or region is available, session
+The system SHALL treat one login as managing a primary organization plus the
+union of two org sets from the login profile: every organization the user
+directly manages (which can span orgs outside the primary org's tree) and the
+primary organization's recursive sub-org tree, including nested descendants.
+Neither set is a superset of the other, so dropping either narrows reach. The
+system SHALL resolve the correct session for any given organization id by
+checking both the primary org and all managed orgs. When a base URL or region is available, session
 resolution SHALL first narrow to active sessions in that region and then match
 the requested org against primary and managed org ids. More than one active
 session being able to manage the same org id is not an error: resolution SHALL
@@ -196,6 +199,13 @@ next capable session only if it remains invalid after that refresh attempt.
 - **GIVEN** a session whose login manages a parent org, a direct child, and a
   deeper descendant
 - **WHEN** an operation references the grandchild org id
+- **THEN** the extension selects the same session
+
+#### Scenario: Operation targets a directly managed org outside the primary org's tree
+
+- **GIVEN** a login whose directly managed orgs include an org that is not in
+  the primary organization's sub-org tree
+- **WHEN** an operation references that org id
 - **THEN** the extension selects the same session
 
 #### Scenario: Duplicate org id resolves to the first capable session

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -467,6 +467,60 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(await SessionManager.getSessionForOrg('org-grandchild'), session);
 		});
 
+		test('managed org set is the union of managedOrgs and the recursive sub-org tree', async () => {
+			const server = createServer((request, response) => {
+				request.on('data', () => {});
+				request.on('end', () => {
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(
+						JSON.stringify({
+							data: {
+								user: {
+									id: 'user-union',
+									username: 'union-user',
+									organization: {
+										id: 'org-root',
+										name: 'Root',
+										managedAndSubOrgs: [{ id: 'org-own-sub', name: 'Own Sub-Org' }],
+									},
+									allManagedOrgs: [{ id: 'org-managed-only', name: 'Managed Elsewhere' }],
+									roleIds: [],
+								},
+							},
+						}),
+					);
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			await vscode.workspace.getConfiguration('rewst-buddy').update(
+				'regions',
+				[
+					{
+						name: 'Local Test',
+						cookieName: 'appSession',
+						graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+						loginUrl: `http://127.0.0.1:${port}`,
+					},
+				],
+				vscode.ConfigurationTarget.Global,
+			);
+
+			const session = await SessionManager.createSession('raw-test-token');
+
+			assert.strictEqual(
+				await SessionManager.getSessionForOrg('org-managed-only'),
+				session,
+				'an org present only in managedOrgs must stay reachable when managedAndSubOrgs is also returned',
+			);
+			assert.strictEqual(
+				await SessionManager.getSessionForOrg('org-own-sub'),
+				session,
+				'a sub-org present only in the recursive tree must be reachable',
+			);
+		});
+
 		test('empty input is rejected and no session is created', async () => {
 			const unstub = stubShowInputBox(async () => '');
 

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -111,10 +111,14 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 			throw log.notifyError('createSession: user has no organization');
 		}
 
-		const managedOrgRows = user.organization?.managedAndSubOrgs ?? user.allManagedOrgs;
-		if (managedOrgRows === undefined) {
+		// Two distinct scopes that only overlap partially: allManagedOrgs is every
+		// org the user directly manages (flat, can span other MSP trees), while
+		// managedAndSubOrgs is the recursive sub-org tree of the user's own org.
+		// Sessions must reach both, so index their union.
+		if (user.allManagedOrgs === undefined && user.organization?.managedAndSubOrgs === undefined) {
 			throw log.notifyError('createSession: user has no managed orgs');
 		}
+		const managedOrgRows = [...(user.allManagedOrgs ?? []), ...(user.organization?.managedAndSubOrgs ?? [])];
 
 		const org: Org = {
 			id: user.organization?.id ?? '',


### PR DESCRIPTION
## Summary

Fixes a scope regression introduced by the #143/#148 sub-org fix (ecac427). That change replaced `user.allManagedOrgs` with `user.organization.managedAndSubOrgs` (`??` fallback) when building a session's managed-org index. The assumption was that `managedAndSubOrgs` is a recursive superset — live probing shows it is not:

- `me.managedOrgs` — every org the user directly manages (flat; for this account, thousands of orgs spanning multiple MSP trees)
- `me.organization.managedAndSubOrgs` — only the recursive sub-org tree of the user's **own** org (~85 orgs)

Preferring the latter dropped every previously reachable org outside the user's own org tree, so tools (workflow list, execution logs, etc.) could no longer find them.

## Fix

Index the **union** of both sets (plus the primary org, deduped by id). Neither set is a superset of the other, so both are required:

- `allManagedOrgs` restores the pre-#148 reach
- `managedAndSubOrgs` keeps the #143 fix (nested sub-orgs of the user's own org)

## Trio

- **Spec**: `session-auth` `Manage multiple organizations per session` requirement now states the union explicitly, with a new scenario for a directly managed org outside the primary org's tree.
- **Test**: new `SessionManager` unit test reproduces the regression (org present only in `managedOrgs` while `managedAndSubOrgs` is also returned) — red before the fix, green after.
- **Code**: `SessionManager.createSession` builds the org index from both lists.

Full unit suite green.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored access to all organizations a session should manage, including organizations outside the primary organization tree.
  * Organization lookups now check both the primary organization scope and directly managed organizations, improving session resolution.
  * Sessions now resolve the correct account when an operation targets a directly managed organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->