### PR TITLE
C2: migrate remaining read capabilities to Zod input schemas

### DIFF
--- a/changelog.d/2.md
+++ b/changelog.d/2.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 2
+---
+
+- Internal: remaining read/local capability files now derive their advertised input schema from the same Zod schema that validates runtime input (no user-facing behaviour change).

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -479,10 +479,10 @@ message -- never a raw serialized list of every issue.
 Implementation status: as of this requirement's schema-based rewrite,
 `src/capabilities/rewstReadCapabilities.ts` validates through per-capability
 Zod schemas per the contract above (`inputHelpers.ts`'s
-`parseCapabilityInput` + `toInputSchema`). The remaining capability files
-still validate via the hand-rolled `asString`/`requireString`/`asPositiveInt`
-helpers in `inputHelpers.ts`; they migrate to the same schema-based contract
-incrementally in follow-up PRs (epic #129 C2).
+`parseCapabilityInput` + `toInputSchema`). Read/local capabilities outside
+`rewstReadCapabilities.ts` now derive their advertised input schema from the
+same Zod schema that parses runtime input. Write capabilities still use the
+legacy helpers until the follow-up C2 write-capability migration.
 
 ### Requirement: Verify saved task inputs after a workflow edit
 

--- a/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
+++ b/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
@@ -1,0 +1,374 @@
+/**
+ * C2 phase 2 schema parity test — frozen LEGACY_SCHEMAS fixture.
+ *
+ * Captures the hand-written inputSchema objects from the 9 target capability
+ * files exactly as they existed BEFORE the Zod migration. After migration,
+ * the derived schemas are compared field-by-field against this fixture to
+ * ensure no required field was dropped, no type changed, and no description
+ * was silently lost.
+ *
+ * Runner: mocha / extension-host (same suite as rewstReadCapabilities.schemaParity.test.ts).
+ */
+
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
+import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
+import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
+import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
+import { JINJA_DOCS_CAPABILITIES } from './jinjaDocsCapabilities';
+import { resultReadCapability } from './resultReadCapability';
+import { TEMPLATE_LINK_CAPABILITIES } from './templateLinkCapabilities';
+import { TEMPLATE_SYNC_CAPABILITIES } from './templateSyncCapabilities';
+import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
+
+const { suite, test } = Mocha;
+
+// ---------------------------------------------------------------------------
+// Frozen legacy schemas — verbatim copy of the pre-migration inputSchema
+// objects. Do NOT update these when migrating; they are the regression guard.
+// ---------------------------------------------------------------------------
+
+interface LegacyProperty {
+	type: string;
+	description?: string;
+	items?: { type: string };
+	enum?: readonly string[];
+}
+
+interface LegacySchema {
+	properties: Record<string, LegacyProperty>;
+	required?: string[];
+}
+
+const ORG_ID_DESC = 'Rewst organization id the operation runs against (from buddy_list_orgs).';
+
+const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
+	// --- triggerFormCapabilities ---
+	buddy_list_triggers: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max triggers to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_forms: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max forms to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_tags: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max tags to return (default 100, max 500).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_org_trigger_instances: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: {
+				type: 'number',
+				description: 'Max trigger activation instances to return (default 50, max 200).',
+			},
+		},
+		required: ['orgId'],
+	},
+	buddy_get_trigger_error_status: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			triggerIds: { type: 'array', items: { type: 'string' }, description: 'Trigger ids to check.' },
+		},
+		required: ['orgId', 'triggerIds'],
+	},
+	// --- packIntegrationCapabilities ---
+	buddy_list_installed_packs: {
+		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
+		required: ['orgId'],
+	},
+	buddy_get_pack_auth_status: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			packName: { type: 'string', description: 'A pack ref, e.g. microsoft_graph' },
+		},
+		required: ['orgId', 'packName'],
+	},
+	buddy_list_pack_configs: {
+		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
+		required: ['orgId'],
+	},
+	buddy_list_integrations: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max integrations to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	// --- orgUserCapabilities ---
+	buddy_search_organizations: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'integer', description: 'Max organizations to return (default 25, max 100).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_users: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional username substring.' },
+			limit: { type: 'integer', description: 'Max users to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_roles: {
+		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
+		required: ['orgId'],
+	},
+	// --- pageTemplateCapabilities ---
+	buddy_search_templates: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'number', description: 'Max templates to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_pages: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max pages to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_sites: {
+		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
+		required: ['orgId'],
+	},
+	buddy_list_jinja_filters: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'number', description: 'Max filters to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	// --- jinjaDocsCapabilities ---
+	buddy_get_jinja_filter_docs: {
+		properties: {
+			name: {
+				type: 'string',
+				description: 'Exact filter name to fetch full documentation for (case-insensitive).',
+			},
+			search: {
+				type: 'string',
+				description: 'Keyword to match against filter names and documentation.',
+			},
+		},
+		required: [],
+	},
+	// --- resultReadCapability ---
+	buddy_result_read: {
+		properties: {
+			id: { type: 'string', description: 'Cached result id returned by an oversized Rewst Buddy tool result.' },
+			offset: { type: 'number', description: 'Character offset to start reading from (default 0).' },
+			limit: { type: 'number', description: 'Maximum characters to return (default 6000, max 8000).' },
+			search: {
+				type: 'string',
+				description: 'Search text; returns matching lines with line numbers instead of a slice.',
+			},
+		},
+		required: ['id'],
+	},
+	// --- templateLinkCapabilities ---
+	buddy_template_link: {
+		properties: {
+			templateId: {
+				type: 'string',
+				description: 'Id of the existing Rewst template to link the file to (from buddy_list_templates).',
+			},
+			uri: {
+				type: 'string',
+				description:
+					'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
+			},
+			orgId: {
+				type: 'string',
+				description:
+					'Optional org id to verify the template belongs to. Defaults to the template\u2019s own org.',
+			},
+			overwrite: {
+				type: 'boolean',
+				description:
+					'If the file is already linked, replace the existing link instead of failing. Default false.',
+			},
+		},
+		required: ['templateId', 'uri'],
+	},
+	buddy_template_link_status: {
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Absolute path, workspace-relative path, or file:// URI of the local file to check.',
+			},
+		},
+		required: ['uri'],
+	},
+	buddy_template_unlink: {
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Path or file URI of the linked file, as shown by buddy_search_template_links.',
+			},
+		},
+		required: ['uri'],
+	},
+	buddy_template_sync_on_save: {
+		properties: {
+			uri: { type: 'string', description: 'Path or file URI of the linked file.' },
+			enabled: {
+				type: 'boolean',
+				description: 'true to enable sync-on-save (upload on save), false to disable.',
+			},
+		},
+		required: ['uri', 'enabled'],
+	},
+	// --- templateSyncCapabilities (read spec only) ---
+	buddy_template_sync_status: {
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Path or file URI of the linked file, as shown by buddy_search_template_links.',
+			},
+		},
+		required: ['uri'],
+	},
+	// --- templateCloneCapabilities ---
+	buddy_template_bundle_clone: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			rootTemplateId: { type: 'string', description: 'Id of the root template to deep-clone.' },
+			sourceOrgId: {
+				type: 'string',
+				description:
+					'Optional id of the org the root and its references live in. Verified against the root; defaults to the root\u2019s org.',
+			},
+			namePrefix: { type: 'string', description: 'Optional prefix for cloned template names.' },
+			nameSuffix: {
+				type: 'string',
+				description: 'Optional suffix for cloned template names. Defaults to " (copy)".',
+			},
+			maxTemplates: {
+				type: 'number',
+				description: 'Max total templates to clone (root + references). Default 50, capped at 200.',
+			},
+			maxDepth: { type: 'number', description: 'Max reference depth to walk. Default 10, capped at 25.' },
+		},
+		required: ['orgId', 'rootTemplateId'],
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers (same contract as rewstReadCapabilities.schemaParity.test.ts)
+// ---------------------------------------------------------------------------
+
+function getSchema(cap: { spec: { inputSchema?: unknown } }): {
+	properties: Record<string, { type?: string; description?: string; enum?: string[]; items?: unknown }>;
+	required?: string[];
+} {
+	return (cap.spec.inputSchema ?? { properties: {} }) as ReturnType<typeof getSchema>;
+}
+
+function assertSchemaParity(toolName: string, legacy: LegacySchema, derived: ReturnType<typeof getSchema>): void {
+	// 1. required fields match
+	const legacyRequired = new Set(legacy.required ?? []);
+	const derivedRequired = new Set(derived.required ?? []);
+	for (const field of legacyRequired) {
+		assert.ok(derivedRequired.has(field), `${toolName}: required field "${field}" missing from derived schema`);
+	}
+
+	// 2. every legacy property key exists in derived
+	for (const key of Object.keys(legacy.properties)) {
+		assert.ok(key in (derived.properties ?? {}), `${toolName}: property "${key}" missing from derived schema`);
+	}
+
+	// 3. type matches (number/integer both acceptable for integer fields)
+	for (const [key, legacyProp] of Object.entries(legacy.properties)) {
+		const derivedProp = derived.properties[key];
+		if (!derivedProp) continue;
+		const legacyType = legacyProp.type;
+		const derivedType = derivedProp.type;
+		const typesCompatible =
+			legacyType === derivedType ||
+			(legacyType === 'integer' && derivedType === 'number') ||
+			(legacyType === 'number' && derivedType === 'integer');
+		assert.ok(
+			typesCompatible,
+			`${toolName}.${key}: type mismatch — legacy "${legacyType}" vs derived "${derivedType}"`,
+		);
+	}
+
+	// 4. enum values match when present
+	for (const [key, legacyProp] of Object.entries(legacy.properties)) {
+		if (!legacyProp.enum) continue;
+		const derivedProp = derived.properties[key];
+		if (!derivedProp?.enum) continue;
+		const legacyEnums = new Set(legacyProp.enum);
+		const derivedEnums = new Set(derivedProp.enum);
+		for (const v of legacyEnums) {
+			assert.ok(derivedEnums.has(v), `${toolName}.${key}: enum value "${v}" missing from derived schema`);
+		}
+	}
+
+	// 5. description present when legacy had one
+	for (const [key, legacyProp] of Object.entries(legacy.properties)) {
+		if (!legacyProp.description) continue;
+		const derivedProp = derived.properties[key];
+		if (!derivedProp) continue;
+		assert.ok(
+			typeof derivedProp.description === 'string' && derivedProp.description.length > 0,
+			`${toolName}.${key}: description missing from derived schema`,
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Collect all capabilities by tool name
+// ---------------------------------------------------------------------------
+
+const ALL_CAPS = [
+	...TRIGGER_FORM_CAPABILITIES,
+	...PACK_INTEGRATION_CAPABILITIES,
+	...ORG_USER_CAPABILITIES,
+	...PAGE_TEMPLATE_CAPABILITIES,
+	...JINJA_DOCS_CAPABILITIES,
+	resultReadCapability,
+	...TEMPLATE_LINK_CAPABILITIES,
+	...TEMPLATE_SYNC_CAPABILITIES,
+	...TEMPLATE_CLONE_CAPABILITIES,
+];
+
+const capByName = new Map(ALL_CAPS.map(c => [c.spec.name, c]));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+suite('Unit: capabilityInputSchemas schemaParity', () => {
+	for (const [toolName, legacy] of Object.entries(LEGACY_SCHEMAS)) {
+		test(`${toolName} derived schema matches legacy`, () => {
+			const cap = capByName.get(toolName);
+			assert.ok(cap, `${toolName} not found in capability registry`);
+			const derived = getSchema(cap);
+			assertSchemaParity(toolName, legacy, derived);
+			// args must be generated from inputSchema (not hand-written)
+			assert.strictEqual(
+				cap.spec.args,
+				JSON.stringify(cap.spec.inputSchema),
+				`${toolName}: args must equal JSON.stringify(inputSchema)`,
+			);
+		});
+	}
+});

--- a/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
+++ b/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
@@ -12,15 +12,15 @@
 
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
-import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
-import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
-import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 import { JINJA_DOCS_CAPABILITIES } from './jinjaDocsCapabilities';
+import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
+import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
+import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 import { resultReadCapability } from './resultReadCapability';
+import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
 import { TEMPLATE_LINK_CAPABILITIES } from './templateLinkCapabilities';
 import { TEMPLATE_SYNC_CAPABILITIES } from './templateSyncCapabilities';
-import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
+import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 
 const { suite, test } = Mocha;
 

--- a/src/capabilities/jinjaDocsCapabilities.test.ts
+++ b/src/capabilities/jinjaDocsCapabilities.test.ts
@@ -58,6 +58,32 @@ suite('Unit: jinjaDocsCapabilities', () => {
 		_resetJinjaFilterFetcherForTesting();
 	});
 
+	// --- Zod parse tests ---
+	test('non-string name is ignored (not rejected)', async () => {
+		_setJinjaFilterFetcherForTesting(async () => parseJinjaFilters(SAMPLE_PAYLOAD));
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.doesNotReject(() => cap('buddy_get_jinja_filter_docs').run({ name: 42 }, ctx));
+	});
+
+	test('non-string search is ignored (not rejected)', async () => {
+		_setJinjaFilterFetcherForTesting(async () => parseJinjaFilters(SAMPLE_PAYLOAD));
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.doesNotReject(() => cap('buddy_get_jinja_filter_docs').run({ search: 99 }, ctx));
+	});
+
+	test('no-arg call lists filter names', async () => {
+		_setJinjaFilterFetcherForTesting(async () => parseJinjaFilters(SAMPLE_PAYLOAD));
+		const { ctx } = fakeCtx({ data: {} });
+		const output = await cap('buddy_get_jinja_filter_docs').run({}, ctx);
+		assert.ok(output.includes('abs'));
+	});
+
+	test('buddy_get_jinja_filter_docs derived schema has no required fields and args generated', () => {
+		const schema = cap('buddy_get_jinja_filter_docs').spec.inputSchema as { required?: string[] };
+		assert.ok(!schema.required || schema.required.length === 0);
+		assert.strictEqual(cap('buddy_get_jinja_filter_docs').spec.args, JSON.stringify(schema));
+	});
+
 	suite('parseJinjaFilters()', () => {
 		test('parses names, signatures, and documentation; sorts by name', () => {
 			const filters = parseJinjaFilters(SAMPLE_PAYLOAD);

--- a/src/capabilities/jinjaDocsCapabilities.test.ts
+++ b/src/capabilities/jinjaDocsCapabilities.test.ts
@@ -1,17 +1,17 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import type { CapabilityContext } from './Capability';
 import {
 	JINJA_DOCS_CAPABILITIES,
+	_resetJinjaFilterCacheForTesting,
+	_resetJinjaFilterFetcherForTesting,
+	_setJinjaFilterFetcherForTesting,
 	engineBaseFromRegion,
 	formatJinjaFilters,
 	getCachedFilters,
 	parseJinjaFilters,
 	primeFilters,
-	_resetJinjaFilterCacheForTesting,
-	_resetJinjaFilterFetcherForTesting,
-	_setJinjaFilterFetcherForTesting,
 	type JinjaFilterDoc,
 } from './jinjaDocsCapabilities';
 

--- a/src/capabilities/jinjaDocsCapabilities.ts
+++ b/src/capabilities/jinjaDocsCapabilities.ts
@@ -10,10 +10,11 @@
  */
 
 import { log } from '@utils';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asString } from './inputHelpers';
+import { optionalStringField, parseCapabilityInput, toInputSchema } from './inputHelpers';
 
 const FILTERS_PATH = '/jinja/intellisense/filters';
 const DEFAULT_ENGINE_BASE = 'https://engine.rewst.io';
@@ -208,26 +209,22 @@ async function getFilters(ctx: CapabilityContext): Promise<JinjaFilterDoc[]> {
 	return getFiltersForBase(engineBaseFrom(ctx));
 }
 
-const getJinjaFilterDocsSpec: ToolSpec = {
+const getJinjaFilterDocsInputSchema = z.object({
+	name: optionalStringField().describe('Exact filter name to fetch full documentation for (case-insensitive).'),
+	search: optionalStringField().describe('Keyword to match against filter names and documentation.'),
+});
+
+const getJinjaFilterDocsSpec: ToolSpecDefinition = {
 	name: 'buddy_get_jinja_filter_docs',
-	args: '{"name"?: string, "search"?: string}',
 	description:
 		'Read the documentation for Rewst\'s built-in Jinja filters (the same catalog Rewst\'s in-app editor uses, including the prose docs that buddy_list_jinja_filters omits). Pass "name" for one filter\'s full documentation, or "search" to match filters by name or documentation keyword. With no arguments, lists every filter name and signature so you can pick one. Read-only and not org-specific.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			name: {
-				type: 'string',
-				description: 'Exact filter name to fetch full documentation for (case-insensitive).',
-			},
-			search: { type: 'string', description: 'Keyword to match against filter names and documentation.' },
-		},
-	},
+	inputSchema: toInputSchema(getJinjaFilterDocsInputSchema),
 };
 
 async function runGetJinjaFilterDocs(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	const filters = await getFilters(ctx);
-	return formatJinjaFilters(filters, { name: asString(input, 'name'), search: asString(input, 'search') });
+	const { name, search } = parseCapabilityInput(getJinjaFilterDocsInputSchema, input);
+	return formatJinjaFilters(filters, { name, search });
 }
 
 export const JINJA_DOCS_CAPABILITIES: Capability[] = [

--- a/src/capabilities/orgUserCapabilities.test.ts
+++ b/src/capabilities/orgUserCapabilities.test.ts
@@ -1,6 +1,6 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
 const { suite, test, setup } = Mocha;
 const { fakeCtx, cap } = createCapabilityTestHarness(ORG_USER_CAPABILITIES);

--- a/src/capabilities/orgUserCapabilities.test.ts
+++ b/src/capabilities/orgUserCapabilities.test.ts
@@ -7,6 +7,52 @@ const { fakeCtx, cap } = createCapabilityTestHarness(ORG_USER_CAPABILITIES);
 suite('Unit: orgUserCapabilities', () => {
 	setup(() => initTestEnvironment());
 
+	// --- Zod parse tests ---
+	test('missing orgId throws before GraphQL for buddy_list_users', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_list_users').run({}, ctx), /orgId/);
+	});
+
+	test('missing orgId throws before GraphQL for buddy_search_organizations', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_search_organizations').run({}, ctx), /orgId/);
+	});
+
+	test('non-number limit falls back to default for buddy_list_users (no throw)', async () => {
+		const { ctx } = fakeCtx({ data: { users: [] } });
+		await assert.doesNotReject(() => cap('buddy_list_users').run({ orgId: 'org-1', limit: 'bad' }, ctx));
+	});
+
+	test('over-max limit is clamped to 200 for buddy_list_users', async () => {
+		const { ctx, calls } = fakeCtx({ data: { users: [] } });
+		await cap('buddy_list_users').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 200);
+	});
+
+	test('over-max limit is clamped to 100 for buddy_search_organizations', async () => {
+		const { ctx, calls } = fakeCtx({ data: { searchManagedOrgs: [] } });
+		await cap('buddy_search_organizations').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 100);
+	});
+
+	test('buddy_search_organizations derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_search_organizations').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_search_organizations').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_users derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_list_users').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_users').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_roles derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_list_roles').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_roles').spec.args, JSON.stringify(schema));
+	});
+
 	test('buddy_search_organizations forwards name search and formats organizations', async () => {
 		const { ctx, calls } = fakeCtx({
 			data: { searchManagedOrgs: [{ id: 'o1', name: 'Acme', isEnabled: true }] },

--- a/src/capabilities/orgUserCapabilities.ts
+++ b/src/capabilities/orgUserCapabilities.ts
@@ -1,7 +1,15 @@
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asPositiveInt, asString, ORG_ID_PROP, rawGraphqlOrThrow, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	toInputSchema,
+} from './inputHelpers';
 
 const SEARCH_ORGANIZATIONS_QUERY =
 	'query($search: String, $limit: Int){ searchManagedOrgs(input:{ search:$search, limit:$limit }){ id name isEnabled } }';
@@ -9,49 +17,45 @@ const LIST_USERS_QUERY =
 	'query($orgId: ID!, $search: UserSearchInput, $limit: Int){ users(where:{ orgId:$orgId }, search:$search, limit:$limit){ id username isApiUser roleIds } }';
 const LIST_ROLES_QUERY = 'query($orgId: ID!){ roles(where:{ orgId:$orgId }){ id name description } }';
 
-const searchOrganizationsSpec: ToolSpec = {
+const searchOrganizationsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional case-insensitive name substring.'),
+	limit: optionalClampedInt(100).describe('Max organizations to return (default 25, max 100).'),
+});
+
+const listUsersInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional username substring.'),
+	limit: optionalClampedInt(200).describe('Max users to return (default 50, max 200).'),
+});
+
+const listRolesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
+
+const searchOrganizationsSpec: ToolSpecDefinition = {
 	name: 'buddy_search_organizations',
-	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'Find organizations by a case-insensitive name substring. orgId only selects which signed-in session to use — results are not limited to that org; they span all organizations the session manages. Returns id, name, isEnabled. Preferred over buddy_list_orgs for finding an org by name (buddy_list_orgs enumerates every managed org).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
-			limit: { type: 'integer', description: 'Max organizations to return (default 25, max 100).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(searchOrganizationsInputSchema),
 };
 
-const listUsersSpec: ToolSpec = {
+const listUsersSpec: ToolSpecDefinition = {
 	name: 'buddy_list_users',
-	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'List the users directly in one Rewst organization (id, username, isApiUser, roleIds). Only users in the named org are returned; parent-org users are not inherited.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional username substring.' },
-			limit: { type: 'integer', description: 'Max users to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listUsersInputSchema),
 };
 
-const listRolesSpec: ToolSpec = {
+const listRolesSpec: ToolSpecDefinition = {
 	name: 'buddy_list_roles',
-	args: '{"orgId": string}',
 	description: 'List the roles defined in one Rewst organization (id, name, description).',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listRolesInputSchema),
 };
 
 async function runSearchOrganizations(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? 25, 100);
-	const search = asString(input, 'search');
+	const { limit: rawLimit, search } = parseCapabilityInput(searchOrganizationsInputSchema, input);
+	const limit = rawLimit ?? 25;
 	const variables: Record<string, unknown> = { limit };
 	if (search) variables.search = search;
 	const data = await rawGraphqlOrThrow(ctx.session, SEARCH_ORGANIZATIONS_QUERY, variables);
@@ -67,9 +71,8 @@ async function runSearchOrganizations(input: Record<string, unknown>, ctx: Capab
 }
 
 async function runListUsers(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? 50, 200);
+	const { orgId, search, limit: rawLimit } = parseCapabilityInput(listUsersInputSchema, input);
+	const limit = rawLimit ?? 50;
 	const variables: Record<string, unknown> = { orgId, limit };
 	if (search) variables.search = { username: { _ilike: `%${search}%` } };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_USERS_QUERY, variables);
@@ -91,7 +94,7 @@ async function runListUsers(input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListRoles(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listRolesInputSchema, input);
 	const variables: Record<string, unknown> = { orgId };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_ROLES_QUERY, variables);
 	const roles = ((data as { roles?: unknown[] } | undefined)?.roles ?? []) as {

--- a/src/capabilities/packIntegrationCapabilities.test.ts
+++ b/src/capabilities/packIntegrationCapabilities.test.ts
@@ -9,6 +9,35 @@ const { fakeCtx, cap } = createCapabilityTestHarness(PACK_INTEGRATION_CAPABILITI
 suite('Unit: packIntegrationCapabilities', () => {
 	setup(() => initTestEnvironment());
 
+	// --- Zod parse tests ---
+	test('missing packName throws with clear message', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_get_pack_auth_status').run({ orgId: 'org-1' }, ctx), /packName/);
+	});
+
+	test('missing orgId throws before GraphQL for buddy_list_installed_packs', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_list_installed_packs').run({}, ctx), /orgId/);
+	});
+
+	test('non-number limit for buddy_list_integrations falls back to default (no throw)', async () => {
+		const { ctx } = fakeCtx({ data: { integrations: [] } });
+		await assert.doesNotReject(() => cap('buddy_list_integrations').run({ orgId: 'org-1', limit: 'bad' }, ctx));
+	});
+
+	test('buddy_list_integrations derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_list_integrations').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_integrations').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_get_pack_auth_status derived schema has orgId and packName required and args generated', () => {
+		const schema = cap('buddy_get_pack_auth_status').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.ok(schema.required.includes('packName'));
+		assert.strictEqual(cap('buddy_get_pack_auth_status').spec.args, JSON.stringify(schema));
+	});
+
 	test('buddy_list_installed_packs formats rows', async () => {
 		const { ctx } = fakeCtx({
 			data: {

--- a/src/capabilities/packIntegrationCapabilities.test.ts
+++ b/src/capabilities/packIntegrationCapabilities.test.ts
@@ -1,6 +1,6 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
 const { suite, test, setup } = Mocha;
 

--- a/src/capabilities/packIntegrationCapabilities.ts
+++ b/src/capabilities/packIntegrationCapabilities.ts
@@ -5,7 +5,6 @@ import { readCapability } from './capabilityFactories';
 import {
 	ORG_ID_FIELD,
 	optionalClampedInt,
-	optionalStringField,
 	parseCapabilityInput,
 	rawGraphqlOrThrow,
 	requiredStringField,

--- a/src/capabilities/packIntegrationCapabilities.ts
+++ b/src/capabilities/packIntegrationCapabilities.ts
@@ -1,58 +1,67 @@
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asPositiveInt, asString, ORG_ID_PROP, rawGraphqlOrThrow, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	requiredStringField,
+	toInputSchema,
+} from './inputHelpers';
 
 const MAX_INTEGRATIONS_LIMIT = 200;
 
 function optionalString(value: unknown): string | undefined {
-	return asString({ value }, 'value');
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-const listInstalledPacksSpec: ToolSpec = {
+const listInstalledPacksInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
+
+const getPackAuthStatusInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	packName: requiredStringField('packName').describe('A pack ref, e.g. microsoft_graph'),
+});
+
+const listPackConfigsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
+
+const listIntegrationsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_INTEGRATIONS_LIMIT).describe('Max integrations to return (default 50, max 200).'),
+});
+
+const listInstalledPacksSpec: ToolSpecDefinition = {
 	name: 'buddy_list_installed_packs',
-	args: '{"orgId": string}',
 	description:
 		'List the integration packs and bundles installed in one Rewst organization (id, name, ref, isBundle, status, packType).',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listInstalledPacksInputSchema),
 };
 
-const getPackAuthStatusSpec: ToolSpec = {
+const getPackAuthStatusSpec: ToolSpecDefinition = {
 	name: 'buddy_get_pack_auth_status',
-	args: '{"orgId": string, "packName": string}',
 	description:
 		"Check whether a pack needs OAuth setup in one Rewst organization. packName is a pack ref (e.g. microsoft_graph). Returns 'configured' when already authenticated, or the setup URL when authorization is needed.",
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			packName: { type: 'string', description: 'A pack ref, e.g. microsoft_graph' },
-		},
-		required: ['orgId', 'packName'],
-	},
+	inputSchema: toInputSchema(getPackAuthStatusInputSchema),
 };
 
-const listPackConfigsSpec: ToolSpec = {
+const listPackConfigsSpec: ToolSpecDefinition = {
 	name: 'buddy_list_pack_configs',
-	args: '{"orgId": string}',
 	description:
 		'List the pack (integration) configurations for one Rewst organization (id, name, packId, default). Returns all configs (this field has no pagination).',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listPackConfigsInputSchema),
 };
 
-const listIntegrationsSpec: ToolSpec = {
+const listIntegrationsSpec: ToolSpecDefinition = {
 	name: 'buddy_list_integrations',
-	args: '{"orgId": string, "limit"?: number}',
 	description:
 		'List integrations available on the Rewst platform (name, description, numInstalled). Global catalog; the orgId only selects which signed-in session to use.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: { type: 'number', description: 'Max integrations to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listIntegrationsInputSchema),
 };
 
 async function runListInstalledPacks(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
@@ -68,7 +77,7 @@ async function runListInstalledPacks(input: Record<string, unknown>, ctx: Capabi
     }
   }
 }`;
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listInstalledPacksInputSchema, input);
 	const variables = { orgId };
 	const data = await rawGraphqlOrThrow(ctx.session, QUERY, variables);
 	const installedPacksAndBundles = ((
@@ -99,8 +108,7 @@ async function runGetPackAuthStatus(input: Record<string, unknown>, ctx: Capabil
 	const QUERY = `query RewstBuddyMcpPackAuthUrl($orgId: ID!, $packName: String!) {
   packAuthUrl(packName: $packName, orgId: $orgId)
 }`;
-	const orgId = requireString(input, 'orgId');
-	const packName = requireString(input, 'packName');
+	const { orgId, packName } = parseCapabilityInput(getPackAuthStatusInputSchema, input);
 	const variables = { orgId, packName };
 	const data = await rawGraphqlOrThrow(ctx.session, QUERY, variables);
 	const url = (data as { packAuthUrl?: unknown } | undefined)?.packAuthUrl;
@@ -118,7 +126,7 @@ async function runListPackConfigs(input: Record<string, unknown>, ctx: Capabilit
     createdAt
   }
 }`;
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listPackConfigsInputSchema, input);
 	const variables = { orgId };
 	const data = await rawGraphqlOrThrow(ctx.session, QUERY, variables);
 	const packConfigs = ((data as { packConfigs?: unknown[] | null } | undefined)?.packConfigs ?? []) as {
@@ -147,8 +155,8 @@ async function runListIntegrations(input: Record<string, unknown>, ctx: Capabili
     isPublic
   }
 }`;
-	requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? 50, MAX_INTEGRATIONS_LIMIT);
+	const { limit: rawLimit } = parseCapabilityInput(listIntegrationsInputSchema, input);
+	const limit = rawLimit ?? 50;
 	const variables = { limit };
 	const data = await rawGraphqlOrThrow(ctx.session, QUERY, variables);
 	const integrations = ((data as { integrations?: unknown[] | null } | undefined)?.integrations ?? []) as {

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -7,6 +7,35 @@ const { fakeCtx, cap } = createCapabilityTestHarness(PAGE_TEMPLATE_CAPABILITIES)
 suite('Unit: pageTemplateCapabilities', () => {
 	setup(() => initTestEnvironment());
 
+	// --- Zod parse tests ---
+	test('missing orgId throws before GraphQL for buddy_search_templates', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_search_templates').run({}, ctx), /orgId/);
+	});
+
+	test('non-number limit falls back to default for buddy_search_templates (no throw)', async () => {
+		const { ctx } = fakeCtx({ data: { templates: [] } });
+		await assert.doesNotReject(() => cap('buddy_search_templates').run({ orgId: 'org-1', limit: 'bad' }, ctx));
+	});
+
+	test('over-max limit is clamped to 200 for buddy_list_pages', async () => {
+		const { ctx, calls } = fakeCtx({ data: { pages: [] } });
+		await cap('buddy_list_pages').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 200);
+	});
+
+	test('buddy_search_templates derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_search_templates').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_search_templates').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_jinja_filters derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_list_jinja_filters').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_jinja_filters').spec.args, JSON.stringify(schema));
+	});
+
 	test('buddy_search_templates maps name search and formats template rows', async () => {
 		const { ctx, calls } = fakeCtx({
 			data: {

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -1,6 +1,6 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 const { suite, test, setup } = Mocha;
 const { fakeCtx, cap } = createCapabilityTestHarness(PAGE_TEMPLATE_CAPABILITIES);

--- a/src/capabilities/pageTemplateCapabilities.ts
+++ b/src/capabilities/pageTemplateCapabilities.ts
@@ -1,74 +1,79 @@
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asPositiveInt, asString, ORG_ID_PROP, rawGraphqlOrThrow, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	toInputSchema,
+} from './inputHelpers';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
+
+const searchTemplatesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional case-insensitive name substring.'),
+	limit: optionalClampedInt(MAX_LIMIT).describe(
+		`Max templates to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
+	),
+});
+
+const listPagesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_LIMIT).describe(`Max pages to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`),
+});
+
+const listSitesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
+
+const listJinjaFiltersInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional case-insensitive name substring.'),
+	limit: optionalClampedInt(MAX_LIMIT).describe(
+		`Max filters to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
+	),
+});
 
 const SEARCH_TEMPLATES_QUERY = `query($orgId: ID!, $search: TemplateSearch, $limit: Int){ templates(where:{ orgId:$orgId }, search:$search, order:[["updatedAt","desc"]], limit:$limit){ id name language contentType updatedAt } }`;
 const LIST_PAGES_QUERY = `query($orgId: ID!, $limit: Int){ pages(where:{ orgId:$orgId }, limit:$limit){ id name path siteId } }`;
 const LIST_SITES_QUERY = `query($orgId: ID!){ sites(where:{ orgId:$orgId }){ id name domain isLive } }`;
 const LIST_JINJA_FILTERS_QUERY = `query{ jinjaFiltersDocumentation { name signature } }`;
 
-const searchTemplatesSpec: ToolSpec = {
+const searchTemplatesSpec: ToolSpecDefinition = {
 	name: 'buddy_search_templates',
-	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'Search templates in one Rewst organization by name substring (case-insensitive), newest first (id, name, language, contentType, updatedAt). Use buddy_get_template for a full body.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
-			limit: { type: 'number', description: 'Max templates to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(searchTemplatesInputSchema),
 };
 
-const listPagesSpec: ToolSpec = {
+const listPagesSpec: ToolSpecDefinition = {
 	name: 'buddy_list_pages',
-	args: '{"orgId": string, "limit"?: number}',
 	description: 'List App Platform pages in one Rewst organization (id, name, path, siteId).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: { type: 'number', description: 'Max pages to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listPagesInputSchema),
 };
 
-const listSitesSpec: ToolSpec = {
+const listSitesSpec: ToolSpecDefinition = {
 	name: 'buddy_list_sites',
-	args: '{"orgId": string}',
 	description:
 		'List App Platform sites in one Rewst organization (id, name, domain, isLive). Returns all sites (this field has no pagination).',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listSitesInputSchema),
 };
 
-const listJinjaFiltersSpec: ToolSpec = {
+const listJinjaFiltersSpec: ToolSpecDefinition = {
 	name: 'buddy_list_jinja_filters',
-	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'List Rewst available Jinja filters with their signatures (global catalog, ~100 entries). Optionally filter by a name substring. Use this instead of the broken singular jinjaFilterDocumentation.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
-			limit: { type: 'number', description: 'Max filters to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listJinjaFiltersInputSchema),
 };
 
 async function runSearchTemplates(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const { orgId, search, limit: rawLimit } = parseCapabilityInput(searchTemplatesInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_LIMIT;
 	const variables: Record<string, unknown> = { orgId, limit };
 	if (search) variables.search = { name: { _ilike: `%${search}%` } };
 	const data = await rawGraphqlOrThrow(ctx.session, SEARCH_TEMPLATES_QUERY, variables);
@@ -95,8 +100,8 @@ async function runSearchTemplates(input: Record<string, unknown>, ctx: Capabilit
 }
 
 async function runListPages(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listPagesInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_PAGES_QUERY, variables);
 	const pages = ((data as { pages?: unknown[] } | undefined)?.pages ?? []) as {
@@ -115,7 +120,7 @@ async function runListPages(input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListSites(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listSitesInputSchema, input);
 	const variables = { orgId };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_SITES_QUERY, variables);
 	const sites = ((data as { sites?: unknown[] } | undefined)?.sites ?? []) as {
@@ -135,9 +140,8 @@ async function runListSites(input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListJinjaFilters(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const { search, limit: rawLimit } = parseCapabilityInput(listJinjaFiltersInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_LIMIT;
 	const variables = {};
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_JINJA_FILTERS_QUERY, variables);
 	const filters = ((data as { jinjaFiltersDocumentation?: unknown[] } | undefined)?.jinjaFiltersDocumentation ??

--- a/src/capabilities/resultReadCapability.test.ts
+++ b/src/capabilities/resultReadCapability.test.ts
@@ -73,6 +73,33 @@ suite('Unit: resultReadCapability', () => {
 	});
 
 	suite('buddy_result_read run', () => {
+		// --- Zod parse tests ---
+		test('missing id throws with the expected message', async () => {
+			await assert.rejects(
+				() => resultReadCapability.run({}, ignoredContext()),
+				/buddy_result_read requires an "id"/,
+			);
+		});
+
+		test('empty string id throws with the expected message', async () => {
+			await assert.rejects(
+				() => resultReadCapability.run({ id: '' }, ignoredContext()),
+				/buddy_result_read requires an "id"/,
+			);
+		});
+
+		test('numeric string offset and limit are accepted', async () => {
+			const id = cacheId(mcpResultCache.store('buddy_list_templates', '0123456789abcdef'));
+			const output = await resultReadCapability.run({ id, offset: '4', limit: '6' }, ignoredContext());
+			assert.ok(output.includes('456789'));
+		});
+
+		test('buddy_result_read derived schema has id required and args generated', () => {
+			const schema = resultReadCapability.spec.inputSchema as { required: string[] };
+			assert.ok(schema.required.includes('id'));
+			assert.strictEqual(resultReadCapability.spec.args, JSON.stringify(schema));
+		});
+
 		test('returns a requested slice with a continuation footer', async () => {
 			const id = cacheId(mcpResultCache.store('buddy_list_templates', '0123456789abcdef'));
 

--- a/src/capabilities/resultReadCapability.test.ts
+++ b/src/capabilities/resultReadCapability.test.ts
@@ -1,6 +1,6 @@
+import { initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
 import type { CapabilityContext } from './Capability';
 import {
 	MCP_MAX_OUTPUT_CHARS,

--- a/src/capabilities/resultReadCapability.ts
+++ b/src/capabilities/resultReadCapability.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'crypto';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asString } from './inputHelpers';
+import { optionalStringField, parseCapabilityInput, requiredStringField, toInputSchema } from './inputHelpers';
 
 export const RESULT_READ_TOOL_NAME = 'buddy_result_read';
 export const MCP_MAX_OUTPUT_CHARS = 24_000;
@@ -95,41 +96,44 @@ export function formatMcpOutput(toolName: string, text: string, cache: McpResult
 	].join('\n');
 }
 
-const resultReadSpec: ToolSpec = {
+const RESULT_READ_ID_ERROR = 'buddy_result_read requires an "id" from a previous oversized Rewst Buddy result.';
+
+const resultReadInputSchema = z.object({
+	id: z
+		.string({ error: RESULT_READ_ID_ERROR })
+		.trim()
+		.min(1, { error: RESULT_READ_ID_ERROR })
+		.describe('Cached result id returned by an oversized Rewst Buddy tool result.'),
+	// Note: id field intentionally uses a custom error message matching the legacy explicit check.
+	offset: z
+		.preprocess(v => (typeof v === 'string' ? Number(v) : v), z.number().optional())
+		.describe('Character offset to start reading from (default 0).'),
+	limit: z
+		.preprocess(v => (typeof v === 'string' ? Number(v) : v), z.number().optional())
+		.describe(`Maximum characters to return (default ${DEFAULT_READ_LIMIT}, max ${MAX_READ_LIMIT}).`),
+	// offset and limit accept numeric strings for backward compatibility (clampInt coerces them downstream).
+	search: optionalStringField().describe('Search text; returns matching lines with line numbers instead of a slice.'),
+});
+
+const resultReadSpec: ToolSpecDefinition = {
 	name: RESULT_READ_TOOL_NAME,
 	description:
 		'Pages or searches an oversized cached Rewst Buddy result by id. The cache is in-memory only; an id can be evicted under memory pressure, so rerun the original tool if it is gone.',
-	args: '{"id": string, "offset"?: number, "limit"?: number, "search"?: string}',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			id: { type: 'string', description: 'Cached result id returned by an oversized Rewst Buddy tool result.' },
-			offset: { type: 'number', description: 'Character offset to start reading from (default 0).' },
-			limit: {
-				type: 'number',
-				description: `Maximum characters to return (default ${DEFAULT_READ_LIMIT}, max ${MAX_READ_LIMIT}).`,
-			},
-			search: {
-				type: 'string',
-				description: 'Search text; returns matching lines with line numbers instead of a slice.',
-			},
-		},
-		required: ['id'],
-	},
+	inputSchema: toInputSchema(resultReadInputSchema),
 };
 
 export const resultReadCapability: Capability = readCapability(
 	resultReadSpec,
 	async (input: Record<string, unknown>, _ctx): Promise<string> => {
-		const id = asString(input, 'id');
-		if (!id) throw new Error('buddy_result_read requires an "id" from a previous oversized Rewst Buddy result.');
+		const parsed = parseCapabilityInput(resultReadInputSchema, input);
+		const id = parsed.id;
 		const entry = mcpResultCache.get(id);
 		if (!entry) {
 			throw new Error(
 				`No cached Rewst Buddy result for id "${id}". The in-memory cache may have evicted it or it may be absent; rerun the original tool to regenerate it.`,
 			);
 		}
-		const search = asString(input, 'search');
+		const search = parsed.search;
 		if (search !== undefined) return searchCachedOutput(entry, search);
 		const offset = clampInt(input.offset, 0, entry.text.length, 0);
 		const limit = clampInt(input.limit, 1, MAX_READ_LIMIT, DEFAULT_READ_LIMIT);

--- a/src/capabilities/resultReadCapability.ts
+++ b/src/capabilities/resultReadCapability.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { optionalStringField, parseCapabilityInput, requiredStringField, toInputSchema } from './inputHelpers';
+import { optionalStringField, parseCapabilityInput, toInputSchema } from './inputHelpers';
 
 export const RESULT_READ_TOOL_NAME = 'buddy_result_read';
 export const MCP_MAX_OUTPUT_CHARS = 24_000;

--- a/src/capabilities/templateCloneCapabilities.test.ts
+++ b/src/capabilities/templateCloneCapabilities.test.ts
@@ -1,9 +1,9 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { createMockSession, initTestEnvironment } from '@test';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
 import { LinkManager } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
+import { createMockSession, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
 import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
 import {
 	defaultTemplateCloneDeps,

--- a/src/capabilities/templateCloneCapabilities.test.ts
+++ b/src/capabilities/templateCloneCapabilities.test.ts
@@ -108,6 +108,35 @@ suite('Unit: templateCloneCapabilities', () => {
 		LinkManager._resetForTesting();
 	});
 
+	// --- Zod parse tests ---
+	test('missing rootTemplateId throws before any fetch', async () => {
+		const { deps } = makeCloneDeps({});
+		await assert.rejects(() => runBundleClone({ orgId: 'tgt-org' }, makeCtx(), deps), /rootTemplateId/);
+	});
+
+	test('missing orgId throws before any fetch', async () => {
+		const { deps } = makeCloneDeps({});
+		await assert.rejects(() => runBundleClone({ rootTemplateId: A }, makeCtx(), deps), /orgId/);
+	});
+
+	test('maxTemplates floors and clamps to 200', async () => {
+		setMcpMutationApprover(async () => true);
+		const { deps } = makeCloneDeps({ [A]: tmpl(A) });
+		// Should not throw; 9999 clamps to 200
+		await assert.doesNotReject(() =>
+			runBundleClone({ orgId: 'tgt-org', rootTemplateId: A, maxTemplates: 9999 }, makeCtx(), deps),
+		);
+	});
+
+	test('buddy_template_bundle_clone derived schema has orgId and rootTemplateId required and args generated', () => {
+		const c = TEMPLATE_CLONE_CAPABILITIES.find(x => x.spec.name === 'buddy_template_bundle_clone');
+		assert.ok(c);
+		const schema = c.spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.ok(schema.required.includes('rootTemplateId'));
+		assert.strictEqual(c.spec.args, JSON.stringify(schema));
+	});
+
 	suite('rewriteReferences', () => {
 		test('rewrites mapped ids, leaves unmapped refs and surrounding Jinja intact', () => {
 			const map = new Map([[A, 'new-1']]);

--- a/src/capabilities/templateCloneCapabilities.ts
+++ b/src/capabilities/templateCloneCapabilities.ts
@@ -7,13 +7,11 @@ import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
 import {
-	asPositiveInt,
-	asString,
 	getTemplateFromAnySession,
 	json,
-	ORG_ID_FIELD,
 	optionalClampedInt,
 	optionalStringField,
+	ORG_ID_FIELD,
 	parseCapabilityInput,
 	requiredStringField,
 	toInputSchema,

--- a/src/capabilities/templateCloneCapabilities.ts
+++ b/src/capabilities/templateCloneCapabilities.ts
@@ -1,11 +1,23 @@
 import type { FullTemplateFragment, Session } from '@sessions';
 import { findAllTemplateReferences } from '@utils';
+import { z } from 'zod';
 import { TEMPLATE_PATTERN } from '../providers/templatePatternUtils';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
-import { asPositiveInt, asString, getTemplateFromAnySession, json, ORG_ID_PROP, requireString } from './inputHelpers';
+import {
+	asPositiveInt,
+	asString,
+	getTemplateFromAnySession,
+	json,
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
+	requiredStringField,
+	toInputSchema,
+} from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -124,27 +136,39 @@ async function rollback(deps: TemplateCloneDeps, session: Session, created: read
 	return failed;
 }
 
+const bundleCloneInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	rootTemplateId: requiredStringField('rootTemplateId').describe('Id of the root template to deep-clone.'),
+	sourceOrgId: optionalStringField().describe(
+		'Optional id of the org the root and its references live in. Verified against the root; defaults to the root\u2019s org.',
+	),
+	namePrefix: optionalStringField().describe('Optional prefix for cloned template names.'),
+	nameSuffix: optionalStringField().describe('Optional suffix for cloned template names. Defaults to " (copy)".'),
+	maxTemplates: optionalClampedInt(MAX_MAX_TEMPLATES).describe(
+		'Max total templates to clone (root + references). Default 50, capped at 200.',
+	),
+	maxDepth: optionalClampedInt(MAX_MAX_DEPTH).describe('Max reference depth to walk. Default 10, capped at 25.'),
+});
+
 export async function runBundleClone(
 	input: Record<string, unknown>,
 	ctx: CapabilityContext,
 	deps: TemplateCloneDeps = defaultTemplateCloneDeps,
 ): Promise<string> {
-	const targetOrgId = requireString(input, 'orgId');
-	const rootId = requireString(input, 'rootTemplateId');
-	const sourceOrgIdArg = asString(input, 'sourceOrgId');
+	const {
+		orgId: targetOrgId,
+		rootTemplateId: rootId,
+		sourceOrgId: sourceOrgIdArg,
+		namePrefix: namePrefixRaw,
+		nameSuffix: nameSuffixRaw,
+		maxTemplates: maxTemplatesRaw,
+		maxDepth: maxDepthRaw,
+	} = parseCapabilityInput(bundleCloneInputSchema, input);
 
-	let namePrefix = '';
-	if (input.namePrefix !== undefined) {
-		if (typeof input.namePrefix !== 'string') throw new Error('"namePrefix" must be a string.');
-		namePrefix = input.namePrefix;
-	}
-	let nameSuffix = DEFAULT_NAME_SUFFIX;
-	if (input.nameSuffix !== undefined) {
-		if (typeof input.nameSuffix !== 'string') throw new Error('"nameSuffix" must be a string.');
-		nameSuffix = input.nameSuffix;
-	}
-	const maxTemplates = Math.min(asPositiveInt(input, 'maxTemplates') ?? DEFAULT_MAX_TEMPLATES, MAX_MAX_TEMPLATES);
-	const maxDepth = Math.min(asPositiveInt(input, 'maxDepth') ?? DEFAULT_MAX_DEPTH, MAX_MAX_DEPTH);
+	const namePrefix = namePrefixRaw ?? '';
+	const nameSuffix = nameSuffixRaw ?? DEFAULT_NAME_SUFFIX;
+	const maxTemplates = maxTemplatesRaw ?? DEFAULT_MAX_TEMPLATES;
+	const maxDepth = maxDepthRaw ?? DEFAULT_MAX_DEPTH;
 
 	// Phase 0 — fetch the root (from any session that can read it) and pin the source org.
 	const fetched = await getTemplateFromAnySession(ctx.sessions, deps.getTemplate, rootId);
@@ -276,34 +300,11 @@ export async function runBundleClone(
 	});
 }
 
-const bundleCloneSpec: ToolSpec = {
+const bundleCloneSpec: ToolSpecDefinition = {
 	name: 'buddy_template_bundle_clone',
-	args: '{"orgId": string, "rootTemplateId": string, "sourceOrgId"?: string, "namePrefix"?: string, "nameSuffix"?: string, "maxTemplates"?: number, "maxDepth"?: number}',
 	description:
 		"Deep-copy a Rewst template and the templates it references (transitively, via template('<id>') calls in the body) into NEW templates in a target org, rewriting every reference to the new template ids. Each clone copies the source name, body, contentType, language, JSON context and cloneOverrides; tags are NOT copied (they are org-scoped) and references inside context/cloneOverrides are not followed. orgId is the TARGET org the clones are created in — it must have write tools enabled, be on the write allowlist, and pass per-call approval. The source org is taken from the root template (verify it with sourceOrgId). References to templates in a different org, or that no longer exist, are left pointing at the original id and reported as foreignReferences / missingReferences. Nodes beyond maxTemplates (default 50, max 200) or maxDepth (default 10, max 25) are not cloned and are reported under skipped.cap / skipped.depth. On any failure mid-clone the templates created so far are deleted (rollback). Returns the old→new id map and the new root id; it does not create a local file link — use buddy_template_link for that.",
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			rootTemplateId: { type: 'string', description: 'Id of the root template to deep-clone.' },
-			sourceOrgId: {
-				type: 'string',
-				description:
-					'Optional id of the org the root and its references live in. Verified against the root; defaults to the root’s org.',
-			},
-			namePrefix: { type: 'string', description: 'Optional prefix for cloned template names.' },
-			nameSuffix: {
-				type: 'string',
-				description: 'Optional suffix for cloned template names. Defaults to " (copy)".',
-			},
-			maxTemplates: {
-				type: 'number',
-				description: 'Max total templates to clone (root + references). Default 50, capped at 200.',
-			},
-			maxDepth: { type: 'number', description: 'Max reference depth to walk. Default 10, capped at 25.' },
-		},
-		required: ['orgId', 'rootTemplateId'],
-	},
+	inputSchema: toInputSchema(bundleCloneInputSchema),
 };
 
 export const TEMPLATE_CLONE_CAPABILITIES: Capability[] = [

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -1,10 +1,10 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
 import type { CapabilityContext } from '@capabilities';
 import { LinkManager, SyncOnSaveManager, type TemplateLink } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
+import { initTestEnvironment } from '@test';
 import { getHash } from '@utils';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
 import vscode from 'vscode';
 import {
 	resolvePathToUri,

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -105,6 +105,41 @@ function addStaleOrgLink(fsPath: string): vscode.Uri {
 }
 
 suite('Unit: templateLinkCapabilities', () => {
+	// --- Zod parse tests ---
+	test('missing uri throws for buddy_template_link', async () => {
+		const ctx = makeCtx();
+		await assert.rejects(() => runLink({ templateId: 't1' }, ctx, makeLinkDeps().deps), /uri/);
+	});
+
+	test('missing templateId throws for buddy_template_link', async () => {
+		const ctx = makeCtx();
+		await assert.rejects(() => runLink({ uri: '/ws/file.j2' }, ctx, makeLinkDeps().deps), /templateId/);
+	});
+
+	test('optional orgId for buddy_template_link is accepted when absent', async () => {
+		const ctx = makeCtx();
+		const { deps } = makeLinkDeps();
+		// Should not throw on missing orgId (it is optional)
+		const out = JSON.parse(await runLink({ templateId: 't1', uri: '/ws/file.j2' }, ctx, deps));
+		assert.ok(
+			out.status === 'linked' ||
+				out.status === 'already_linked' ||
+				out.status === 'invalid_path' ||
+				out.status === 'file_not_found' ||
+				out.status === 'template_not_found',
+		);
+	});
+
+	test('TEMPLATE_LINK_CAPABILITIES derived schemas have args generated from inputSchema', () => {
+		for (const c of TEMPLATE_LINK_CAPABILITIES) {
+			assert.strictEqual(
+				c.spec.args,
+				JSON.stringify(c.spec.inputSchema),
+				`${c.spec.name}: args must equal JSON.stringify(inputSchema)`,
+			);
+		}
+	});
+
 	setup(() => {
 		initTestEnvironment();
 		LinkManager._resetForTesting();

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -1,11 +1,19 @@
 import { buildTemplateLink, LinkManager, orgForTemplateLink, SyncOnSaveManager } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
 import { uriExists } from '@utils';
+import { z } from 'zod';
 import vscode from 'vscode';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asString, getTemplateFromAnySession, json, requireString } from './inputHelpers';
+import {
+	getTemplateFromAnySession,
+	json,
+	optionalStringField,
+	parseCapabilityInput,
+	requiredStringField,
+	toInputSchema,
+} from './inputHelpers';
 import { resolveLinkedUri } from './templateSyncCapabilities';
 
 /**
@@ -65,15 +73,53 @@ export const defaultTemplateLinkDeps: TemplateLinkDeps = {
 	getTemplate: (session, templateId) => session.getTemplate(templateId),
 };
 
+const linkInputSchema = z.object({
+	templateId: requiredStringField('templateId').describe(
+		'Id of the existing Rewst template to link the file to (from buddy_list_templates).',
+	),
+	uri: requiredStringField('uri').describe(
+		'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
+	),
+	orgId: optionalStringField().describe(
+		'Optional org id to verify the template belongs to. Defaults to the template\u2019s own org.',
+	),
+	overwrite: z
+		.boolean()
+		.optional()
+		.describe('If the file is already linked, replace the existing link instead of failing. Default false.'),
+});
+
+const unlinkInputSchema = z.object({
+	uri: requiredStringField('uri').describe(
+		'Path or file URI of the linked file, as shown by buddy_search_template_links.',
+	),
+});
+
+const syncOnSaveInputSchema = z.object({
+	uri: requiredStringField('uri').describe('Path or file URI of the linked file.'),
+	enabled: z
+		.boolean({ error: '"enabled" must be a boolean (true to enable sync-on-save, false to disable).' })
+		.describe('true to enable sync-on-save (upload on save), false to disable.'),
+});
+
+const linkStatusInputSchema = z.object({
+	uri: requiredStringField('uri').describe(
+		'Absolute path, workspace-relative path, or file:// URI of the local file to check.',
+	),
+});
+
 export async function runLink(
 	input: Record<string, unknown>,
 	ctx: CapabilityContext,
 	deps: TemplateLinkDeps = defaultTemplateLinkDeps,
 ): Promise<string> {
-	const templateId = requireString(input, 'templateId');
-	const rawUri = requireString(input, 'uri');
-	const requestedOrgId = asString(input, 'orgId');
-	const overwrite = input.overwrite === true;
+	const {
+		templateId,
+		uri: rawUri,
+		orgId: requestedOrgId,
+		overwrite: overwriteRaw,
+	} = parseCapabilityInput(linkInputSchema, input);
+	const overwrite = overwriteRaw === true;
 
 	const uri = deps.resolvePathToUri(rawUri);
 	if (!uri) {
@@ -148,7 +194,7 @@ export async function runLink(
 }
 
 export async function runUnlink(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
-	const rawUri = requireString(input, 'uri');
+	const { uri: rawUri } = parseCapabilityInput(unlinkInputSchema, input);
 	const resolved = resolveLinkedUri(rawUri);
 	if (!resolved) {
 		return json({
@@ -183,7 +229,7 @@ export async function runUnlink(input: Record<string, unknown>, _ctx: Capability
  * file is definitely unlinked.
  */
 export function runLinkStatus(input: Record<string, unknown>): string {
-	const rawUri = requireString(input, 'uri');
+	const { uri: rawUri } = parseCapabilityInput(linkStatusInputSchema, input);
 	const resolved = resolveLinkedUri(rawUri);
 	if (!resolved) {
 		return json({
@@ -210,11 +256,7 @@ export function runLinkStatus(input: Record<string, unknown>): string {
 }
 
 export async function runSyncOnSave(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
-	const rawUri = requireString(input, 'uri');
-	const enabled = input.enabled;
-	if (typeof enabled !== 'boolean') {
-		throw new Error('"enabled" must be a boolean (true to enable sync-on-save, false to disable).');
-	}
+	const { uri: rawUri, enabled } = parseCapabilityInput(syncOnSaveInputSchema, input);
 	const resolved = resolveLinkedUri(rawUri);
 	if (!resolved) {
 		return json({
@@ -245,87 +287,32 @@ export async function runSyncOnSave(input: Record<string, unknown>, _ctx: Capabi
 	});
 }
 
-const linkSpec: ToolSpec = {
+const linkSpec: ToolSpecDefinition = {
 	name: 'buddy_template_link',
-	args: '{"templateId": string, "uri": string, "orgId"?: string, "overwrite"?: boolean}',
 	description:
 		'Associate an existing local file with an existing Rewst template, so it can be synced. Does not create the file or the template. Identify the file by an absolute path, a workspace-relative path, or a file:// URI. The link starts out-of-sync on purpose — afterwards call buddy_template_sync_status to compare, or buddy_template_sync to reconcile. Returns already_linked unless overwrite is true, and invalid_path / file_not_found / template_not_found / org_mismatch on the obvious failures. This changes only local link state (no Rewst write).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			templateId: {
-				type: 'string',
-				description: 'Id of the existing Rewst template to link the file to (from buddy_list_templates).',
-			},
-			uri: {
-				type: 'string',
-				description:
-					'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
-			},
-			orgId: {
-				type: 'string',
-				description: 'Optional org id to verify the template belongs to. Defaults to the template’s own org.',
-			},
-			overwrite: {
-				type: 'boolean',
-				description:
-					'If the file is already linked, replace the existing link instead of failing. Default false.',
-			},
-		},
-		required: ['templateId', 'uri'],
-	},
+	inputSchema: toInputSchema(linkInputSchema),
 };
 
-const unlinkSpec: ToolSpec = {
+const unlinkSpec: ToolSpecDefinition = {
 	name: 'buddy_template_unlink',
-	args: '{"uri": string}',
 	description:
 		'Remove the link between a local file and its Rewst template. The local file and the remote template are left untouched; only the local association (and its sync-on-save setting) is removed. Identify the file by the path shown in buddy_search_template_links or its file URI. Returns not_linked if no template is linked to it.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			uri: {
-				type: 'string',
-				description: 'Path or file URI of the linked file, as shown by buddy_search_template_links.',
-			},
-		},
-		required: ['uri'],
-	},
+	inputSchema: toInputSchema(unlinkInputSchema),
 };
 
-const syncOnSaveSpec: ToolSpec = {
+const syncOnSaveSpec: ToolSpecDefinition = {
 	name: 'buddy_template_sync_on_save',
-	args: '{"uri": string, "enabled": boolean}',
 	description:
 		'Enable or disable sync-on-save for a linked file: when on, saving the file in VS Code uploads it to its Rewst template. The file must already be linked (see buddy_template_link). Returns the effective syncOnSave state, which also depends on the rewst-buddy.syncOnSaveByDefault setting. This changes only local state (no Rewst write).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			uri: { type: 'string', description: 'Path or file URI of the linked file.' },
-			enabled: {
-				type: 'boolean',
-				description: 'true to enable sync-on-save (upload on save), false to disable.',
-			},
-		},
-		required: ['uri', 'enabled'],
-	},
+	inputSchema: toInputSchema(syncOnSaveInputSchema),
 };
 
-const linkStatusSpec: ToolSpec = {
+const linkStatusSpec: ToolSpecDefinition = {
 	name: 'buddy_template_link_status',
-	args: '{"uri": string}',
 	description:
 		'Report whether one local file is linked to a Rewst template, reading only local link state (no network or remote comparison). Identify the file by an absolute path, a workspace-relative path, or a file:// URI. Returns linked:false when nothing is linked; otherwise the template id and name, org id and name, and whether sync-on-save is on. For an up-to-date comparison with the Rewst template use buddy_template_sync_status; to list linked files use buddy_search_template_links.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			uri: {
-				type: 'string',
-				description: 'Absolute path, workspace-relative path, or file:// URI of the local file to check.',
-			},
-		},
-		required: ['uri'],
-	},
+	inputSchema: toInputSchema(linkStatusInputSchema),
 };
 
 export const TEMPLATE_LINK_CAPABILITIES: Capability[] = [

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -1,8 +1,8 @@
 import { buildTemplateLink, LinkManager, orgForTemplateLink, SyncOnSaveManager } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
 import { uriExists } from '@utils';
-import { z } from 'zod';
 import vscode from 'vscode';
+import { z } from 'zod';
 import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -127,6 +127,20 @@ suite('Unit: templateSyncCapabilities', () => {
 		_resetMcpMutationApproverForTesting();
 	});
 
+	// --- Zod parse tests ---
+	test('missing uri throws for buddy_template_sync_status', async () => {
+		const { deps } = makeDeps(null);
+		await assert.rejects(() => runSyncStatus({}, makeCtx(), deps), /uri/);
+	});
+
+	test('buddy_template_sync_status derived schema has uri required and args generated', () => {
+		const statusCap = TEMPLATE_SYNC_CAPABILITIES.find(c => c.spec.name === 'buddy_template_sync_status');
+		assert.ok(statusCap);
+		const schema = statusCap.spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('uri'));
+		assert.strictEqual(statusCap.spec.args, JSON.stringify(schema));
+	});
+
 	suite('buddy_template_sync_status', () => {
 		test('reports unlinked files without touching Rewst', async () => {
 			const { deps } = makeDeps(null);

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -1,9 +1,9 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
 import { LinkManager, type SyncDecision, type SyncDecisionContext, type TemplateLink } from '@models';
 import { SessionManager, type FullTemplateFragment, type Session } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
 import vscode from 'vscode';
 import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import {

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -9,11 +9,12 @@ import {
 } from '@models';
 import { SessionManager } from '@sessions';
 import vscode from 'vscode';
+import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpec, ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability, writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, requireString } from './inputHelpers';
+import { ORG_ID_PROP, parseCapabilityInput, requiredStringField, requireString, toInputSchema } from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -205,12 +206,18 @@ function resolveEffectiveAction(direction: SyncDirection, action: SyncDecision['
 	return 'conflict';
 }
 
+const syncStatusInputSchema = z.object({
+	uri: requiredStringField('uri').describe(
+		'Path or file URI of the local file, as shown by buddy_search_template_links.',
+	),
+});
+
 export async function runSyncStatus(
 	input: Record<string, unknown>,
 	_ctx: CapabilityContext,
 	deps: TemplateSyncDeps = defaultTemplateSyncDeps,
 ): Promise<string> {
-	const uri = requireString(input, 'uri');
+	const { uri } = parseCapabilityInput(syncStatusInputSchema, input);
 	const prepared = await deps.prepare(uri);
 	if (prepared.kind === 'unlinked') {
 		return JSON.stringify(
@@ -363,21 +370,11 @@ export async function runSync(
 	});
 }
 
-const syncStatusSpec: ToolSpec = {
+const syncStatusSpec: ToolSpecDefinition = {
 	name: 'buddy_template_sync_status',
-	args: '{"uri": string}',
 	description:
 		'Report whether a local file is linked to a Rewst template and how it compares to the remote template, without changing anything. Identify the file by the path shown in buddy_search_template_links (workspace-relative or absolute) or its file URI. Returns linked:false when no template is linked. When linked, returns the org id and template id to pass to buddy_template_sync, whether sync-on-save is on, and a status of "in-sync", "remote-only" (the local file is empty), "local-ahead" (safe to upload), or "conflict" (both changed since the last sync), plus a recommended direction.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			uri: {
-				type: 'string',
-				description: 'Path or file URI of the local file, as shown by buddy_search_template_links.',
-			},
-		},
-		required: ['uri'],
-	},
+	inputSchema: toInputSchema(syncStatusInputSchema),
 };
 
 const syncSpec: ToolSpec = {

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -1,8 +1,8 @@
 import {
 	LinkManager,
+	orgForTemplateLink,
 	SyncManager,
 	SyncOnSaveManager,
-	orgForTemplateLink,
 	type SyncDecision,
 	type SyncDecisionContext,
 	type TemplateLink,

--- a/src/capabilities/triggerFormCapabilities.test.ts
+++ b/src/capabilities/triggerFormCapabilities.test.ts
@@ -7,6 +7,64 @@ const { fakeCtx, cap } = createCapabilityTestHarness(TRIGGER_FORM_CAPABILITIES);
 suite('Unit: triggerFormCapabilities', () => {
 	setup(() => initTestEnvironment());
 
+	// --- Zod parse tests ---
+	test('missing orgId throws before GraphQL', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_list_triggers').run({}, ctx), /orgId/);
+	});
+
+	test('non-number limit falls back to default (no throw)', async () => {
+		const { ctx } = fakeCtx({ data: { triggers: [] } });
+		await assert.doesNotReject(() => cap('buddy_list_triggers').run({ orgId: 'org-1', limit: 'bad' }, ctx));
+	});
+
+	test('fractional limit is floored', async () => {
+		const { ctx, calls } = fakeCtx({ data: { triggers: [] } });
+		await cap('buddy_list_triggers').run({ orgId: 'org-1', limit: 7.9 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 7);
+	});
+
+	test('over-max limit is clamped to 200', async () => {
+		const { ctx, calls } = fakeCtx({ data: { triggers: [] } });
+		await cap('buddy_list_triggers').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 200);
+	});
+
+	test('buddy_list_triggers derived schema has orgId required and limit optional', () => {
+		const schema = cap('buddy_list_triggers').spec.inputSchema as {
+			required: string[];
+			properties: Record<string, unknown>;
+		};
+		assert.ok(schema.required.includes('orgId'));
+		assert.ok('limit' in schema.properties);
+		assert.strictEqual(cap('buddy_list_triggers').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_forms derived schema has orgId required', () => {
+		const schema = cap('buddy_list_forms').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_forms').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_tags derived schema has orgId required', () => {
+		const schema = cap('buddy_list_tags').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_tags').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_org_trigger_instances derived schema has orgId required', () => {
+		const schema = cap('buddy_list_org_trigger_instances').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_org_trigger_instances').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_get_trigger_error_status derived schema has orgId and triggerIds required', () => {
+		const schema = cap('buddy_get_trigger_error_status').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.ok(schema.required.includes('triggerIds'));
+		assert.strictEqual(cap('buddy_get_trigger_error_status').spec.args, JSON.stringify(schema));
+	});
+
 	test('buddy_list_triggers uses triggers query and formats trigger rows', async () => {
 		const { ctx, calls } = fakeCtx({
 			data: {

--- a/src/capabilities/triggerFormCapabilities.test.ts
+++ b/src/capabilities/triggerFormCapabilities.test.ts
@@ -1,6 +1,6 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 const { suite, test, setup } = Mocha;
 const { fakeCtx, cap } = createCapabilityTestHarness(TRIGGER_FORM_CAPABILITIES);

--- a/src/capabilities/triggerFormCapabilities.ts
+++ b/src/capabilities/triggerFormCapabilities.ts
@@ -1,7 +1,14 @@
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asPositiveInt, asString, ORG_ID_PROP, rawGraphqlOrThrow, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	toInputSchema,
+} from './inputHelpers';
 
 const DEFAULT_TRIGGER_LIMIT = 50;
 const MAX_TRIGGER_LIMIT = 200;
@@ -18,107 +25,83 @@ const LIST_TAGS_QUERY = `query($orgId: ID!, $limit: Int){ tags(where:{ orgId:$or
 const LIST_ORG_TRIGGER_INSTANCES_QUERY = `query($orgId: ID!, $limit: Int){ orgTriggerInstances(where:{ orgId:$orgId }, limit:$limit){ id triggerId nextFireTime isManualActivation } }`;
 const GET_TRIGGER_ERROR_STATUS_QUERY = `query($triggerIds: [ID!]){ getTriggerErrorStatus(triggerIds:$triggerIds) }`;
 
-const listTriggersSpec: ToolSpec = {
+const listTriggersInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_TRIGGER_LIMIT).describe(
+		`Max triggers to return (default ${DEFAULT_TRIGGER_LIMIT}, max ${MAX_TRIGGER_LIMIT}).`,
+	),
+});
+
+const listFormsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_FORM_LIMIT).describe(
+		`Max forms to return (default ${DEFAULT_FORM_LIMIT}, max ${MAX_FORM_LIMIT}).`,
+	),
+});
+
+const listTagsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_TAG_LIMIT).describe(
+		`Max tags to return (default ${DEFAULT_TAG_LIMIT}, max ${MAX_TAG_LIMIT}).`,
+	),
+});
+
+const listOrgTriggerInstancesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_ORG_TRIGGER_INSTANCE_LIMIT).describe(
+		`Max trigger activation instances to return (default ${DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT}, max ${MAX_ORG_TRIGGER_INSTANCE_LIMIT}).`,
+	),
+});
+
+const TRIGGER_IDS_ERROR = 'Missing required non-empty string array argument "triggerIds".';
+
+const getTriggerErrorStatusInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	triggerIds: z
+		.preprocess(
+			raw => (raw === undefined || raw === null ? [] : raw),
+			z.array(z.string(), { error: TRIGGER_IDS_ERROR }).min(1, { error: TRIGGER_IDS_ERROR }),
+		)
+		.describe('Trigger ids to check.'),
+});
+
+const listTriggersSpec: ToolSpecDefinition = {
 	name: 'buddy_list_triggers',
-	args: '{"orgId": string, "limit"?: number}',
 	description:
 		'List the triggers in one Rewst organization (id, name, enabled, triggerTypeId, workflowId). Triggers are how workflows are invoked.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: {
-				type: 'number',
-				description: `Max triggers to return (default ${DEFAULT_TRIGGER_LIMIT}, max ${MAX_TRIGGER_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listTriggersInputSchema),
 };
 
-const listFormsSpec: ToolSpec = {
+const listFormsSpec: ToolSpecDefinition = {
 	name: 'buddy_list_forms',
-	args: '{"orgId": string, "limit"?: number}',
 	description: 'List the forms in one Rewst organization (id, name, updatedAt).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: {
-				type: 'number',
-				description: `Max forms to return (default ${DEFAULT_FORM_LIMIT}, max ${MAX_FORM_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listFormsInputSchema),
 };
 
-const listTagsSpec: ToolSpec = {
+const listTagsSpec: ToolSpecDefinition = {
 	name: 'buddy_list_tags',
-	args: '{"orgId": string, "limit"?: number}',
 	description:
 		'List the tags in one Rewst organization (id, name, color). Use the ids for tag filters on other tools.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: {
-				type: 'number',
-				description: `Max tags to return (default ${DEFAULT_TAG_LIMIT}, max ${MAX_TAG_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listTagsInputSchema),
 };
 
-const listOrgTriggerInstancesSpec: ToolSpec = {
+const listOrgTriggerInstancesSpec: ToolSpecDefinition = {
 	name: 'buddy_list_org_trigger_instances',
-	args: '{"orgId": string, "limit"?: number}',
 	description:
 		'List trigger activation instances for one Rewst organization (id, triggerId, nextFireTime, isManualActivation). nextFireTime is an epoch-millisecond string.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: {
-				type: 'number',
-				description: `Max trigger activation instances to return (default ${DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT}, max ${MAX_ORG_TRIGGER_INSTANCE_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listOrgTriggerInstancesInputSchema),
 };
 
-const getTriggerErrorStatusSpec: ToolSpec = {
+const getTriggerErrorStatusSpec: ToolSpecDefinition = {
 	name: 'buddy_get_trigger_error_status',
-	args: '{"orgId": string, "triggerIds": string[]}',
 	description:
 		'Batch health check for triggers: given trigger ids, returns whether each currently has errors (true = has errors).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			triggerIds: { type: 'array', items: { type: 'string' }, description: 'Trigger ids to check.' },
-		},
-		required: ['orgId', 'triggerIds'],
-	},
+	inputSchema: toInputSchema(getTriggerErrorStatusInputSchema),
 };
 
-function requireStringArray(input: Record<string, unknown>, key: string): string[] {
-	const value = input[key];
-	if (!Array.isArray(value) || value.length === 0) {
-		throw new Error(`Missing required non-empty string array argument "${key}".`);
-	}
-	const strings = value.map((_, index) => asString({ value: value[index] }, 'value'));
-	if (strings.some(value => !value)) {
-		throw new Error(`Missing required non-empty string array argument "${key}".`);
-	}
-	return strings as string[];
-}
-
 async function runListTriggers(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_TRIGGER_LIMIT, MAX_TRIGGER_LIMIT);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listTriggersInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_TRIGGER_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_TRIGGERS_QUERY, variables);
 	const triggers = ((data as { triggers?: unknown[] } | undefined)?.triggers ?? []) as {
@@ -141,8 +124,8 @@ async function runListTriggers(input: Record<string, unknown>, ctx: CapabilityCo
 }
 
 async function runListForms(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_FORM_LIMIT, MAX_FORM_LIMIT);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listFormsInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_FORM_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_FORMS_QUERY, variables);
 	const forms = ((data as { forms?: unknown[] } | undefined)?.forms ?? []) as {
@@ -155,8 +138,8 @@ async function runListForms(input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListTags(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_TAG_LIMIT, MAX_TAG_LIMIT);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listTagsInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_TAG_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_TAGS_QUERY, variables);
 	const tags = ((data as { tags?: unknown[] } | undefined)?.tags ?? []) as {
@@ -169,11 +152,8 @@ async function runListTags(input: Record<string, unknown>, ctx: CapabilityContex
 }
 
 async function runListOrgTriggerInstances(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(
-		asPositiveInt(input, 'limit') ?? DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT,
-		MAX_ORG_TRIGGER_INSTANCE_LIMIT,
-	);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listOrgTriggerInstancesInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_ORG_TRIGGER_INSTANCES_QUERY, variables);
 	const instances = ((data as { orgTriggerInstances?: unknown[] } | undefined)?.orgTriggerInstances ?? []) as {
@@ -196,8 +176,7 @@ async function runListOrgTriggerInstances(input: Record<string, unknown>, ctx: C
 
 // orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by trigger ids alone.
 async function runGetTriggerErrorStatus(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const triggerIds = requireStringArray(input, 'triggerIds');
+	const { triggerIds } = parseCapabilityInput(getTriggerErrorStatusInputSchema, input);
 	const variables = { triggerIds };
 	const data = await rawGraphqlOrThrow(ctx.session, GET_TRIGGER_ERROR_STATUS_QUERY, variables);
 	const statuses = ((data as { getTriggerErrorStatus?: Record<string, boolean> } | undefined)


### PR DESCRIPTION
## Summary

C2 phase 2 (epic #129). Migrates 9 capability files to derive their advertised `inputSchema` from the same Zod schema that validates runtime input, matching the pattern established in `rewstReadCapabilities.ts` (C2 phase 1).

## Files migrated

- `triggerFormCapabilities.ts`
- `packIntegrationCapabilities.ts`
- `orgUserCapabilities.ts`
- `pageTemplateCapabilities.ts`
- `jinjaDocsCapabilities.ts`
- `resultReadCapability.ts`
- `templateLinkCapabilities.ts`
- `templateSyncCapabilities.ts` (read spec only; write spec left for phase 3)
- `templateCloneCapabilities.ts`

## Tests

- New `capabilityInputSchemas.schemaParity.test.ts` with frozen legacy schema fixtures for all 9 files
- Runtime parse tests added to each existing capability test file
- All 1437 unit tests pass

## Acceptance criteria

- [x] `npm run lint` — clean
- [x] `npm run type-check` — clean
- [x] `npm run test:unit` — 1437 passing
- [x] `npm run changelog:check` — OK

## Changelog

`skip-changelog` justification: internal validation plumbing, no user-facing behaviour change. (A changelog note is included anyway per project convention.)