### PR TITLE
Epic #129: finish remaining roadmap work

### DIFF
--- a/.claude/commands/epic-implement.md
+++ b/.claude/commands/epic-implement.md
@@ -3,14 +3,14 @@ description: Execute an implementation spec produced by /epic-spec — the worke
 argument-hint: [spec file path, e.g. .claude/specs/e2-workflow-diagnose.md]
 ---
 
-You are the implementing agent for one epic-#129 PR in the rewst-buddy-vscode repo. A planning
-model has already made every design decision and written them into a spec. Your job is faithful
-execution, not design.
+You are the implementing agent for one specced PR in the rewst-buddy-vscode repo. A planning
+model (via /epic-spec) has already made every design decision and written them into a spec.
+Your job is faithful execution, not design.
 
 SPEC: $ARGUMENTS
 
 If no path was given, take the most recently modified file in `.claude/specs/`. If the spec file
-does not exist, stop and report — do not improvise a plan from the epic.
+does not exist, stop and report — do not improvise a plan from the issue(s) yourself.
 
 ## Authority order
 
@@ -56,7 +56,8 @@ Run every acceptance command the spec lists, in the spec's order, and fix until 
 never a substitute. Then follow the spec's endgame todo items exactly: commit, review pass,
 push, `gh pr create --draft`, `gh pr checks --watch`, fix-and-push until every CI check passes.
 
-- Never commit the spec file itself; it stays untracked.
+- Never commit the spec file itself; it stays untracked. Same for any `.claude/specs/plan-*.md`
+  plan file — check off the entry when the spec's todo list says to, but never commit it.
 - Never commit to main; never mark the PR ready for review.
 - Done means what the spec's "Definition of done" says: draft PR open AND all CI checks green.
   "PR opened" is not done.

--- a/.claude/commands/epic-spec.md
+++ b/.claude/commands/epic-spec.md
@@ -1,6 +1,6 @@
 ---
-description: Produce a self-contained implementation spec for one epic-#129 item, written for Sonnet 4.6 to execute
-argument-hint: [epic item or grouping, e.g. E2 or "D2.4 + D2.6"]
+description: Plan a set of GitHub issues into PR-sized work, then produce a self-contained implementation spec for one PR, written for Sonnet 4.6 to execute
+argument-hint: [issue number(s), epic ref, or plan item — e.g. "123", '123 145 167', 'epic 129 E2']
 ---
 
 You are a planning model producing an implementation spec for Sonnet 4.6 to execute in the
@@ -11,21 +11,53 @@ repo, so the spec must be self-contained.
 
 TARGET: $ARGUMENTS
 
-The target is one epic-#129 item or one of the epic's suggested PR-sized groupings
-(e.g. "E2", "D2.4 + D2.6", "E3.1–E3.5"). Scope = exactly one draft PR. If no target was
-given above, pick the next unchecked item in the epic's "Recommended order of PRs" whose
-dependencies (sequencing block) are all merged.
+The target names the work to spec. Accepted forms:
+
+- **One issue** (`123`, `#123`): scope = that issue as exactly one draft PR. If the issue is
+  too big for one cohesive PR, treat it like an epic (below) instead of speccing it whole.
+- **Several issues** (`123 145 167`): enter PLANNING MODE first (below), then spec the first
+  unblocked entry of the resulting plan.
+- **An epic-style issue with a checklist** (`epic 129`, optionally plus an item id like
+  `epic 129 E2`): the epic's items/groupings are the plan. With an item id, spec that item;
+  without one, pick the next unchecked item whose dependencies are merged. If the epic body
+  has no usable ordering, enter PLANNING MODE over its unchecked items.
+- **A plan item id** (`plan crash-fixes PR2` or just `PR2` when unambiguous): spec that entry
+  of the existing plan file.
+- **No target**: take the most recently modified `.claude/specs/plan-*.md`, verify its
+  checkboxes against reality (`gh issue view` / merged PRs — fix stale ones), and spec the
+  next unchecked entry whose dependencies are done. If no plan file exists, stop and ask for
+  a target instead of guessing.
+
+Scope of a spec is always exactly one draft PR.
+
+## Planning mode (multiple issues, or an epic without usable ordering)
+
+Before speccing anything:
+
+1. `gh issue view <n>` every target issue. Drop ones already closed or fixed by a merged PR
+   (check linked PRs); note that in the plan.
+2. Group the rest into PR-sized batches — one PR per cohesive effort, closely related fixes
+   batched (repo PR convention). Order batches by dependency, then by risk/value.
+3. Write the plan to `.claude/specs/plan-<kebab-slug>.md`: a checkbox list where each entry
+   has an id (`PR1`, `PR2`, …), the issue number(s) it covers, a one-line scope, its
+   dependencies (other entry ids), and a suggested branch name. Like spec files, plan files
+   are working material: never committed, never changelogged.
+4. Then spec the first unblocked entry, per the rest of this command. Later invocations pick
+   up the same plan file.
 
 ## Ground truth, in priority order
 
 1. `CLAUDE.md` at repo root — read fully; it is normative (capability authoring rules, testing,
    changelog, PR conventions, performance rules, AI-steering wording rules).
-2. Epic #129: run `gh issue view 129`. Read the target item's bullets verbatim — its "Do not"
-   bullets and its "Trio" bullet are requirements, copy them into the spec. Check the
-   sequencing block: if a dependency of the target is unmerged, stop and report that instead
-   of speccing. CAUTION: items A1–A4, B1, D1, D2.1–D2.3, D2.5 already landed (PRs #130, #131);
-   every file:line reference in the epic body predates those merges — re-verify each against
-   current code before citing it. Never copy an epic line number into your spec unverified.
+2. The target issue(s): `gh issue view <n>` each one, plus the plan file entry when speccing
+   from a plan. Read the target's bullets verbatim — any "Do not" bullets and any explicit
+   test/spec requirements are requirements, copy them into the spec. If a dependency of the
+   target (plan entry dependency, or an epic's sequencing block) is unmerged, stop and report
+   that instead of speccing. CAUTION: issue bodies go stale — parts may already be fixed by
+   merged PRs, and every file:line reference predates whatever landed since the issue was
+   written. Check the issue's linked/closing PRs, and re-verify each cited path and line
+   against current code before citing it. Never copy an issue's line number into your spec
+   unverified.
 3. `openspec/specs/*/spec.md` — behavioral baseline (session-auth, template-sync,
    template-linking, template-management, mcp-bridge, ai-chat, credential-server,
    language-navigation; conventions in openspec/specs/README.md).
@@ -99,8 +131,9 @@ every applicable one explicitly (skip inapplicable ones silently):
   `docs/reference.md` (commands/settings tables — must match `package.json` `contributes.*`
   titles exactly), and the README glance bullet. Conventions/internal detail never go in
   changelog or user docs.
-- **D3 only**: breaking tool renames ship in a stable EVEN minor; nightlies ride the next odd
-  minor. Old names stay aliased one release with a deprecation note in output.
+- **Breaking renames**: breaking tool/command renames ship in a stable EVEN minor; nightlies
+  ride the next odd minor. Old names stay aliased one release with a deprecation note in
+  output. (Only applies when the target renames something user-facing.)
 
 ## Process
 
@@ -111,7 +144,7 @@ every applicable one explicitly (skip inapplicable ones silently):
    and events are involved, and which openspec file owns the behavior.
 3. Identify each place where a plausible-but-wrong implementation exists. State the wrong
    approach Sonnet would take, then the required approach. Start from the trap list above and
-   the epic item's own "Do not" bullets; add target-specific ones you find in the code.
+   the target issue's own "Do not" bullets; add target-specific ones you find in the code.
 4. Pin contracts exactly: capability spec objects (name, description text, inputSchema,
    access, requiresOrg, scopedSessions), function signatures, storage keys + shapes, event
    names, settings ids. Ambiguity in contracts cascades; ambiguity in internal logic is fine.
@@ -125,16 +158,19 @@ every applicable one explicitly (skip inapplicable ones silently):
 ## Output destination
 
 Write the finished spec to a file with the Write tool:
-`.claude/specs/<kebab-case-target>.md` (e.g. `.claude/specs/e2-workflow-diagnose.md`) —
-the implementing agent picks it up from there. The file is working material, not part of
-the PR: it stays untracked; never commit it, never add a changelog note for it. In your
-chat reply, give only the file path plus a few-line summary (target chosen, key
-verification findings, anything that reshaped scope) — do not duplicate the spec body
-in the reply. If a spec file for the same target already exists, overwrite it.
+`.claude/specs/<kebab-case-target>.md` (e.g. `.claude/specs/issue-142-hover-cache.md` or
+`.claude/specs/crash-fixes-pr2.md` for a plan entry) — the implementing agent picks it up
+from there. The file is working material, not part of the PR: it stays untracked; never
+commit it, never add a changelog note for it. In your chat reply, give only the file path
+(plus the plan file path if planning mode ran) and a few-line summary (target chosen, key
+verification findings, anything that reshaped scope) — do not duplicate the spec body in
+the reply. If a spec file for the same target already exists, overwrite it.
 
 ## Output format (dense, written for a model, no prose padding)
 
-- Target & scope: epic item ids covered, items explicitly out of scope, branch name, PR title.
+- Target & scope: issue numbers / plan entry ids covered, things explicitly out of scope,
+  branch name, PR title, and the `Closes #<n>` lines the PR body must carry (only for issues
+  the PR fully resolves — partially addressed issues get `Part of #<n>` instead).
 - Project summary (max 10 lines, target-relevant slice only).
 - Spec delta: which `openspec/specs/*/spec.md`, the requirement/scenario text to add or change
   (SHALL / GIVEN-WHEN-THEN, matching the file's existing style, with a Source: line).
@@ -149,7 +185,7 @@ in the reply. If a spec file for the same target already exists, overwrite it.
 - Ordered implementation steps, each with: files touched, contract changes, done-check command.
 - Tricky sections: wrong approach vs required approach; include the exact test(s) that catch
   the wrong approach. Use pseudocode only where prose is ambiguous.
-- Do NOT: the epic item's "Do not" bullets plus applicable repo traps, as explicit
+- Do NOT: the target issue's "Do not" bullets plus applicable repo traps, as explicit
   anti-instructions.
 - Left to implementer discretion: name what you are deliberately not specifying.
 - Changelog: exact `changelog.d/<name>.md` contents verbatim (frontmatter + body), or
@@ -172,6 +208,8 @@ in the reply. If a spec file for the same target already exists, overwrite it.
   `- [ ] Open the draft PR with gh pr create --draft.`
   `- [ ] Watch CI with gh pr checks --watch until every check passes.`
   `- [ ] If CI fails, fix, push, and re-watch until every check passes.`
+  If this spec came from a plan file, append:
+  `- [ ] Check off this entry in <plan file path> (do not commit the plan file).`
 - Definition of done (spell this out verbatim in the spec): all acceptance commands green
   locally → commit → push → `gh pr create --draft` → `gh pr checks --watch` until every CI
   check passes. If CI fails, fix, push, and re-watch; the task is not done until the draft

--- a/.claude/commands/epic-test-review.md
+++ b/.claude/commands/epic-test-review.md
@@ -3,8 +3,9 @@ description: Codex follow-up review — verify spec-mandated tests exist, are ho
 argument-hint: [spec file path, e.g. .claude/specs/e2-workflow-diagnose.md]
 ---
 
-You are a test-integrity reviewer running after an implementing agent finished an epic-#129 PR
-branch in the rewst-buddy-vscode repo. You are NOT a general code reviewer.
+You are a test-integrity reviewer running after an implementing agent finished a specced PR
+branch (spec produced by /epic-spec) in the rewst-buddy-vscode repo. You are NOT a general
+code reviewer.
 
 SPEC: $ARGUMENTS
 

--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ scripts/wf-backups/
 .claudeignore
 .LOCAL
 .vscode/settings.json
+.superpowers/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -244,12 +244,13 @@ async execute(...args: unknown[]): Promise<void> {
 
 ## Data Persistence
 
-| Storage       | Key                    | Data                                  |
-| ------------- | ---------------------- | ------------------------------------- |
-| `globalState` | `RewstSessionProfiles` | Session metadata (org, region, label) |
-| `globalState` | `RewstTemplateLinks`   | File-to-template mappings             |
-| `secrets`     | `{orgId}`              | Encrypted cookies/tokens              |
-| `settings`    | `rewst-buddy.*`        | User preferences                      |
+| Storage       | Key                     | Data                                                                              |
+| ------------- | ----------------------- | --------------------------------------------------------------------------------- |
+| `globalState` | `SessionProfiles`       | Active session metadata (org, region, label)                                      |
+| `globalState` | `RewstAllKnownProfiles` | Cache of every known profile, active or not                                       |
+| `globalState` | `RewstTemplateLinks`    | File-to-template mappings                                                         |
+| `secrets`     | `{userId}`              | Encrypted cookies/tokens, keyed by user id (migrated from a legacy `{orgId}` key) |
+| `settings`    | `rewst-buddy.*`         | User preferences                                                                  |
 
 ## Logging
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -292,10 +292,12 @@ All components implement `vscode.Disposable` and push to `context.subscriptions`
 
 Capabilities live in `src/capabilities/*Capabilities.ts` and are surfaced to the MCP server and chat. Most review round-trips on these tools trace to a few rules — apply them up front instead of in follow-up commits.
 
-- **MCP inputs are NOT validated against `inputSchema`.** `McpActions` passes the raw `arguments` straight to `capability.run()` (see `src/mcp/McpActions.ts`); the schema is only advertised to the client, never enforced. So `run()` must defensively validate/coerce **every** input:
-    - Strings: `requireString` (required) / `asString` (optional) — never read `input.x` directly.
-    - Numbers: clamp — `Math.min(asPositiveInt(input, 'limit') ?? DEFAULT, MAX)`. `asPositiveInt` already rejects `0`, negatives, and fractions (returns `undefined`); preserve that property in any new numeric helper (e.g. `mapWithConcurrency` throws on a non-positive limit).
-    - Enums: validate against the allowed set before use — never blind-cast `input.kind as Kind`. An unexpected value must fall back to a safe default or throw, not slip through.
+- **MCP inputs are NOT validated against `inputSchema`.** `McpActions` passes the raw `arguments` straight to `capability.run()` (see `src/mcp/McpActions.ts`); the schema is only advertised to the client, never enforced. So `run()` must defensively validate/coerce **every** input through a capability-local Zod schema:
+    - Define a `z.object({…})` schema at the top of the capability file and call `parseCapabilityInput(schema, input)` at the start of `run()` — never read `input.x` directly.
+    - Strings: `requiredStringField(key)` (required, trimmed, non-empty) / `optionalStringField()` (optional, trimmed) / `requiredStringAllowEmptyField(key)` (required, empty string accepted — use for template bodies and org-variable values).
+    - Numbers: `optionalClampedInt(MAX)` — silently resolves non-number, non-finite, ≤0, and floor-to-≤0 inputs to `undefined`; apply `?? DEFAULT` after parsing. `mapWithConcurrency` throws on a non-positive limit.
+    - Enums: use `z.enum([…])` with a custom `error:` message — never blind-cast `input.kind as Kind`. An unexpected value must fall back to a safe default or throw, not slip through.
+    - Derive the advertised `inputSchema` from the same Zod schema via `toInputSchema(schema)` so description and behavior stay in sync.
 - **GraphQL error handling:** after every `rawGraphql`, check `errors` and throw _with context_ — include the serialized errors in the message (`GraphQL error: ...`), never a bare `throw new Error()` (which discards the failure).
 - **Description ↔ behavior parity:** if a tool's `description`/`inputSchema` says it returns or accepts a field, the handler must actually surface/use it. Drift (e.g. fetching `roleIds` but dropping them from the output) gets flagged.
 - **Build list output from the requested inputs, not the response keys.** Iterate the requested `ids`/`triggerIds` and look each up, so a missing or empty (`{}`) response yields deterministic rows (`unknown`) instead of dropped entries or a blank line.

--- a/changelog.d/2.md
+++ b/changelog.d/2.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 2
+---
+
+- Internal: remaining read/local capability files now derive their advertised input schema from the same Zod schema that validates runtime input (no user-facing behaviour change).

--- a/changelog.d/2.md
+++ b/changelog.d/2.md
@@ -1,6 +1,0 @@
----
-category: Fixed
-pr: 2
----
-
-- Internal: remaining read/local capability files now derive their advertised input schema from the same Zod schema that validates runtime input (no user-facing behaviour change).

--- a/changelog.d/d3-remove-deprecated-tool-aliases.md
+++ b/changelog.d/d3-remove-deprecated-tool-aliases.md
@@ -1,0 +1,5 @@
+---
+category: Removed
+---
+
+- **Buddy tool aliases removed:** deprecated template, Jinja filter, action, and workflow-execution tool names now require their canonical replacements.

--- a/changelog.d/d3-tool-consolidation.md
+++ b/changelog.d/d3-tool-consolidation.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Buddy tool names are simpler:** duplicate template, Jinja filter, action, and execution tools now use canonical replacements.

--- a/changelog.d/d4-session-state.md
+++ b/changelog.d/d4-session-state.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **Session restore is more reliable:** Rewst Buddy now stores credentials per signed-in user and avoids startup races when several session consumers load at once.

--- a/changelog.d/workflow-input-profiles.md
+++ b/changelog.d/workflow-input-profiles.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- **Workflow input profiles:** save named payloads for repeatable workflow test runs and call them from `buddy_workflow_run` without retyping JSON each time.

--- a/changelog.d/workflow-lint-tool.md
+++ b/changelog.d/workflow-lint-tool.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+- Add the `buddy_workflow_lint` read-only AI tool that audits a workflow's structure — unreachable tasks, shadowed or missing default transitions, action tasks without retry/timeout, enabled mock input, and a size heuristic — without editing it.

--- a/docs/dev/graphql-field-guide.md
+++ b/docs/dev/graphql-field-guide.md
@@ -96,15 +96,16 @@ Status: implemented, type-checked, unit-tested (full unit suite green), and live
 - `buddy_list_workflows` (FIX — `workflows(where:{orgId})`, name filter → `_ilike`)
 - `buddy_resolve_reference` — universal name→id over `localReferenceOptions` (13 model types)
 - `buddy_list_org_variables` — `orgVariables` with `maskSecrets:true`
-- `buddy_find_action` — `searchInstalledPackActions`, flatten + cap client-side
-- `buddy_list_workflow_executions`, `buddy_latest_workflow_execution`, `buddy_get_workflow_execution_stats`
+- `buddy_action_search` — installed/catalog action lookup
+- `buddy_workflow_executions`, `buddy_get_workflow_execution_stats`
 - `buddy_list_workflow_tasks`, `buddy_list_workflow_patches`, `buddy_get_workflow_patch`
 - `buddy_find_executions_by_variable` — find a workflow's executions by an input/output/context variable name (+ optional value); input/output inline via `conductor`, context via the N+1 `workflowExecutionContexts` fetch
 
 **`triggerFormCapabilities.ts`**: `buddy_list_triggers`, `buddy_list_forms`, `buddy_list_tags`, `buddy_list_org_trigger_instances`, `buddy_get_trigger_error_status`
 **`packIntegrationCapabilities.ts`**: `buddy_list_installed_packs`, `buddy_get_pack_auth_status`, `buddy_list_pack_configs`, `buddy_list_integrations`
 **`orgUserCapabilities.ts`**: `buddy_search_organizations`, `buddy_list_users`, `buddy_list_roles`
-**`pageTemplateCapabilities.ts`**: `buddy_search_templates`, `buddy_list_pages`, `buddy_list_sites`, `buddy_list_jinja_filters`
+**`pageTemplateCapabilities.ts`**: `buddy_list_pages`, `buddy_list_sites`
+**`rewstReadCapabilities.ts`**: `buddy_search_templates`, workflow/task/patch/stat read helpers, org variables, generic reference resolution
 
 ### Not built (deferred — lower value / informed by Haiku findings)
 
@@ -125,12 +126,12 @@ Status: implemented, type-checked, unit-tested (full unit suite green), and live
 
 A Haiku (weak) model ran 9 realistic tasks against the live tools using **descriptions only** (no field guide). 6 solved cleanly, 2 partial, all completed. Tool-description/narrowing fixes it surfaced:
 
-1. **`buddy_find_action` — filter scope unspecified.** Description doesn't say what the `filter` matches (name? ref? description?). It matches the **display name** only (case-insensitive substring) — `filter:"send email"` finds nothing though "Send Mail…" actions exist. → State the scope explicitly.
-2. **`buddy_find_action` — return format ambiguous.** `"ref-or-name (id) — pack: description"` doesn't say which token is the ref vs the name, or when `ref` is null (workflow-as-action rows show the name). → Spell out the line format + that `id` is the action id, `ref` the callable reference (null ⇒ name shown).
+1. **`buddy_action_search` — query scope should stay explicit.** Description should make clear whether the query searches installed actions, catalog actions, or describe mode.
+2. **`buddy_action_search` — return format should stay explicit.** Spell out which token is the callable ref vs display name, and when describe mode is needed for inputs.
 3. **`buddy_search_organizations` — `orgId` semantics unclear.** It reads as a scope filter but is only session routing; results span **all** managed orgs filtered by name, not sub-orgs of `orgId`. → Say "orgId only selects the session; results span all managed orgs."
-4. **Action `ref` vs `id` usage not documented** — model couldn't tell which to use downstream. → One line in `buddy_find_action`.
+4. **Action `ref` vs `id` usage must stay documented** — model couldn't tell which to use downstream. → Keep one line in `buddy_action_search`.
 5. **`buddy_search_organizations` vs `buddy_list_orgs` overlap** — two ways to find orgs. → Cross-reference: `buddy_search_organizations` is preferred for name lookup; `buddy_list_orgs` is the full enumeration.
-6. **`buddy_find_action` vs existing `buddy_action_search` overlap** — two action finders. → Cross-reference (buddy_find_action = org-scoped installed-pack actions).
+6. **Action finder overlap was removed in D3** — keep `buddy_action_search` as the single action lookup entry point.
 
 Also observed: for "find a workflow by name," Haiku reached for `buddy_workflow_search` over `buddy_resolve_reference(Workflow)` — the generic resolver competes with type-specific tools (acceptable; both work). **No tool removals indicated** — all fixes are description tightenings.
 
@@ -209,7 +210,7 @@ Grouped by domain. `wave` = which explorer batch owns it; `status` updated as fi
 | `orgInterpreterSetting`       | EMPTY      | **Must** pass both `orgId` AND `language` — `language`-less call crashes; by-`id` crashes on not-found.                              |
 | `orgInterpreterSettings`      | EMPTY      | `orgId: ID!` top-level. Safe plural — `[]` not crash.                                                                                |
 
-**Tool candidates:** enhance existing `buddy_list_templates` with `search`+`order`+pagination (currently it just enumerates); a Jinja-filter-docs search wrapper (large payload → searchable, return signature-only); `cratesForTemplate` clean single-arg lookup.
+**Tool candidates:** `buddy_search_templates` already supports `search`+`order`+pagination (D3 consolidated it into `rewstReadCapabilities.ts` with raw GraphQL); a Jinja-filter-docs search wrapper (large payload → searchable, return signature-only); `cratesForTemplate` clean single-arg lookup.
 
 ### Workflows (core) — _wave 1 · done_
 

--- a/docs/dev/mcp-server-design.md
+++ b/docs/dev/mcp-server-design.md
@@ -104,7 +104,7 @@ external clients, `CopyMcpConfig` copies a credential-free client config JSON: t
 `/mcp` URL plus the `REWST_BUDDY_MCP_TOKEN` Bearer placeholder. No `node`, no
 spawned process, no discovery file.
 
-Initial read tools: `buddy_list_orgs`, `buddy_list_templates`, `buddy_get_template`,
+Initial read tools: `buddy_list_orgs`, `buddy_search_templates`, `buddy_get_template`,
 `buddy_list_workflows`, `buddy_get_workflow`, `buddy_graphql_query` (read-only), `buddy_get_bundle`.
 Resources: `rewst://{org}/templates`, `…/templates/{id}`, `…/workflows`.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -162,7 +162,7 @@ Cage-Free Rewsty is still told your VS Code working directory when one is open, 
 
 Rewst-specific actions are exposed through the Rewst Buddy MCP server instead of the chat LM tool surface. MCP exposure uses three switches:
 
-- `rewst-buddy.mcp.enable` exposes all read capabilities: `buddy_list_orgs`, `buddy_search_templates`, `buddy_get_template`, `buddy_list_workflows`, `buddy_get_workflow`, `buddy_graphql_query`, `buddy_graphql_schema`, `buddy_search_template_links`, `buddy_template_link_status`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_workflow_diagnose`, `buddy_render_jinja`, `buddy_action_search`, `buddy_workflow_impact`, `buddy_search_crates`, `buddy_get_jinja_filter_docs`, and `buddy_result_read`.
+- `rewst-buddy.mcp.enable` exposes all read capabilities: `buddy_list_orgs`, `buddy_search_templates`, `buddy_get_template`, `buddy_list_workflows`, `buddy_get_workflow`, `buddy_workflow_lint`, `buddy_graphql_query`, `buddy_graphql_schema`, `buddy_search_template_links`, `buddy_template_link_status`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_workflow_diagnose`, `buddy_render_jinja`, `buddy_action_search`, `buddy_workflow_impact`, `buddy_search_crates`, `buddy_get_jinja_filter_docs`, and `buddy_result_read`.
 - `rewst-buddy.mcp.enableWriteTools` adds the write tools that change Rewst data: workflow editing, auto-layout, and runs; workflow create/delete; template create, edit, rename, delete, and sync; and org-variable, tag, and trigger changes.
 - `rewst-buddy.mcp.enableDangerousGraphqlMutation` unlocks only `buddy_graphql_mutate`, the raw GraphQL mutation tool.
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -147,7 +147,7 @@ Cage-Free Rewsty is still told your VS Code working directory when one is open, 
 
 Rewst-specific actions are exposed through the Rewst Buddy MCP server instead of the chat LM tool surface. MCP exposure uses three switches:
 
-- `rewst-buddy.mcp.enable` exposes all read capabilities: `buddy_list_orgs`, `buddy_list_templates`, `buddy_get_template`, `buddy_list_workflows`, `buddy_get_workflow`, `buddy_graphql_query`, `buddy_graphql_schema`, `buddy_search_template_links`, `buddy_template_link_status`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_workflow_diagnose`, `buddy_render_jinja`, `buddy_action_search`, `buddy_workflow_impact`, `buddy_search_crates`, `buddy_list_jinja_filters`, `buddy_get_jinja_filter_docs`, and `buddy_result_read`.
+- `rewst-buddy.mcp.enable` exposes all read capabilities: `buddy_list_orgs`, `buddy_search_templates`, `buddy_get_template`, `buddy_list_workflows`, `buddy_get_workflow`, `buddy_graphql_query`, `buddy_graphql_schema`, `buddy_search_template_links`, `buddy_template_link_status`, `buddy_workflow_get`, `buddy_workflow_search`, `buddy_workflow_executions`, `buddy_execution_logs`, `buddy_workflow_diagnose`, `buddy_render_jinja`, `buddy_action_search`, `buddy_workflow_impact`, `buddy_search_crates`, `buddy_get_jinja_filter_docs`, and `buddy_result_read`.
 - `rewst-buddy.mcp.enableWriteTools` adds the write tools that change Rewst data: workflow editing, auto-layout, and runs; workflow create/delete; template create, edit, rename, delete, and sync; and org-variable, tag, and trigger changes.
 - `rewst-buddy.mcp.enableDangerousGraphqlMutation` unlocks only `buddy_graphql_mutate`, the raw GraphQL mutation tool.
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -136,7 +136,7 @@ read capabilities and gates as tools. Resource URIs SHALL use the
 - **GIVEN** a `rewst://org-1/templates` resource URI
 - **WHEN** an MCP client reads that resource
 - **THEN** the bridge runs the same gated capability used by
-  `buddy_list_templates`
+  `buddy_search_templates`
 - **AND** the read is subject to the same scope and rate-limit rules as a tool
   call
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -476,13 +476,12 @@ message -- never a raw serialized list of every issue.
 - **THEN** the capability rejects the call with a single message naming the
   missing argument
 
-Implementation status: as of this requirement's schema-based rewrite,
-`src/capabilities/rewstReadCapabilities.ts` validates through per-capability
-Zod schemas per the contract above (`inputHelpers.ts`'s
-`parseCapabilityInput` + `toInputSchema`). Read/local capabilities outside
-`rewstReadCapabilities.ts` now derive their advertised input schema from the
-same Zod schema that parses runtime input. Write capabilities still use the
-legacy helpers until the follow-up C2 write-capability migration.
+Implementation status: complete. All registry capabilities parse runtime input
+through capability-local Zod schemas and derive advertised input schemas from
+those schemas via `parseCapabilityInput` + `toInputSchema` (`inputHelpers.ts`).
+The legacy hand-written string/integer helper exports (`requireString`,
+`asString`, `asPositiveInt`, `requireStringAllowEmpty`, `ORG_ID_PROP`) have
+been removed from `inputHelpers.ts` and from new capability authoring guidance.
 
 ### Requirement: Verify saved task inputs after a workflow edit
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -479,10 +479,10 @@ message -- never a raw serialized list of every issue.
 Implementation status: as of this requirement's schema-based rewrite,
 `src/capabilities/rewstReadCapabilities.ts` validates through per-capability
 Zod schemas per the contract above (`inputHelpers.ts`'s
-`parseCapabilityInput` + `toInputSchema`). The remaining capability files
-still validate via the hand-rolled `asString`/`requireString`/`asPositiveInt`
-helpers in `inputHelpers.ts`; they migrate to the same schema-based contract
-incrementally in follow-up PRs (epic #129 C2).
+`parseCapabilityInput` + `toInputSchema`). Read/local capabilities outside
+`rewstReadCapabilities.ts` now derive their advertised input schema from the
+same Zod schema that parses runtime input. Write capabilities still use the
+legacy helpers until the follow-up C2 write-capability migration.
 
 ### Requirement: Verify saved task inputs after a workflow edit
 

--- a/openspec/specs/session-auth/spec.md
+++ b/openspec/specs/session-auth/spec.md
@@ -55,15 +55,14 @@ id, so the user never has to pick a region manually.
 
 ### Requirement: Store credentials securely
 
-The system SHALL store the raw session cookie only in VS Code `secrets`, keyed by
-the session profile's primary organization id. Non-secret session metadata
-(region, org, managed orgs, label, user) SHALL be stored in `globalState` under
+The system SHALL store the raw session cookie only in VS Code `secrets`, keyed
+by the authenticated user's id. Non-secret session metadata (region, org,
+managed orgs, label, user) SHALL be stored in `globalState` under
 `SessionProfiles`. The system SHALL also maintain a non-secret
 `RewstAllKnownProfiles` cache for profiles that have been seen before, including
-profiles that are not currently active. Managed organization ids MAY resolve to
-the profile through non-secret indexes, but their ids SHALL NOT be relied on as
-the primary secret key for restoration. The cookie SHALL NOT be written to
-`globalState`.
+profiles that are not currently active. Organization ids MAY resolve to the
+profile through non-secret indexes, but SHALL NOT be used as the secret key.
+The cookie SHALL NOT be written to `globalState`.
 
 **Implementation status:** today known-profile lookup resolves by org id without
 distinguishing region; the region-aware selection described in the scenario
@@ -71,12 +70,31 @@ below is the target lookup contract and is tracked as follow-up work.
 
 #### Scenario: Credential placement after login
 
-- **GIVEN** a session is successfully established for org `org-123`
+- **GIVEN** a session is successfully established for user `user-123` in org
+  `org-123`
 - **WHEN** persistence runs
-- **THEN** the cookie value is stored via `secrets` under key `org-123`
+- **THEN** the cookie value is stored via `secrets` under key `user-123`
+- **AND** any cookie previously stored under the legacy org-id key `org-123` is
+  deleted
 - **AND** the session profile (without the cookie) is stored under
   `SessionProfiles`
 - **AND** the profile is included in `RewstAllKnownProfiles`
+
+#### Scenario: Restoring a legacy org-keyed cookie
+
+- **GIVEN** a saved profile with user id `U` and primary org id `O`
+- **AND** `secrets` contains a cookie under `O` but not under `U`
+- **WHEN** sessions are loaded
+- **THEN** the cookie is read from `O`, the session is restored, and the
+  cookie is written under `U`
+
+#### Scenario: Removing one of two sessions with the same primary org
+
+- **GIVEN** two saved profiles with distinct user ids and the same primary org
+  id
+- **WHEN** one profile is removed
+- **THEN** only that user's credential is deleted
+- **AND** the remaining session can still be restored
 
 #### Scenario: Known profile lookup
 
@@ -283,12 +301,12 @@ expires.
 
 The system SHALL provide a way to remove all saved Rewst sessions, not merely
 disconnect active in-memory sessions. Clearing sessions SHALL delete raw cookies
-from VS Code `secrets` for every active or known session profile, including
-primary organization keys and any legacy managed-organization secret keys if
-present. It SHALL remove `SessionProfiles` and `RewstAllKnownProfiles` from
-`globalState`, clear in-memory sessions, org indexes, validation caches, and
-known-profile caches, and update extension context so no session is considered
-active.
+from VS Code `secrets` for every active or known session profile, keyed by user
+id, plus any legacy org-id-keyed cookies (primary or managed org) left over from
+before migration. It SHALL remove `SessionProfiles` and `RewstAllKnownProfiles`
+from `globalState`, clear in-memory sessions, org indexes, validation caches,
+and known-profile caches, and update extension context so no session is
+considered active.
 
 #### Scenario: User clears sessions
 
@@ -296,8 +314,8 @@ active.
 - **WHEN** the user runs `Rewst Buddy: Clear Sessions`
 - **THEN** active profiles are removed from `SessionProfiles`
 - **AND** all known profiles are removed from `RewstAllKnownProfiles`
-- **AND** raw cookies for active, known, and legacy managed-org profile keys are
-  deleted from VS Code `secrets`
+- **AND** raw cookies for active and known profiles' user-id keys, plus any
+  legacy org-id keys, are deleted from VS Code `secrets`
 - **AND** no org id resolves to an active session
 - **AND** the Sessions tree is emptied
 
@@ -306,17 +324,19 @@ active.
 - **GIVEN** no session is active
 - **AND** `RewstAllKnownProfiles` contains previously saved profiles
 - **WHEN** the user runs `Rewst Buddy: Clear Sessions`
-- **THEN** known profiles and their primary-org and legacy managed-org secrets
-  are removed
+- **THEN** known profiles and their user-id-keyed and legacy org-id-keyed
+  secrets are removed
 - **AND** future startup does not restore those sessions without a new cookie
 
 ### Requirement: Remove a single session
 
 The system SHALL provide a way to remove one authenticated or previously
 authenticated session — active or known-only — without disturbing any other
-session. Removing a session SHALL delete its raw cookie(s) from VS Code
-`secrets` (primary organization key and any legacy managed-organization keys),
-except keys another remaining profile still needs, remove its profile from
+session. Removing a session SHALL delete its cookie from VS Code `secrets`
+under its user-id key, plus any legacy cookie left at its primary-organization
+key. Because cookies are keyed by user id, removing one session cannot delete
+another session's cookie even when their organizations overlap, so no
+retained-key bookkeeping is needed. Removal SHALL remove the profile from
 `SessionProfiles` (if active) and `RewstAllKnownProfiles`, and clear its
 entries from in-memory sessions and org indexes before any persistence await,
 so the session stops resolving the moment removal is confirmed. If the removed
@@ -352,12 +372,13 @@ cookie.
 - **THEN** the extension no longer considers any session active
 - **AND** the background credential-refresh interval stops
 
-#### Scenario: A secret shared with another profile survives removal
+#### Scenario: Another session survives removal even when their orgs overlap
 
 - **GIVEN** session A whose managed orgs include the primary org of session B
 - **WHEN** the user removes session A
-- **THEN** session A's own cookie is deleted from `secrets`
-- **AND** the cookie stored under session B's primary org id is kept
+- **THEN** session A's own user-keyed cookie is deleted from `secrets`
+- **AND** session B's user-keyed cookie is unaffected, because cookies are
+  keyed by user id rather than org id
 - **AND** session B still resolves for its orgs
 
 #### Scenario: A session being removed stops resolving immediately

--- a/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
+++ b/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
@@ -1,0 +1,374 @@
+/**
+ * C2 phase 2 schema parity test — frozen LEGACY_SCHEMAS fixture.
+ *
+ * Captures the hand-written inputSchema objects from the 9 target capability
+ * files exactly as they existed BEFORE the Zod migration. After migration,
+ * the derived schemas are compared field-by-field against this fixture to
+ * ensure no required field was dropped, no type changed, and no description
+ * was silently lost.
+ *
+ * Runner: mocha / extension-host (same suite as rewstReadCapabilities.schemaParity.test.ts).
+ */
+
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
+import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
+import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
+import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
+import { JINJA_DOCS_CAPABILITIES } from './jinjaDocsCapabilities';
+import { resultReadCapability } from './resultReadCapability';
+import { TEMPLATE_LINK_CAPABILITIES } from './templateLinkCapabilities';
+import { TEMPLATE_SYNC_CAPABILITIES } from './templateSyncCapabilities';
+import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
+
+const { suite, test } = Mocha;
+
+// ---------------------------------------------------------------------------
+// Frozen legacy schemas — verbatim copy of the pre-migration inputSchema
+// objects. Do NOT update these when migrating; they are the regression guard.
+// ---------------------------------------------------------------------------
+
+interface LegacyProperty {
+	type: string;
+	description?: string;
+	items?: { type: string };
+	enum?: readonly string[];
+}
+
+interface LegacySchema {
+	properties: Record<string, LegacyProperty>;
+	required?: string[];
+}
+
+const ORG_ID_DESC = 'Rewst organization id the operation runs against (from buddy_list_orgs).';
+
+const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
+	// --- triggerFormCapabilities ---
+	buddy_list_triggers: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max triggers to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_forms: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max forms to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_tags: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max tags to return (default 100, max 500).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_org_trigger_instances: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: {
+				type: 'number',
+				description: 'Max trigger activation instances to return (default 50, max 200).',
+			},
+		},
+		required: ['orgId'],
+	},
+	buddy_get_trigger_error_status: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			triggerIds: { type: 'array', items: { type: 'string' }, description: 'Trigger ids to check.' },
+		},
+		required: ['orgId', 'triggerIds'],
+	},
+	// --- packIntegrationCapabilities ---
+	buddy_list_installed_packs: {
+		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
+		required: ['orgId'],
+	},
+	buddy_get_pack_auth_status: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			packName: { type: 'string', description: 'A pack ref, e.g. microsoft_graph' },
+		},
+		required: ['orgId', 'packName'],
+	},
+	buddy_list_pack_configs: {
+		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
+		required: ['orgId'],
+	},
+	buddy_list_integrations: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max integrations to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	// --- orgUserCapabilities ---
+	buddy_search_organizations: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'integer', description: 'Max organizations to return (default 25, max 100).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_users: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional username substring.' },
+			limit: { type: 'integer', description: 'Max users to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_roles: {
+		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
+		required: ['orgId'],
+	},
+	// --- pageTemplateCapabilities ---
+	buddy_search_templates: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'number', description: 'Max templates to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_pages: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			limit: { type: 'number', description: 'Max pages to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	buddy_list_sites: {
+		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
+		required: ['orgId'],
+	},
+	buddy_list_jinja_filters: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'number', description: 'Max filters to return (default 50, max 200).' },
+		},
+		required: ['orgId'],
+	},
+	// --- jinjaDocsCapabilities ---
+	buddy_get_jinja_filter_docs: {
+		properties: {
+			name: {
+				type: 'string',
+				description: 'Exact filter name to fetch full documentation for (case-insensitive).',
+			},
+			search: {
+				type: 'string',
+				description: 'Keyword to match against filter names and documentation.',
+			},
+		},
+		required: [],
+	},
+	// --- resultReadCapability ---
+	buddy_result_read: {
+		properties: {
+			id: { type: 'string', description: 'Cached result id returned by an oversized Rewst Buddy tool result.' },
+			offset: { type: 'number', description: 'Character offset to start reading from (default 0).' },
+			limit: { type: 'number', description: 'Maximum characters to return (default 6000, max 8000).' },
+			search: {
+				type: 'string',
+				description: 'Search text; returns matching lines with line numbers instead of a slice.',
+			},
+		},
+		required: ['id'],
+	},
+	// --- templateLinkCapabilities ---
+	buddy_template_link: {
+		properties: {
+			templateId: {
+				type: 'string',
+				description: 'Id of the existing Rewst template to link the file to (from buddy_list_templates).',
+			},
+			uri: {
+				type: 'string',
+				description:
+					'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
+			},
+			orgId: {
+				type: 'string',
+				description:
+					'Optional org id to verify the template belongs to. Defaults to the template\u2019s own org.',
+			},
+			overwrite: {
+				type: 'boolean',
+				description:
+					'If the file is already linked, replace the existing link instead of failing. Default false.',
+			},
+		},
+		required: ['templateId', 'uri'],
+	},
+	buddy_template_link_status: {
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Absolute path, workspace-relative path, or file:// URI of the local file to check.',
+			},
+		},
+		required: ['uri'],
+	},
+	buddy_template_unlink: {
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Path or file URI of the linked file, as shown by buddy_search_template_links.',
+			},
+		},
+		required: ['uri'],
+	},
+	buddy_template_sync_on_save: {
+		properties: {
+			uri: { type: 'string', description: 'Path or file URI of the linked file.' },
+			enabled: {
+				type: 'boolean',
+				description: 'true to enable sync-on-save (upload on save), false to disable.',
+			},
+		},
+		required: ['uri', 'enabled'],
+	},
+	// --- templateSyncCapabilities (read spec only) ---
+	buddy_template_sync_status: {
+		properties: {
+			uri: {
+				type: 'string',
+				description: 'Path or file URI of the linked file, as shown by buddy_search_template_links.',
+			},
+		},
+		required: ['uri'],
+	},
+	// --- templateCloneCapabilities ---
+	buddy_template_bundle_clone: {
+		properties: {
+			orgId: { type: 'string', description: ORG_ID_DESC },
+			rootTemplateId: { type: 'string', description: 'Id of the root template to deep-clone.' },
+			sourceOrgId: {
+				type: 'string',
+				description:
+					'Optional id of the org the root and its references live in. Verified against the root; defaults to the root\u2019s org.',
+			},
+			namePrefix: { type: 'string', description: 'Optional prefix for cloned template names.' },
+			nameSuffix: {
+				type: 'string',
+				description: 'Optional suffix for cloned template names. Defaults to " (copy)".',
+			},
+			maxTemplates: {
+				type: 'number',
+				description: 'Max total templates to clone (root + references). Default 50, capped at 200.',
+			},
+			maxDepth: { type: 'number', description: 'Max reference depth to walk. Default 10, capped at 25.' },
+		},
+		required: ['orgId', 'rootTemplateId'],
+	},
+};
+
+// ---------------------------------------------------------------------------
+// Helpers (same contract as rewstReadCapabilities.schemaParity.test.ts)
+// ---------------------------------------------------------------------------
+
+function getSchema(cap: { spec: { inputSchema?: unknown } }): {
+	properties: Record<string, { type?: string; description?: string; enum?: string[]; items?: unknown }>;
+	required?: string[];
+} {
+	return (cap.spec.inputSchema ?? { properties: {} }) as ReturnType<typeof getSchema>;
+}
+
+function assertSchemaParity(toolName: string, legacy: LegacySchema, derived: ReturnType<typeof getSchema>): void {
+	// 1. required fields match
+	const legacyRequired = new Set(legacy.required ?? []);
+	const derivedRequired = new Set(derived.required ?? []);
+	for (const field of legacyRequired) {
+		assert.ok(derivedRequired.has(field), `${toolName}: required field "${field}" missing from derived schema`);
+	}
+
+	// 2. every legacy property key exists in derived
+	for (const key of Object.keys(legacy.properties)) {
+		assert.ok(key in (derived.properties ?? {}), `${toolName}: property "${key}" missing from derived schema`);
+	}
+
+	// 3. type matches (number/integer both acceptable for integer fields)
+	for (const [key, legacyProp] of Object.entries(legacy.properties)) {
+		const derivedProp = derived.properties[key];
+		if (!derivedProp) continue;
+		const legacyType = legacyProp.type;
+		const derivedType = derivedProp.type;
+		const typesCompatible =
+			legacyType === derivedType ||
+			(legacyType === 'integer' && derivedType === 'number') ||
+			(legacyType === 'number' && derivedType === 'integer');
+		assert.ok(
+			typesCompatible,
+			`${toolName}.${key}: type mismatch — legacy "${legacyType}" vs derived "${derivedType}"`,
+		);
+	}
+
+	// 4. enum values match when present
+	for (const [key, legacyProp] of Object.entries(legacy.properties)) {
+		if (!legacyProp.enum) continue;
+		const derivedProp = derived.properties[key];
+		if (!derivedProp?.enum) continue;
+		const legacyEnums = new Set(legacyProp.enum);
+		const derivedEnums = new Set(derivedProp.enum);
+		for (const v of legacyEnums) {
+			assert.ok(derivedEnums.has(v), `${toolName}.${key}: enum value "${v}" missing from derived schema`);
+		}
+	}
+
+	// 5. description present when legacy had one
+	for (const [key, legacyProp] of Object.entries(legacy.properties)) {
+		if (!legacyProp.description) continue;
+		const derivedProp = derived.properties[key];
+		if (!derivedProp) continue;
+		assert.ok(
+			typeof derivedProp.description === 'string' && derivedProp.description.length > 0,
+			`${toolName}.${key}: description missing from derived schema`,
+		);
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Collect all capabilities by tool name
+// ---------------------------------------------------------------------------
+
+const ALL_CAPS = [
+	...TRIGGER_FORM_CAPABILITIES,
+	...PACK_INTEGRATION_CAPABILITIES,
+	...ORG_USER_CAPABILITIES,
+	...PAGE_TEMPLATE_CAPABILITIES,
+	...JINJA_DOCS_CAPABILITIES,
+	resultReadCapability,
+	...TEMPLATE_LINK_CAPABILITIES,
+	...TEMPLATE_SYNC_CAPABILITIES,
+	...TEMPLATE_CLONE_CAPABILITIES,
+];
+
+const capByName = new Map(ALL_CAPS.map(c => [c.spec.name, c]));
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+suite('Unit: capabilityInputSchemas schemaParity', () => {
+	for (const [toolName, legacy] of Object.entries(LEGACY_SCHEMAS)) {
+		test(`${toolName} derived schema matches legacy`, () => {
+			const cap = capByName.get(toolName);
+			assert.ok(cap, `${toolName} not found in capability registry`);
+			const derived = getSchema(cap);
+			assertSchemaParity(toolName, legacy, derived);
+			// args must be generated from inputSchema (not hand-written)
+			assert.strictEqual(
+				cap.spec.args,
+				JSON.stringify(cap.spec.inputSchema),
+				`${toolName}: args must equal JSON.stringify(inputSchema)`,
+			);
+		});
+	}
+});

--- a/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
+++ b/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
@@ -32,13 +32,20 @@ const { suite, test } = Mocha;
 interface LegacyProperty {
 	type: string;
 	description?: string;
-	items?: { type: string };
+	items?: { type: string; enum?: readonly string[] };
 	enum?: readonly string[];
 }
 
 interface LegacySchema {
 	properties: Record<string, LegacyProperty>;
 	required?: string[];
+}
+
+interface SchemaProperty {
+	type?: string;
+	description?: string;
+	enum?: readonly string[];
+	items?: SchemaProperty;
 }
 
 const ORG_ID_DESC = 'Rewst organization id the operation runs against (from buddy_list_orgs).';
@@ -267,7 +274,7 @@ const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
 // ---------------------------------------------------------------------------
 
 function getSchema(cap: { spec: { inputSchema?: unknown } }): {
-	properties: Record<string, { type?: string; description?: string; enum?: string[]; items?: unknown }>;
+	properties: Record<string, { type?: string; description?: string; enum?: string[]; items?: SchemaProperty }>;
 	required?: string[];
 } {
 	return (cap.spec.inputSchema ?? { properties: {} }) as ReturnType<typeof getSchema>;
@@ -279,6 +286,9 @@ function assertSchemaParity(toolName: string, legacy: LegacySchema, derived: Ret
 	const derivedRequired = new Set(derived.required ?? []);
 	for (const field of legacyRequired) {
 		assert.ok(derivedRequired.has(field), `${toolName}: required field "${field}" missing from derived schema`);
+	}
+	for (const field of derivedRequired) {
+		assert.ok(legacyRequired.has(field), `${toolName}: field "${field}" became required unexpectedly`);
 	}
 
 	// 2. every legacy property key exists in derived
@@ -300,6 +310,20 @@ function assertSchemaParity(toolName: string, legacy: LegacySchema, derived: Ret
 			typesCompatible,
 			`${toolName}.${key}: type mismatch — legacy "${legacyType}" vs derived "${derivedType}"`,
 		);
+		if (legacyProp.type === 'array' && legacyProp.items) {
+			assert.strictEqual(
+				derivedProp.items?.type,
+				legacyProp.items.type,
+				`${toolName}.${key}: array item type mismatch`,
+			);
+			if (legacyProp.items.enum) {
+				const legacyItemEnums = new Set(legacyProp.items.enum);
+				const derivedItemEnums = new Set(derivedProp.items?.enum ?? []);
+				for (const v of legacyItemEnums) {
+					assert.ok(derivedItemEnums.has(v), `${toolName}.${key}: array item enum value "${v}" missing`);
+				}
+			}
+		}
 	}
 
 	// 4. enum values match when present

--- a/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
+++ b/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
@@ -147,14 +147,6 @@ const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
 		properties: { orgId: { type: 'string', description: ORG_ID_DESC } },
 		required: ['orgId'],
 	},
-	buddy_list_jinja_filters: {
-		properties: {
-			orgId: { type: 'string', description: ORG_ID_DESC },
-			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
-			limit: { type: 'number', description: 'Max filters to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
 	// --- jinjaDocsCapabilities ---
 	buddy_get_jinja_filter_docs: {
 		properties: {
@@ -187,7 +179,7 @@ const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
 		properties: {
 			templateId: {
 				type: 'string',
-				description: 'Id of the existing Rewst template to link the file to (from buddy_list_templates).',
+				description: 'Id of the existing Rewst template to link the file to (from buddy_search_templates).',
 			},
 			uri: {
 				type: 'string',

--- a/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
+++ b/src/capabilities/capabilityInputSchemas.schemaParity.test.ts
@@ -12,15 +12,15 @@
 
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
-import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
-import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
-import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 import { JINJA_DOCS_CAPABILITIES } from './jinjaDocsCapabilities';
+import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
+import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
+import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 import { resultReadCapability } from './resultReadCapability';
+import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
 import { TEMPLATE_LINK_CAPABILITIES } from './templateLinkCapabilities';
 import { TEMPLATE_SYNC_CAPABILITIES } from './templateSyncCapabilities';
-import { TEMPLATE_CLONE_CAPABILITIES } from './templateCloneCapabilities';
+import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 
 const { suite, test } = Mocha;
 

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -266,6 +266,11 @@ suite('Unit: inputHelpers — requiredStringAllowEmptyField', () => {
 		assert.strictEqual(result.body, 'hello');
 	});
 
+	test('preserves leading and trailing whitespace', () => {
+		const result = parseCapabilityInput(schema, { body: '  hello  ' });
+		assert.strictEqual(result.body, '  hello  ');
+	});
+
 	test('throws when the key is absent', () => {
 		assert.throws(() => parseCapabilityInput(schema, {}), /Missing required string argument "body"/);
 	});

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -8,7 +8,7 @@ import {
 	parseCapabilityInput,
 	rawGraphqlOrThrow,
 	requireResourceInOrg,
-	requireStringAllowEmpty,
+	requiredStringAllowEmptyField,
 	requiredStringField,
 	throwOnGraphqlErrors,
 	toInputSchema,
@@ -252,23 +252,25 @@ suite('Unit: inputHelpers', () => {
 	});
 });
 
-suite('Unit: inputHelpers — requireStringAllowEmpty', () => {
+suite('Unit: inputHelpers — requiredStringAllowEmptyField', () => {
+	const schema = z.object({ body: requiredStringAllowEmptyField('body') });
+
 	test('returns empty string for an empty-string value', () => {
-		const result = requireStringAllowEmpty({ body: '' }, 'body');
-		assert.strictEqual(result, '');
+		const result = parseCapabilityInput(schema, { body: '' });
+		assert.strictEqual(result.body, '');
 	});
 
-	test('returns the string unchanged (no trimming) for a padded value', () => {
-		const result = requireStringAllowEmpty({ body: '  hello  ' }, 'body');
-		assert.strictEqual(result, '  hello  ');
+	test('returns the string unchanged for a non-empty value', () => {
+		const result = parseCapabilityInput(schema, { body: 'hello' });
+		assert.strictEqual(result.body, 'hello');
 	});
 
 	test('throws when the key is absent', () => {
-		assert.throws(() => requireStringAllowEmpty({}, 'body'), /Missing required string argument "body"/);
+		assert.throws(() => parseCapabilityInput(schema, {}), /Missing required string argument "body"/);
 	});
 
 	test('throws when the value is a non-string (number)', () => {
-		assert.throws(() => requireStringAllowEmpty({ body: 42 }, 'body'), /Missing required string argument "body"/);
+		assert.throws(() => parseCapabilityInput(schema, { body: 42 }), /Missing required string argument "body"/);
 	});
 });
 

--- a/src/capabilities/inputHelpers.test.ts
+++ b/src/capabilities/inputHelpers.test.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 import { suite, test } from '../test/tdd';
 import {
 	mapWithConcurrency,
+	optionalBooleanField,
 	optionalClampedInt,
 	optionalStringField,
 	parseCapabilityInput,
@@ -409,6 +410,41 @@ suite('Unit: inputHelpers — optionalClampedInt', () => {
 		const schema = z.object({ n: optionalClampedInt(500) });
 		const result = parseCapabilityInput(schema, { n: 42 });
 		assert.strictEqual(result.n, 42);
+	});
+});
+
+suite('Unit: inputHelpers — optionalBooleanField', () => {
+	test('resolves undefined for missing key (no throw)', () => {
+		const schema = z.object({ flag: optionalBooleanField('flag') });
+		const result = parseCapabilityInput(schema, {});
+		assert.strictEqual(result.flag, undefined);
+	});
+
+	test('accepts true', () => {
+		const schema = z.object({ flag: optionalBooleanField('flag') });
+		const result = parseCapabilityInput(schema, { flag: true });
+		assert.strictEqual(result.flag, true);
+	});
+
+	test('accepts false', () => {
+		const schema = z.object({ flag: optionalBooleanField('flag') });
+		const result = parseCapabilityInput(schema, { flag: false });
+		assert.strictEqual(result.flag, false);
+	});
+
+	test('rejects a string value with a clear keyed message', () => {
+		const schema = z.object({ flag: optionalBooleanField('flag') });
+		assert.throws(() => parseCapabilityInput(schema, { flag: 'true' }), /"flag" must be a boolean/);
+	});
+
+	test('rejects a numeric value with a clear keyed message', () => {
+		const schema = z.object({ flag: optionalBooleanField('flag') });
+		assert.throws(() => parseCapabilityInput(schema, { flag: 1 }), /"flag" must be a boolean/);
+	});
+
+	test('rejects null with a clear keyed message', () => {
+		const schema = z.object({ flag: optionalBooleanField('flag') });
+		assert.throws(() => parseCapabilityInput(schema, { flag: null }), /"flag" must be a boolean/);
 	});
 });
 

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -204,6 +204,31 @@ export function optionalClampedInt(max: number): z.ZodType<number | undefined> {
 }
 
 /**
+ * Zod counterpart to requireStringAllowEmpty: required string that may be
+ * empty (e.g. template body, org-variable value). Missing key or non-string
+ * type throws; empty string is accepted.
+ */
+export function requiredStringAllowEmptyField(key: string): z.ZodString {
+	const message = `Missing required string argument "${key}".`;
+	return z.string({ error: message });
+}
+
+/**
+ * Optional boolean field that rejects non-boolean values with a clear message.
+ * Missing key resolves to undefined; wrong type throws.
+ */
+export function optionalBooleanField(key: string): z.ZodType<boolean | undefined> {
+	return z.preprocess(
+		raw => (raw === undefined ? undefined : raw),
+		z
+			.boolean({
+				error: `"${key}" must be a boolean.`,
+			})
+			.optional(),
+	);
+}
+
+/**
  * Shared orgId field for read-capability schemas; description text matches
  * the existing ORG_ID_PROP so the two stay in sync until every capability
  * migrates.

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -195,9 +195,7 @@ export function optionalBooleanField(key: string): z.ZodType<boolean | undefined
 }
 
 /**
- * Shared orgId field for read-capability schemas; description text matches
- * the existing ORG_ID_PROP so the two stay in sync until every capability
- * migrates.
+ * Shared orgId field for capability schemas.
  */
 export const ORG_ID_FIELD: z.ZodString = requiredStringField('orgId').describe(
 	'Rewst organization id the operation runs against (from buddy_list_orgs).',

--- a/src/capabilities/inputHelpers.ts
+++ b/src/capabilities/inputHelpers.ts
@@ -83,35 +83,6 @@ export async function getTemplateFromAnySession(
 	return undefined;
 }
 
-export function asString(input: Record<string, unknown>, key: string): string | undefined {
-	const value = input[key];
-	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
-}
-
-export function requireString(input: Record<string, unknown>, key: string): string {
-	const value = asString(input, key);
-	if (!value) throw new Error(`Missing required string argument "${key}".`);
-	return value;
-}
-
-/**
- * Like requireString but accepts an empty string as a valid value.
- * Throws only when the key is absent or the value is not a string.
- */
-export function requireStringAllowEmpty(input: Record<string, unknown>, key: string): string {
-	if (!(key in input) || typeof input[key] !== 'string') {
-		throw new Error(`Missing required string argument "${key}".`);
-	}
-	return input[key] as string;
-}
-
-export function asPositiveInt(input: Record<string, unknown>, key: string): number | undefined {
-	const value = input[key];
-	if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) return undefined;
-	const normalized = Math.floor(value);
-	return normalized > 0 ? normalized : undefined;
-}
-
 export async function mapWithConcurrency<T, R>(
 	items: readonly T[],
 	limit: number,
@@ -132,11 +103,6 @@ export async function mapWithConcurrency<T, R>(
 	await Promise.all(workers);
 	return results;
 }
-
-/** Standard orgId property block for capability inputSchemas. */
-export const ORG_ID_PROP = {
-	orgId: { type: 'string', description: 'Rewst organization id the operation runs against (from buddy_list_orgs).' },
-} as const;
 
 // ---------------------------------------------------------------------------
 // Zod-based helpers (C2 migration)
@@ -233,4 +199,6 @@ export function optionalBooleanField(key: string): z.ZodType<boolean | undefined
  * the existing ORG_ID_PROP so the two stay in sync until every capability
  * migrates.
  */
-export const ORG_ID_FIELD: z.ZodString = requiredStringField('orgId').describe(ORG_ID_PROP.orgId.description);
+export const ORG_ID_FIELD: z.ZodString = requiredStringField('orgId').describe(
+	'Rewst organization id the operation runs against (from buddy_list_orgs).',
+);

--- a/src/capabilities/jinjaDocsCapabilities.test.ts
+++ b/src/capabilities/jinjaDocsCapabilities.test.ts
@@ -58,6 +58,32 @@ suite('Unit: jinjaDocsCapabilities', () => {
 		_resetJinjaFilterFetcherForTesting();
 	});
 
+	// --- Zod parse tests ---
+	test('non-string name is ignored (not rejected)', async () => {
+		_setJinjaFilterFetcherForTesting(async () => parseJinjaFilters(SAMPLE_PAYLOAD));
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.doesNotReject(() => cap('buddy_get_jinja_filter_docs').run({ name: 42 }, ctx));
+	});
+
+	test('non-string search is ignored (not rejected)', async () => {
+		_setJinjaFilterFetcherForTesting(async () => parseJinjaFilters(SAMPLE_PAYLOAD));
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.doesNotReject(() => cap('buddy_get_jinja_filter_docs').run({ search: 99 }, ctx));
+	});
+
+	test('no-arg call lists filter names', async () => {
+		_setJinjaFilterFetcherForTesting(async () => parseJinjaFilters(SAMPLE_PAYLOAD));
+		const { ctx } = fakeCtx({ data: {} });
+		const output = await cap('buddy_get_jinja_filter_docs').run({}, ctx);
+		assert.ok(output.includes('abs'));
+	});
+
+	test('buddy_get_jinja_filter_docs derived schema has no required fields and args generated', () => {
+		const schema = cap('buddy_get_jinja_filter_docs').spec.inputSchema as { required?: string[] };
+		assert.ok(!schema.required || schema.required.length === 0);
+		assert.strictEqual(cap('buddy_get_jinja_filter_docs').spec.args, JSON.stringify(schema));
+	});
+
 	suite('parseJinjaFilters()', () => {
 		test('parses names, signatures, and documentation; sorts by name', () => {
 			const filters = parseJinjaFilters(SAMPLE_PAYLOAD);

--- a/src/capabilities/jinjaDocsCapabilities.test.ts
+++ b/src/capabilities/jinjaDocsCapabilities.test.ts
@@ -1,17 +1,17 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import type { CapabilityContext } from './Capability';
 import {
 	JINJA_DOCS_CAPABILITIES,
+	_resetJinjaFilterCacheForTesting,
+	_resetJinjaFilterFetcherForTesting,
+	_setJinjaFilterFetcherForTesting,
 	engineBaseFromRegion,
 	formatJinjaFilters,
 	getCachedFilters,
 	parseJinjaFilters,
 	primeFilters,
-	_resetJinjaFilterCacheForTesting,
-	_resetJinjaFilterFetcherForTesting,
-	_setJinjaFilterFetcherForTesting,
 	type JinjaFilterDoc,
 } from './jinjaDocsCapabilities';
 

--- a/src/capabilities/jinjaDocsCapabilities.ts
+++ b/src/capabilities/jinjaDocsCapabilities.ts
@@ -217,7 +217,7 @@ const getJinjaFilterDocsInputSchema = z.object({
 const getJinjaFilterDocsSpec: ToolSpecDefinition = {
 	name: 'buddy_get_jinja_filter_docs',
 	description:
-		'Read the documentation for Rewst\'s built-in Jinja filters (the same catalog Rewst\'s in-app editor uses, including the prose docs that buddy_list_jinja_filters omits). Pass "name" for one filter\'s full documentation, or "search" to match filters by name or documentation keyword. With no arguments, lists every filter name and signature so you can pick one. Read-only and not org-specific.',
+		'Read the documentation for Rewst\'s built-in Jinja filters from the same catalog Rewst\'s in-app editor uses. Pass "name" for one filter\'s full documentation, or "search" to match filters by name or documentation keyword. With no arguments, lists every filter name and signature so you can pick one. Read-only and not org-specific.',
 	inputSchema: toInputSchema(getJinjaFilterDocsInputSchema),
 };
 

--- a/src/capabilities/jinjaDocsCapabilities.ts
+++ b/src/capabilities/jinjaDocsCapabilities.ts
@@ -10,10 +10,11 @@
  */
 
 import { log } from '@utils';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asString } from './inputHelpers';
+import { optionalStringField, parseCapabilityInput, toInputSchema } from './inputHelpers';
 
 const FILTERS_PATH = '/jinja/intellisense/filters';
 const DEFAULT_ENGINE_BASE = 'https://engine.rewst.io';
@@ -208,26 +209,22 @@ async function getFilters(ctx: CapabilityContext): Promise<JinjaFilterDoc[]> {
 	return getFiltersForBase(engineBaseFrom(ctx));
 }
 
-const getJinjaFilterDocsSpec: ToolSpec = {
+const getJinjaFilterDocsInputSchema = z.object({
+	name: optionalStringField().describe('Exact filter name to fetch full documentation for (case-insensitive).'),
+	search: optionalStringField().describe('Keyword to match against filter names and documentation.'),
+});
+
+const getJinjaFilterDocsSpec: ToolSpecDefinition = {
 	name: 'buddy_get_jinja_filter_docs',
-	args: '{"name"?: string, "search"?: string}',
 	description:
 		'Read the documentation for Rewst\'s built-in Jinja filters (the same catalog Rewst\'s in-app editor uses, including the prose docs that buddy_list_jinja_filters omits). Pass "name" for one filter\'s full documentation, or "search" to match filters by name or documentation keyword. With no arguments, lists every filter name and signature so you can pick one. Read-only and not org-specific.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			name: {
-				type: 'string',
-				description: 'Exact filter name to fetch full documentation for (case-insensitive).',
-			},
-			search: { type: 'string', description: 'Keyword to match against filter names and documentation.' },
-		},
-	},
+	inputSchema: toInputSchema(getJinjaFilterDocsInputSchema),
 };
 
 async function runGetJinjaFilterDocs(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	const filters = await getFilters(ctx);
-	return formatJinjaFilters(filters, { name: asString(input, 'name'), search: asString(input, 'search') });
+	const { name, search } = parseCapabilityInput(getJinjaFilterDocsInputSchema, input);
+	return formatJinjaFilters(filters, { name, search });
 }
 
 export const JINJA_DOCS_CAPABILITIES: Capability[] = [

--- a/src/capabilities/orgUserCapabilities.test.ts
+++ b/src/capabilities/orgUserCapabilities.test.ts
@@ -1,6 +1,6 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
 const { suite, test, setup } = Mocha;
 const { fakeCtx, cap } = createCapabilityTestHarness(ORG_USER_CAPABILITIES);

--- a/src/capabilities/orgUserCapabilities.test.ts
+++ b/src/capabilities/orgUserCapabilities.test.ts
@@ -7,6 +7,52 @@ const { fakeCtx, cap } = createCapabilityTestHarness(ORG_USER_CAPABILITIES);
 suite('Unit: orgUserCapabilities', () => {
 	setup(() => initTestEnvironment());
 
+	// --- Zod parse tests ---
+	test('missing orgId throws before GraphQL for buddy_list_users', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_list_users').run({}, ctx), /orgId/);
+	});
+
+	test('missing orgId throws before GraphQL for buddy_search_organizations', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_search_organizations').run({}, ctx), /orgId/);
+	});
+
+	test('non-number limit falls back to default for buddy_list_users (no throw)', async () => {
+		const { ctx } = fakeCtx({ data: { users: [] } });
+		await assert.doesNotReject(() => cap('buddy_list_users').run({ orgId: 'org-1', limit: 'bad' }, ctx));
+	});
+
+	test('over-max limit is clamped to 200 for buddy_list_users', async () => {
+		const { ctx, calls } = fakeCtx({ data: { users: [] } });
+		await cap('buddy_list_users').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 200);
+	});
+
+	test('over-max limit is clamped to 100 for buddy_search_organizations', async () => {
+		const { ctx, calls } = fakeCtx({ data: { searchManagedOrgs: [] } });
+		await cap('buddy_search_organizations').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 100);
+	});
+
+	test('buddy_search_organizations derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_search_organizations').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_search_organizations').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_users derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_list_users').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_users').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_roles derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_list_roles').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_roles').spec.args, JSON.stringify(schema));
+	});
+
 	test('buddy_search_organizations forwards name search and formats organizations', async () => {
 		const { ctx, calls } = fakeCtx({
 			data: { searchManagedOrgs: [{ id: 'o1', name: 'Acme', isEnabled: true }] },

--- a/src/capabilities/orgUserCapabilities.ts
+++ b/src/capabilities/orgUserCapabilities.ts
@@ -1,7 +1,15 @@
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asPositiveInt, asString, ORG_ID_PROP, rawGraphqlOrThrow, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	toInputSchema,
+} from './inputHelpers';
 
 const SEARCH_ORGANIZATIONS_QUERY =
 	'query($search: String, $limit: Int){ searchManagedOrgs(input:{ search:$search, limit:$limit }){ id name isEnabled } }';
@@ -9,49 +17,45 @@ const LIST_USERS_QUERY =
 	'query($orgId: ID!, $search: UserSearchInput, $limit: Int){ users(where:{ orgId:$orgId }, search:$search, limit:$limit){ id username isApiUser roleIds } }';
 const LIST_ROLES_QUERY = 'query($orgId: ID!){ roles(where:{ orgId:$orgId }){ id name description } }';
 
-const searchOrganizationsSpec: ToolSpec = {
+const searchOrganizationsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional case-insensitive name substring.'),
+	limit: optionalClampedInt(100).describe('Max organizations to return (default 25, max 100).'),
+});
+
+const listUsersInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional username substring.'),
+	limit: optionalClampedInt(200).describe('Max users to return (default 50, max 200).'),
+});
+
+const listRolesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
+
+const searchOrganizationsSpec: ToolSpecDefinition = {
 	name: 'buddy_search_organizations',
-	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'Find organizations by a case-insensitive name substring. orgId only selects which signed-in session to use — results are not limited to that org; they span all organizations the session manages. Returns id, name, isEnabled. Preferred over buddy_list_orgs for finding an org by name (buddy_list_orgs enumerates every managed org).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
-			limit: { type: 'integer', description: 'Max organizations to return (default 25, max 100).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(searchOrganizationsInputSchema),
 };
 
-const listUsersSpec: ToolSpec = {
+const listUsersSpec: ToolSpecDefinition = {
 	name: 'buddy_list_users',
-	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'List the users directly in one Rewst organization (id, username, isApiUser, roleIds). Only users in the named org are returned; parent-org users are not inherited.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional username substring.' },
-			limit: { type: 'integer', description: 'Max users to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listUsersInputSchema),
 };
 
-const listRolesSpec: ToolSpec = {
+const listRolesSpec: ToolSpecDefinition = {
 	name: 'buddy_list_roles',
-	args: '{"orgId": string}',
 	description: 'List the roles defined in one Rewst organization (id, name, description).',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listRolesInputSchema),
 };
 
 async function runSearchOrganizations(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? 25, 100);
-	const search = asString(input, 'search');
+	const { limit: rawLimit, search } = parseCapabilityInput(searchOrganizationsInputSchema, input);
+	const limit = rawLimit ?? 25;
 	const variables: Record<string, unknown> = { limit };
 	if (search) variables.search = search;
 	const data = await rawGraphqlOrThrow(ctx.session, SEARCH_ORGANIZATIONS_QUERY, variables);
@@ -67,9 +71,8 @@ async function runSearchOrganizations(input: Record<string, unknown>, ctx: Capab
 }
 
 async function runListUsers(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? 50, 200);
+	const { orgId, search, limit: rawLimit } = parseCapabilityInput(listUsersInputSchema, input);
+	const limit = rawLimit ?? 50;
 	const variables: Record<string, unknown> = { orgId, limit };
 	if (search) variables.search = { username: { _ilike: `%${search}%` } };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_USERS_QUERY, variables);
@@ -91,7 +94,7 @@ async function runListUsers(input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListRoles(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listRolesInputSchema, input);
 	const variables: Record<string, unknown> = { orgId };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_ROLES_QUERY, variables);
 	const roles = ((data as { roles?: unknown[] } | undefined)?.roles ?? []) as {

--- a/src/capabilities/orgVariableMutateCapabilities.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.ts
@@ -1,13 +1,17 @@
+import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
 import {
-	ORG_ID_PROP,
+	ORG_ID_FIELD,
+	optionalBooleanField,
+	parseCapabilityInput,
 	rawGraphqlOrThrow,
 	requireResourceInOrg,
-	requireString,
-	requireStringAllowEmpty,
+	requiredStringAllowEmptyField,
+	requiredStringField,
+	toInputSchema,
 } from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
@@ -21,7 +25,12 @@ import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 // Categories a caller may set. 'system' is reserved for Rewst-managed variables
 // and is rejected rather than offered.
-const SETTABLE_CATEGORIES = new Set(['general', 'contact', 'secret']);
+const SETTABLE_CATEGORIES = ['general', 'contact', 'secret'] as const;
+type SettableCategory = (typeof SETTABLE_CATEGORIES)[number];
+
+const categoryField = z
+	.enum(SETTABLE_CATEGORIES, { error: `"category" must be one of ${SETTABLE_CATEGORIES.join(', ')}.` })
+	.optional();
 
 const CREATE_ORG_VARIABLE = `mutation RewstBuddyMcpCreateOrgVariable($orgVariable: OrgVariableCreateInput!) {
   createOrgVariable(orgVariable: $orgVariable) { id name category cascade orgId }
@@ -45,24 +54,6 @@ interface OrgVariableRow {
 	category?: string;
 	cascade?: boolean;
 	orgId?: string;
-}
-
-/** Reads an optional category argument, rejecting unknown or reserved values. */
-function optionalCategory(input: Record<string, unknown>): string | undefined {
-	const value = input.category;
-	if (value === undefined || value === null) return undefined;
-	if (typeof value !== 'string' || !SETTABLE_CATEGORIES.has(value)) {
-		throw new Error(`"category" must be one of ${[...SETTABLE_CATEGORIES].join(', ')}.`);
-	}
-	return value;
-}
-
-/** Reads an optional boolean argument; non-booleans are an error, not coerced. */
-function optionalBoolean(input: Record<string, unknown>, key: string): boolean | undefined {
-	const value = input[key];
-	if (value === undefined) return undefined;
-	if (typeof value !== 'boolean') throw new Error(`"${key}" must be a boolean.`);
-	return value;
 }
 
 /**
@@ -90,34 +81,31 @@ async function requireOrgVariableInOrg(
 	});
 }
 
-const createOrgVariableSpec: ToolSpec = {
+const createOrgVariableSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	name: requiredStringField('name').describe('Variable name.'),
+	value: requiredStringAllowEmptyField('value').describe('Variable value; may be an empty string.'),
+	category: categoryField.describe('Variable category (default general). secret masks the value in reads.'),
+	cascade: optionalBooleanField('cascade').describe('Whether descendant orgs inherit the variable (default false).'),
+});
+
+const createOrgVariableSpec: ToolSpecDefinition = {
 	name: 'buddy_create_org_variable',
-	args: '{"orgId": string, "name": string, "value": string, "category"?: "general"|"contact"|"secret", "cascade"?: boolean}',
 	description:
 		'Create a configuration variable in one Rewst organization. category defaults to general (use secret for sensitive values); cascade (default false) makes the variable visible to descendant orgs. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			name: { type: 'string', description: 'Variable name.' },
-			value: { type: 'string', description: 'Variable value; may be an empty string.' },
-			category: {
-				type: 'string',
-				enum: ['general', 'contact', 'secret'],
-				description: 'Variable category (default general). secret masks the value in reads.',
-			},
-			cascade: { type: 'boolean', description: 'Whether descendant orgs inherit the variable (default false).' },
-		},
-		required: ['orgId', 'name', 'value'],
-	},
+	inputSchema: toInputSchema(createOrgVariableSchema),
 };
 
 async function runCreateOrgVariable(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const name = requireString(input, 'name');
-	const value = requireStringAllowEmpty(input, 'value');
-	const category = optionalCategory(input) ?? 'general';
-	const cascade = optionalBoolean(input, 'cascade') ?? false;
+	const {
+		orgId,
+		name,
+		value,
+		category: categoryInput,
+		cascade: cascadeInput,
+	} = parseCapabilityInput(createOrgVariableSchema, input);
+	const category: SettableCategory = categoryInput ?? 'general';
+	const cascade = cascadeInput ?? false;
 	const orgName = orgDisplayName(ctx);
 	const scope: MutationScope = { scopeId: orgId, scopeName: `new variable "${name}"`, orgId, orgName };
 	const summary = `Create ${category} variable "${name}" in org "${orgName}" (${orgId})`;
@@ -131,34 +119,29 @@ async function runCreateOrgVariable(input: Record<string, unknown>, ctx: Capabil
 	});
 }
 
-const updateOrgVariableSpec: ToolSpec = {
+const updateOrgVariableSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	variableId: requiredStringField('variableId').describe('Id of the variable to update.'),
+	value: requiredStringAllowEmptyField('value').describe('New value; may be an empty string.'),
+	category: categoryField.describe("Optional new category; defaults to the variable's current category."),
+	cascade: optionalBooleanField('cascade').describe('Optional new cascade flag; defaults to the current value.'),
+});
+
+const updateOrgVariableSpec: ToolSpecDefinition = {
 	name: 'buddy_update_org_variable',
-	args: '{"orgId": string, "variableId": string, "value": string, "category"?: "general"|"contact"|"secret", "cascade"?: boolean}',
 	description:
 		'Replace the value of one existing org variable, identified by org and variable id. The variable must belong to the given org. Optionally also change its category or cascade; the name is preserved. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			variableId: { type: 'string', description: 'Id of the variable to update.' },
-			value: { type: 'string', description: 'New value; may be an empty string.' },
-			category: {
-				type: 'string',
-				enum: ['general', 'contact', 'secret'],
-				description: 'Optional new category; defaults to the variable’s current category.',
-			},
-			cascade: { type: 'boolean', description: 'Optional new cascade flag; defaults to the current value.' },
-		},
-		required: ['orgId', 'variableId', 'value'],
-	},
+	inputSchema: toInputSchema(updateOrgVariableSchema),
 };
 
 async function runUpdateOrgVariable(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const variableId = requireString(input, 'variableId');
-	const value = requireStringAllowEmpty(input, 'value');
-	const categoryOverride = optionalCategory(input);
-	const cascadeOverride = optionalBoolean(input, 'cascade');
+	const {
+		orgId,
+		variableId,
+		value,
+		category: categoryOverride,
+		cascade: cascadeOverride,
+	} = parseCapabilityInput(updateOrgVariableSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const current = await requireOrgVariableInOrg(ctx, variableId, orgId);
 	const name = current.name ?? '';
@@ -179,24 +162,20 @@ async function runUpdateOrgVariable(input: Record<string, unknown>, ctx: Capabil
 	});
 }
 
-const deleteOrgVariableSpec: ToolSpec = {
+const deleteOrgVariableSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	variableId: requiredStringField('variableId').describe('Id of the variable to delete.'),
+});
+
+const deleteOrgVariableSpec: ToolSpecDefinition = {
 	name: 'buddy_delete_org_variable',
-	args: '{"orgId": string, "variableId": string}',
 	description:
 		'Permanently delete one org variable, identified by org and variable id. The variable must belong to the given org. This cannot be undone. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			variableId: { type: 'string', description: 'Id of the variable to delete.' },
-		},
-		required: ['orgId', 'variableId'],
-	},
+	inputSchema: toInputSchema(deleteOrgVariableSchema),
 };
 
 async function runDeleteOrgVariable(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const variableId = requireString(input, 'variableId');
+	const { orgId, variableId } = parseCapabilityInput(deleteOrgVariableSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const current = await requireOrgVariableInOrg(ctx, variableId, orgId);
 	const name = current.name ?? '(unnamed)';

--- a/src/capabilities/packIntegrationCapabilities.test.ts
+++ b/src/capabilities/packIntegrationCapabilities.test.ts
@@ -25,6 +25,12 @@ suite('Unit: packIntegrationCapabilities', () => {
 		await assert.doesNotReject(() => cap('buddy_list_integrations').run({ orgId: 'org-1', limit: 'bad' }, ctx));
 	});
 
+	test('over-max limit is clamped to 200 for buddy_list_integrations', async () => {
+		const { ctx, calls } = fakeCtx({ data: { integrations: [] } });
+		await cap('buddy_list_integrations').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 200);
+	});
+
 	test('buddy_list_integrations derived schema has orgId required and args generated', () => {
 		const schema = cap('buddy_list_integrations').spec.inputSchema as { required: string[] };
 		assert.ok(schema.required.includes('orgId'));

--- a/src/capabilities/packIntegrationCapabilities.test.ts
+++ b/src/capabilities/packIntegrationCapabilities.test.ts
@@ -9,6 +9,35 @@ const { fakeCtx, cap } = createCapabilityTestHarness(PACK_INTEGRATION_CAPABILITI
 suite('Unit: packIntegrationCapabilities', () => {
 	setup(() => initTestEnvironment());
 
+	// --- Zod parse tests ---
+	test('missing packName throws with clear message', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_get_pack_auth_status').run({ orgId: 'org-1' }, ctx), /packName/);
+	});
+
+	test('missing orgId throws before GraphQL for buddy_list_installed_packs', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_list_installed_packs').run({}, ctx), /orgId/);
+	});
+
+	test('non-number limit for buddy_list_integrations falls back to default (no throw)', async () => {
+		const { ctx } = fakeCtx({ data: { integrations: [] } });
+		await assert.doesNotReject(() => cap('buddy_list_integrations').run({ orgId: 'org-1', limit: 'bad' }, ctx));
+	});
+
+	test('buddy_list_integrations derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_list_integrations').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_integrations').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_get_pack_auth_status derived schema has orgId and packName required and args generated', () => {
+		const schema = cap('buddy_get_pack_auth_status').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.ok(schema.required.includes('packName'));
+		assert.strictEqual(cap('buddy_get_pack_auth_status').spec.args, JSON.stringify(schema));
+	});
+
 	test('buddy_list_installed_packs formats rows', async () => {
 		const { ctx } = fakeCtx({
 			data: {

--- a/src/capabilities/packIntegrationCapabilities.test.ts
+++ b/src/capabilities/packIntegrationCapabilities.test.ts
@@ -1,6 +1,6 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { PACK_INTEGRATION_CAPABILITIES } from './packIntegrationCapabilities';
 const { suite, test, setup } = Mocha;
 

--- a/src/capabilities/packIntegrationCapabilities.ts
+++ b/src/capabilities/packIntegrationCapabilities.ts
@@ -5,7 +5,6 @@ import { readCapability } from './capabilityFactories';
 import {
 	ORG_ID_FIELD,
 	optionalClampedInt,
-	optionalStringField,
 	parseCapabilityInput,
 	rawGraphqlOrThrow,
 	requiredStringField,

--- a/src/capabilities/packIntegrationCapabilities.ts
+++ b/src/capabilities/packIntegrationCapabilities.ts
@@ -1,58 +1,67 @@
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asPositiveInt, asString, ORG_ID_PROP, rawGraphqlOrThrow, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	requiredStringField,
+	toInputSchema,
+} from './inputHelpers';
 
 const MAX_INTEGRATIONS_LIMIT = 200;
 
 function optionalString(value: unknown): string | undefined {
-	return asString({ value }, 'value');
+	return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined;
 }
 
-const listInstalledPacksSpec: ToolSpec = {
+const listInstalledPacksInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
+
+const getPackAuthStatusInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	packName: requiredStringField('packName').describe('A pack ref, e.g. microsoft_graph'),
+});
+
+const listPackConfigsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
+
+const listIntegrationsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_INTEGRATIONS_LIMIT).describe('Max integrations to return (default 50, max 200).'),
+});
+
+const listInstalledPacksSpec: ToolSpecDefinition = {
 	name: 'buddy_list_installed_packs',
-	args: '{"orgId": string}',
 	description:
 		'List the integration packs and bundles installed in one Rewst organization (id, name, ref, isBundle, status, packType).',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listInstalledPacksInputSchema),
 };
 
-const getPackAuthStatusSpec: ToolSpec = {
+const getPackAuthStatusSpec: ToolSpecDefinition = {
 	name: 'buddy_get_pack_auth_status',
-	args: '{"orgId": string, "packName": string}',
 	description:
 		"Check whether a pack needs OAuth setup in one Rewst organization. packName is a pack ref (e.g. microsoft_graph). Returns 'configured' when already authenticated, or the setup URL when authorization is needed.",
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			packName: { type: 'string', description: 'A pack ref, e.g. microsoft_graph' },
-		},
-		required: ['orgId', 'packName'],
-	},
+	inputSchema: toInputSchema(getPackAuthStatusInputSchema),
 };
 
-const listPackConfigsSpec: ToolSpec = {
+const listPackConfigsSpec: ToolSpecDefinition = {
 	name: 'buddy_list_pack_configs',
-	args: '{"orgId": string}',
 	description:
 		'List the pack (integration) configurations for one Rewst organization (id, name, packId, default). Returns all configs (this field has no pagination).',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listPackConfigsInputSchema),
 };
 
-const listIntegrationsSpec: ToolSpec = {
+const listIntegrationsSpec: ToolSpecDefinition = {
 	name: 'buddy_list_integrations',
-	args: '{"orgId": string, "limit"?: number}',
 	description:
 		'List integrations available on the Rewst platform (name, description, numInstalled). Global catalog; the orgId only selects which signed-in session to use.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: { type: 'number', description: 'Max integrations to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listIntegrationsInputSchema),
 };
 
 async function runListInstalledPacks(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
@@ -68,7 +77,7 @@ async function runListInstalledPacks(input: Record<string, unknown>, ctx: Capabi
     }
   }
 }`;
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listInstalledPacksInputSchema, input);
 	const variables = { orgId };
 	const data = await rawGraphqlOrThrow(ctx.session, QUERY, variables);
 	const installedPacksAndBundles = ((
@@ -99,8 +108,7 @@ async function runGetPackAuthStatus(input: Record<string, unknown>, ctx: Capabil
 	const QUERY = `query RewstBuddyMcpPackAuthUrl($orgId: ID!, $packName: String!) {
   packAuthUrl(packName: $packName, orgId: $orgId)
 }`;
-	const orgId = requireString(input, 'orgId');
-	const packName = requireString(input, 'packName');
+	const { orgId, packName } = parseCapabilityInput(getPackAuthStatusInputSchema, input);
 	const variables = { orgId, packName };
 	const data = await rawGraphqlOrThrow(ctx.session, QUERY, variables);
 	const url = (data as { packAuthUrl?: unknown } | undefined)?.packAuthUrl;
@@ -118,7 +126,7 @@ async function runListPackConfigs(input: Record<string, unknown>, ctx: Capabilit
     createdAt
   }
 }`;
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listPackConfigsInputSchema, input);
 	const variables = { orgId };
 	const data = await rawGraphqlOrThrow(ctx.session, QUERY, variables);
 	const packConfigs = ((data as { packConfigs?: unknown[] | null } | undefined)?.packConfigs ?? []) as {
@@ -147,8 +155,8 @@ async function runListIntegrations(input: Record<string, unknown>, ctx: Capabili
     isPublic
   }
 }`;
-	requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? 50, MAX_INTEGRATIONS_LIMIT);
+	const { limit: rawLimit } = parseCapabilityInput(listIntegrationsInputSchema, input);
+	const limit = rawLimit ?? 50;
 	const variables = { limit };
 	const data = await rawGraphqlOrThrow(ctx.session, QUERY, variables);
 	const integrations = ((data as { integrations?: unknown[] | null } | undefined)?.integrations ?? []) as {

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -7,6 +7,35 @@ const { fakeCtx, cap } = createCapabilityTestHarness(PAGE_TEMPLATE_CAPABILITIES)
 suite('Unit: pageTemplateCapabilities', () => {
 	setup(() => initTestEnvironment());
 
+	// --- Zod parse tests ---
+	test('missing orgId throws before GraphQL for buddy_search_templates', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_search_templates').run({}, ctx), /orgId/);
+	});
+
+	test('non-number limit falls back to default for buddy_search_templates (no throw)', async () => {
+		const { ctx } = fakeCtx({ data: { templates: [] } });
+		await assert.doesNotReject(() => cap('buddy_search_templates').run({ orgId: 'org-1', limit: 'bad' }, ctx));
+	});
+
+	test('over-max limit is clamped to 200 for buddy_list_pages', async () => {
+		const { ctx, calls } = fakeCtx({ data: { pages: [] } });
+		await cap('buddy_list_pages').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 200);
+	});
+
+	test('buddy_search_templates derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_search_templates').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_search_templates').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_jinja_filters derived schema has orgId required and args generated', () => {
+		const schema = cap('buddy_list_jinja_filters').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_jinja_filters').spec.args, JSON.stringify(schema));
+	});
+
 	test('buddy_search_templates maps name search and formats template rows', async () => {
 		const { ctx, calls } = fakeCtx({
 			data: {

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -30,12 +30,6 @@ suite('Unit: pageTemplateCapabilities', () => {
 		assert.strictEqual(cap('buddy_search_templates').spec.args, JSON.stringify(schema));
 	});
 
-	test('buddy_list_jinja_filters derived schema has orgId required and args generated', () => {
-		const schema = cap('buddy_list_jinja_filters').spec.inputSchema as { required: string[] };
-		assert.ok(schema.required.includes('orgId'));
-		assert.strictEqual(cap('buddy_list_jinja_filters').spec.args, JSON.stringify(schema));
-	});
-
 	test('buddy_search_templates maps name search and formats template rows', async () => {
 		const { ctx, calls } = fakeCtx({
 			data: {
@@ -79,22 +73,6 @@ suite('Unit: pageTemplateCapabilities', () => {
 		assert.ok(calls[0].query.includes('sites('));
 		assert.ok(!calls[0].query.includes('limit'));
 		assert.ok(output.includes('[live]'));
-	});
-
-	test('buddy_list_jinja_filters filters the global catalog client-side', async () => {
-		const { ctx } = fakeCtx({
-			data: {
-				jinjaFiltersDocumentation: [
-					{ name: 'default', signature: 'default(value, default_value)' },
-					{ name: 'abs', signature: 'abs(x)' },
-				],
-			},
-		});
-
-		const output = await cap('buddy_list_jinja_filters').run({ orgId: 'org-1', search: 'abs' }, ctx);
-
-		assert.ok(output.includes('abs'));
-		assert.ok(!output.includes('default'));
 	});
 
 	test('buddy_search_templates reports GraphQL errors with details', async () => {

--- a/src/capabilities/pageTemplateCapabilities.test.ts
+++ b/src/capabilities/pageTemplateCapabilities.test.ts
@@ -1,6 +1,6 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { PAGE_TEMPLATE_CAPABILITIES } from './pageTemplateCapabilities';
 const { suite, test, setup } = Mocha;
 const { fakeCtx, cap } = createCapabilityTestHarness(PAGE_TEMPLATE_CAPABILITIES);

--- a/src/capabilities/pageTemplateCapabilities.ts
+++ b/src/capabilities/pageTemplateCapabilities.ts
@@ -1,74 +1,79 @@
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asPositiveInt, asString, ORG_ID_PROP, rawGraphqlOrThrow, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	toInputSchema,
+} from './inputHelpers';
 
 const DEFAULT_LIMIT = 50;
 const MAX_LIMIT = 200;
+
+const searchTemplatesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional case-insensitive name substring.'),
+	limit: optionalClampedInt(MAX_LIMIT).describe(
+		`Max templates to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
+	),
+});
+
+const listPagesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_LIMIT).describe(`Max pages to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`),
+});
+
+const listSitesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+});
+
+const listJinjaFiltersInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	search: optionalStringField().describe('Optional case-insensitive name substring.'),
+	limit: optionalClampedInt(MAX_LIMIT).describe(
+		`Max filters to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
+	),
+});
 
 const SEARCH_TEMPLATES_QUERY = `query($orgId: ID!, $search: TemplateSearch, $limit: Int){ templates(where:{ orgId:$orgId }, search:$search, order:[["updatedAt","desc"]], limit:$limit){ id name language contentType updatedAt } }`;
 const LIST_PAGES_QUERY = `query($orgId: ID!, $limit: Int){ pages(where:{ orgId:$orgId }, limit:$limit){ id name path siteId } }`;
 const LIST_SITES_QUERY = `query($orgId: ID!){ sites(where:{ orgId:$orgId }){ id name domain isLive } }`;
 const LIST_JINJA_FILTERS_QUERY = `query{ jinjaFiltersDocumentation { name signature } }`;
 
-const searchTemplatesSpec: ToolSpec = {
+const searchTemplatesSpec: ToolSpecDefinition = {
 	name: 'buddy_search_templates',
-	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'Search templates in one Rewst organization by name substring (case-insensitive), newest first (id, name, language, contentType, updatedAt). Use buddy_get_template for a full body.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
-			limit: { type: 'number', description: 'Max templates to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(searchTemplatesInputSchema),
 };
 
-const listPagesSpec: ToolSpec = {
+const listPagesSpec: ToolSpecDefinition = {
 	name: 'buddy_list_pages',
-	args: '{"orgId": string, "limit"?: number}',
 	description: 'List App Platform pages in one Rewst organization (id, name, path, siteId).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: { type: 'number', description: 'Max pages to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listPagesInputSchema),
 };
 
-const listSitesSpec: ToolSpec = {
+const listSitesSpec: ToolSpecDefinition = {
 	name: 'buddy_list_sites',
-	args: '{"orgId": string}',
 	description:
 		'List App Platform sites in one Rewst organization (id, name, domain, isLive). Returns all sites (this field has no pagination).',
-	inputSchema: { type: 'object', properties: { ...ORG_ID_PROP }, required: ['orgId'] },
+	inputSchema: toInputSchema(listSitesInputSchema),
 };
 
-const listJinjaFiltersSpec: ToolSpec = {
+const listJinjaFiltersSpec: ToolSpecDefinition = {
 	name: 'buddy_list_jinja_filters',
-	args: '{"orgId": string, "search"?: string, "limit"?: number}',
 	description:
 		'List Rewst available Jinja filters with their signatures (global catalog, ~100 entries). Optionally filter by a name substring. Use this instead of the broken singular jinjaFilterDocumentation.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
-			limit: { type: 'number', description: 'Max filters to return (default 50, max 200).' },
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listJinjaFiltersInputSchema),
 };
 
 async function runSearchTemplates(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const { orgId, search, limit: rawLimit } = parseCapabilityInput(searchTemplatesInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_LIMIT;
 	const variables: Record<string, unknown> = { orgId, limit };
 	if (search) variables.search = { name: { _ilike: `%${search}%` } };
 	const data = await rawGraphqlOrThrow(ctx.session, SEARCH_TEMPLATES_QUERY, variables);
@@ -95,8 +100,8 @@ async function runSearchTemplates(input: Record<string, unknown>, ctx: Capabilit
 }
 
 async function runListPages(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listPagesInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_PAGES_QUERY, variables);
 	const pages = ((data as { pages?: unknown[] } | undefined)?.pages ?? []) as {
@@ -115,7 +120,7 @@ async function runListPages(input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListSites(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
+	const { orgId } = parseCapabilityInput(listSitesInputSchema, input);
 	const variables = { orgId };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_SITES_QUERY, variables);
 	const sites = ((data as { sites?: unknown[] } | undefined)?.sites ?? []) as {
@@ -135,9 +140,8 @@ async function runListSites(input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListJinjaFilters(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const search = asString(input, 'search');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_LIMIT, MAX_LIMIT);
+	const { search, limit: rawLimit } = parseCapabilityInput(listJinjaFiltersInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_LIMIT;
 	const variables = {};
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_JINJA_FILTERS_QUERY, variables);
 	const filters = ((data as { jinjaFiltersDocumentation?: unknown[] } | undefined)?.jinjaFiltersDocumentation ??

--- a/src/capabilities/pageTemplateCapabilities.ts
+++ b/src/capabilities/pageTemplateCapabilities.ts
@@ -31,18 +31,9 @@ const listSitesInputSchema = z.object({
 	orgId: ORG_ID_FIELD,
 });
 
-const listJinjaFiltersInputSchema = z.object({
-	orgId: ORG_ID_FIELD,
-	search: optionalStringField().describe('Optional case-insensitive name substring.'),
-	limit: optionalClampedInt(MAX_LIMIT).describe(
-		`Max filters to return (default ${DEFAULT_LIMIT}, max ${MAX_LIMIT}).`,
-	),
-});
-
 const SEARCH_TEMPLATES_QUERY = `query($orgId: ID!, $search: TemplateSearch, $limit: Int){ templates(where:{ orgId:$orgId }, search:$search, order:[["updatedAt","desc"]], limit:$limit){ id name language contentType updatedAt } }`;
 const LIST_PAGES_QUERY = `query($orgId: ID!, $limit: Int){ pages(where:{ orgId:$orgId }, limit:$limit){ id name path siteId } }`;
 const LIST_SITES_QUERY = `query($orgId: ID!){ sites(where:{ orgId:$orgId }){ id name domain isLive } }`;
-const LIST_JINJA_FILTERS_QUERY = `query{ jinjaFiltersDocumentation { name signature } }`;
 
 const searchTemplatesSpec: ToolSpecDefinition = {
 	name: 'buddy_search_templates',
@@ -62,13 +53,6 @@ const listSitesSpec: ToolSpecDefinition = {
 	description:
 		'List App Platform sites in one Rewst organization (id, name, domain, isLive). Returns all sites (this field has no pagination).',
 	inputSchema: toInputSchema(listSitesInputSchema),
-};
-
-const listJinjaFiltersSpec: ToolSpecDefinition = {
-	name: 'buddy_list_jinja_filters',
-	description:
-		'List Rewst available Jinja filters with their signatures (global catalog, ~100 entries). Optionally filter by a name substring. Use this instead of the broken singular jinjaFilterDocumentation.',
-	inputSchema: toInputSchema(listJinjaFiltersInputSchema),
 };
 
 async function runSearchTemplates(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
@@ -139,33 +123,8 @@ async function runListSites(input: Record<string, unknown>, ctx: CapabilityConte
 		.join('\n');
 }
 
-async function runListJinjaFilters(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const { search, limit: rawLimit } = parseCapabilityInput(listJinjaFiltersInputSchema, input);
-	const limit = rawLimit ?? DEFAULT_LIMIT;
-	const variables = {};
-	const data = await rawGraphqlOrThrow(ctx.session, LIST_JINJA_FILTERS_QUERY, variables);
-	const filters = ((data as { jinjaFiltersDocumentation?: unknown[] } | undefined)?.jinjaFiltersDocumentation ??
-		[]) as {
-		name?: string | null;
-		signature?: string | null;
-	}[];
-	const matched = search
-		? filters.filter(filter => (filter.name ?? '').toLowerCase().includes(search.toLowerCase()))
-		: filters;
-	const capped = matched.slice(0, limit);
-	if (capped.length === 0) return search ? `No Jinja filters found matching "${search}".` : 'No Jinja filters found.';
-	const lines = capped.map(
-		filter => `${filter.name ?? '(unnamed)'}${filter.signature ? ` - ${filter.signature}` : ''}`,
-	);
-	if (matched.length > limit) {
-		lines.push(`...(${matched.length - limit} more not shown; refine the search)`);
-	}
-	return lines.join('\n');
-}
-
 export const PAGE_TEMPLATE_CAPABILITIES: Capability[] = [
 	readCapability(searchTemplatesSpec, runSearchTemplates),
 	readCapability(listPagesSpec, runListPages),
 	readCapability(listSitesSpec, runListSites),
-	readCapability(listJinjaFiltersSpec, runListJinjaFilters),
 ];

--- a/src/capabilities/registry.test.ts
+++ b/src/capabilities/registry.test.ts
@@ -106,11 +106,36 @@ suite('Unit: capability registry', () => {
 	});
 
 	suite('mcp surface', () => {
+		test('retired Buddy tool aliases are absent from the unified PR', () => {
+			const retiredNames = [
+				'buddy_list_templates',
+				'buddy_list_jinja_filters',
+				'buddy_find_action',
+				'buddy_list_workflow_executions',
+				'buddy_latest_workflow_execution',
+			];
+			const canonicalNames = [
+				'buddy_search_templates',
+				'buddy_get_jinja_filter_docs',
+				'buddy_action_search',
+				'buddy_workflow_executions',
+			];
+			const mcpNames = mcpCapabilities().map(c => c.spec.name);
+			for (const name of retiredNames) {
+				assert.strictEqual(getCapability(name), undefined, `retired tool ${name} must not be registered`);
+				assert.ok(!mcpNames.includes(name), `retired tool ${name} must not appear in MCP tool list`);
+			}
+			for (const name of canonicalNames) {
+				assert.ok(getCapability(name), `canonical tool ${name} must be registered`);
+				assert.ok(mcpNames.includes(name), `canonical tool ${name} must appear in MCP tool list`);
+			}
+		});
+
 		test('read tools and the dedicated mutation tool are exposed to MCP', () => {
 			const names = mcpCapabilities().map(capability => capability.spec.name);
 			for (const expected of [
 				'buddy_list_orgs',
-				'buddy_list_templates',
+				'buddy_search_templates',
 				'buddy_get_template',
 				'buddy_list_workflows',
 				'buddy_get_workflow',

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -22,6 +22,7 @@ import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 import { TRIGGER_MUTATE_CAPABILITIES } from './triggerMutateCapabilities';
 import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
 import { workflowImpactCapability } from './workflowImpactCapability';
+import { workflowLintCapability } from './workflowLintCapability';
 import { WORKING_SCOPE_CAPABILITIES } from './workingScopeCapability';
 
 /**
@@ -51,6 +52,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...JINJA_DOCS_CAPABILITIES,
 	...CRATE_CAPABILITIES,
 	workflowImpactCapability,
+	workflowLintCapability,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -23,6 +23,11 @@ import { TRIGGER_MUTATE_CAPABILITIES } from './triggerMutateCapabilities';
 import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
 import { workflowImpactCapability } from './workflowImpactCapability';
 import { workflowLintCapability } from './workflowLintCapability';
+import {
+	deleteWorkflowInputProfileCapability,
+	listWorkflowInputProfilesCapability,
+	saveWorkflowInputProfileCapability,
+} from './workflowInputProfileCapabilities';
 import { WORKING_SCOPE_CAPABILITIES } from './workingScopeCapability';
 
 /**
@@ -53,6 +58,9 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...CRATE_CAPABILITIES,
 	workflowImpactCapability,
 	workflowLintCapability,
+	saveWorkflowInputProfileCapability,
+	listWorkflowInputProfilesCapability,
+	deleteWorkflowInputProfileCapability,
 	graphqlMutateCapability,
 	resultReadCapability,
 ];

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -22,12 +22,12 @@ import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 import { TRIGGER_MUTATE_CAPABILITIES } from './triggerMutateCapabilities';
 import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
 import { workflowImpactCapability } from './workflowImpactCapability';
-import { workflowLintCapability } from './workflowLintCapability';
 import {
 	deleteWorkflowInputProfileCapability,
 	listWorkflowInputProfilesCapability,
 	saveWorkflowInputProfileCapability,
 } from './workflowInputProfileCapabilities';
+import { workflowLintCapability } from './workflowLintCapability';
 import { WORKING_SCOPE_CAPABILITIES } from './workingScopeCapability';
 
 /**

--- a/src/capabilities/resultReadCapability.test.ts
+++ b/src/capabilities/resultReadCapability.test.ts
@@ -94,6 +94,13 @@ suite('Unit: resultReadCapability', () => {
 			assert.ok(output.includes('456789'));
 		});
 
+		test('non-numeric offset and limit fall back to defaults', async () => {
+			const id = cacheId(mcpResultCache.store('buddy_search_templates', '0123456789abcdef'));
+			const output = await resultReadCapability.run({ id, offset: 'abc', limit: 'def' }, ignoredContext());
+			assert.ok(output.startsWith(`Cached result "${id}" (buddy_search_templates), characters 0-16 of 16.`));
+			assert.ok(output.includes('\n\n0123456789abcdef\n'));
+		});
+
 		test('buddy_result_read derived schema has id required and args generated', () => {
 			const schema = resultReadCapability.spec.inputSchema as { required: string[] };
 			assert.ok(schema.required.includes('id'));

--- a/src/capabilities/resultReadCapability.test.ts
+++ b/src/capabilities/resultReadCapability.test.ts
@@ -34,14 +34,14 @@ suite('Unit: resultReadCapability', () => {
 			const cache = new McpResultCache();
 			const text = 'x'.repeat(MCP_MAX_OUTPUT_CHARS);
 
-			assert.strictEqual(formatMcpOutput('buddy_list_templates', text, cache), text);
+			assert.strictEqual(formatMcpOutput('buddy_search_templates', text, cache), text);
 			assert.strictEqual(cache.size, 0);
 		});
 
 		test('caches oversized output and returns preview with paging instructions', () => {
 			const cache = new McpResultCache();
 			const text = `${'x'.repeat(MCP_MAX_OUTPUT_CHARS)}tail`;
-			const formatted = formatMcpOutput('buddy_list_templates', text, cache);
+			const formatted = formatMcpOutput('buddy_search_templates', text, cache);
 
 			assert.ok(formatted.startsWith(text.slice(0, MCP_MAX_OUTPUT_CHARS)));
 			assert.match(formatted, /cached in memory as id "[0-9a-f]{8}"/);
@@ -64,7 +64,7 @@ suite('Unit: resultReadCapability', () => {
 		test('returns a preview with a cache-budget note when the result is too large to store', () => {
 			const cache = new McpResultCache(8);
 			const text = 'x'.repeat(MCP_MAX_OUTPUT_CHARS + 1);
-			const formatted = formatMcpOutput('buddy_list_templates', text, cache);
+			const formatted = formatMcpOutput('buddy_search_templates', text, cache);
 
 			assert.ok(formatted.startsWith(text.slice(0, MCP_MAX_OUTPUT_CHARS)));
 			assert.ok(formatted.includes('exceeds the in-memory cache budget'));
@@ -89,7 +89,7 @@ suite('Unit: resultReadCapability', () => {
 		});
 
 		test('numeric string offset and limit are accepted', async () => {
-			const id = cacheId(mcpResultCache.store('buddy_list_templates', '0123456789abcdef'));
+			const id = cacheId(mcpResultCache.store('buddy_search_templates', '0123456789abcdef'));
 			const output = await resultReadCapability.run({ id, offset: '4', limit: '6' }, ignoredContext());
 			assert.ok(output.includes('456789'));
 		});
@@ -101,17 +101,17 @@ suite('Unit: resultReadCapability', () => {
 		});
 
 		test('returns a requested slice with a continuation footer', async () => {
-			const id = cacheId(mcpResultCache.store('buddy_list_templates', '0123456789abcdef'));
+			const id = cacheId(mcpResultCache.store('buddy_search_templates', '0123456789abcdef'));
 
 			const output = await resultReadCapability.run({ id, offset: '4', limit: '6' }, ignoredContext());
 
-			assert.ok(output.startsWith(`Cached result "${id}" (buddy_list_templates), characters 4-10 of 16.`));
+			assert.ok(output.startsWith(`Cached result "${id}" (buddy_search_templates), characters 4-10 of 16.`));
 			assert.ok(output.includes('\n\n456789\n'));
 			assert.ok(output.includes(`{"id":"${id}","offset":10}`));
 		});
 
 		test('marks the final slice as the end of the result', async () => {
-			const id = cacheId(mcpResultCache.store('buddy_list_templates', '0123456789abcdef'));
+			const id = cacheId(mcpResultCache.store('buddy_search_templates', '0123456789abcdef'));
 
 			const output = await resultReadCapability.run({ id, offset: 10, limit: 100 }, ignoredContext());
 

--- a/src/capabilities/resultReadCapability.test.ts
+++ b/src/capabilities/resultReadCapability.test.ts
@@ -73,6 +73,33 @@ suite('Unit: resultReadCapability', () => {
 	});
 
 	suite('buddy_result_read run', () => {
+		// --- Zod parse tests ---
+		test('missing id throws with the expected message', async () => {
+			await assert.rejects(
+				() => resultReadCapability.run({}, ignoredContext()),
+				/buddy_result_read requires an "id"/,
+			);
+		});
+
+		test('empty string id throws with the expected message', async () => {
+			await assert.rejects(
+				() => resultReadCapability.run({ id: '' }, ignoredContext()),
+				/buddy_result_read requires an "id"/,
+			);
+		});
+
+		test('numeric string offset and limit are accepted', async () => {
+			const id = cacheId(mcpResultCache.store('buddy_list_templates', '0123456789abcdef'));
+			const output = await resultReadCapability.run({ id, offset: '4', limit: '6' }, ignoredContext());
+			assert.ok(output.includes('456789'));
+		});
+
+		test('buddy_result_read derived schema has id required and args generated', () => {
+			const schema = resultReadCapability.spec.inputSchema as { required: string[] };
+			assert.ok(schema.required.includes('id'));
+			assert.strictEqual(resultReadCapability.spec.args, JSON.stringify(schema));
+		});
+
 		test('returns a requested slice with a continuation footer', async () => {
 			const id = cacheId(mcpResultCache.store('buddy_list_templates', '0123456789abcdef'));
 

--- a/src/capabilities/resultReadCapability.test.ts
+++ b/src/capabilities/resultReadCapability.test.ts
@@ -1,6 +1,6 @@
+import { initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
 import type { CapabilityContext } from './Capability';
 import {
 	MCP_MAX_OUTPUT_CHARS,

--- a/src/capabilities/resultReadCapability.ts
+++ b/src/capabilities/resultReadCapability.ts
@@ -98,6 +98,11 @@ export function formatMcpOutput(toolName: string, text: string, cache: McpResult
 
 const RESULT_READ_ID_ERROR = 'buddy_result_read requires an "id" from a previous oversized Rewst Buddy result.';
 
+function optionalPagingNumber(value: unknown): number | undefined {
+	const n = typeof value === 'string' ? Number(value) : typeof value === 'number' ? value : NaN;
+	return Number.isFinite(n) ? n : undefined;
+}
+
 const resultReadInputSchema = z.object({
 	id: z
 		.string({ error: RESULT_READ_ID_ERROR })
@@ -106,12 +111,12 @@ const resultReadInputSchema = z.object({
 		.describe('Cached result id returned by an oversized Rewst Buddy tool result.'),
 	// Note: id field intentionally uses a custom error message matching the legacy explicit check.
 	offset: z
-		.preprocess(v => (typeof v === 'string' ? Number(v) : v), z.number().optional())
+		.preprocess(optionalPagingNumber, z.number().optional())
 		.describe('Character offset to start reading from (default 0).'),
 	limit: z
-		.preprocess(v => (typeof v === 'string' ? Number(v) : v), z.number().optional())
+		.preprocess(optionalPagingNumber, z.number().optional())
 		.describe(`Maximum characters to return (default ${DEFAULT_READ_LIMIT}, max ${MAX_READ_LIMIT}).`),
-	// offset and limit accept numeric strings for backward compatibility (clampInt coerces them downstream).
+	// offset and limit accept numeric strings and ignore bad values for backward compatibility.
 	search: optionalStringField().describe('Search text; returns matching lines with line numbers instead of a slice.'),
 });
 
@@ -135,8 +140,8 @@ export const resultReadCapability: Capability = readCapability(
 		}
 		const search = parsed.search;
 		if (search !== undefined) return searchCachedOutput(entry, search);
-		const offset = clampInt(input.offset, 0, entry.text.length, 0);
-		const limit = clampInt(input.limit, 1, MAX_READ_LIMIT, DEFAULT_READ_LIMIT);
+		const offset = clampInt(parsed.offset, 0, entry.text.length, 0);
+		const limit = clampInt(parsed.limit, 1, MAX_READ_LIMIT, DEFAULT_READ_LIMIT);
 		return sliceCachedOutput(entry, offset, limit);
 	},
 	{ requiresOrg: false },

--- a/src/capabilities/resultReadCapability.ts
+++ b/src/capabilities/resultReadCapability.ts
@@ -1,8 +1,9 @@
 import { randomUUID } from 'crypto';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asString } from './inputHelpers';
+import { optionalStringField, parseCapabilityInput, requiredStringField, toInputSchema } from './inputHelpers';
 
 export const RESULT_READ_TOOL_NAME = 'buddy_result_read';
 export const MCP_MAX_OUTPUT_CHARS = 24_000;
@@ -95,41 +96,44 @@ export function formatMcpOutput(toolName: string, text: string, cache: McpResult
 	].join('\n');
 }
 
-const resultReadSpec: ToolSpec = {
+const RESULT_READ_ID_ERROR = 'buddy_result_read requires an "id" from a previous oversized Rewst Buddy result.';
+
+const resultReadInputSchema = z.object({
+	id: z
+		.string({ error: RESULT_READ_ID_ERROR })
+		.trim()
+		.min(1, { error: RESULT_READ_ID_ERROR })
+		.describe('Cached result id returned by an oversized Rewst Buddy tool result.'),
+	// Note: id field intentionally uses a custom error message matching the legacy explicit check.
+	offset: z
+		.preprocess(v => (typeof v === 'string' ? Number(v) : v), z.number().optional())
+		.describe('Character offset to start reading from (default 0).'),
+	limit: z
+		.preprocess(v => (typeof v === 'string' ? Number(v) : v), z.number().optional())
+		.describe(`Maximum characters to return (default ${DEFAULT_READ_LIMIT}, max ${MAX_READ_LIMIT}).`),
+	// offset and limit accept numeric strings for backward compatibility (clampInt coerces them downstream).
+	search: optionalStringField().describe('Search text; returns matching lines with line numbers instead of a slice.'),
+});
+
+const resultReadSpec: ToolSpecDefinition = {
 	name: RESULT_READ_TOOL_NAME,
 	description:
 		'Pages or searches an oversized cached Rewst Buddy result by id. The cache is in-memory only; an id can be evicted under memory pressure, so rerun the original tool if it is gone.',
-	args: '{"id": string, "offset"?: number, "limit"?: number, "search"?: string}',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			id: { type: 'string', description: 'Cached result id returned by an oversized Rewst Buddy tool result.' },
-			offset: { type: 'number', description: 'Character offset to start reading from (default 0).' },
-			limit: {
-				type: 'number',
-				description: `Maximum characters to return (default ${DEFAULT_READ_LIMIT}, max ${MAX_READ_LIMIT}).`,
-			},
-			search: {
-				type: 'string',
-				description: 'Search text; returns matching lines with line numbers instead of a slice.',
-			},
-		},
-		required: ['id'],
-	},
+	inputSchema: toInputSchema(resultReadInputSchema),
 };
 
 export const resultReadCapability: Capability = readCapability(
 	resultReadSpec,
 	async (input: Record<string, unknown>, _ctx): Promise<string> => {
-		const id = asString(input, 'id');
-		if (!id) throw new Error('buddy_result_read requires an "id" from a previous oversized Rewst Buddy result.');
+		const parsed = parseCapabilityInput(resultReadInputSchema, input);
+		const id = parsed.id;
 		const entry = mcpResultCache.get(id);
 		if (!entry) {
 			throw new Error(
 				`No cached Rewst Buddy result for id "${id}". The in-memory cache may have evicted it or it may be absent; rerun the original tool to regenerate it.`,
 			);
 		}
-		const search = asString(input, 'search');
+		const search = parsed.search;
 		if (search !== undefined) return searchCachedOutput(entry, search);
 		const offset = clampInt(input.offset, 0, entry.text.length, 0);
 		const limit = clampInt(input.limit, 1, MAX_READ_LIMIT, DEFAULT_READ_LIMIT);

--- a/src/capabilities/resultReadCapability.ts
+++ b/src/capabilities/resultReadCapability.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { optionalStringField, parseCapabilityInput, requiredStringField, toInputSchema } from './inputHelpers';
+import { optionalStringField, parseCapabilityInput, toInputSchema } from './inputHelpers';
 
 export const RESULT_READ_TOOL_NAME = 'buddy_result_read';
 export const MCP_MAX_OUTPUT_CHARS = 24_000;

--- a/src/capabilities/rewstReadCapabilities.schemaParity.test.ts
+++ b/src/capabilities/rewstReadCapabilities.schemaParity.test.ts
@@ -45,9 +45,11 @@ const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
 	buddy_list_orgs: {
 		properties: {},
 	},
-	buddy_list_templates: {
+	buddy_search_templates: {
 		properties: {
 			orgId: { type: 'string', description: ORG_ID_DESC },
+			search: { type: 'string', description: 'Optional case-insensitive name substring.' },
+			limit: { type: 'number', description: 'Max templates to return (default 50, max 200).' },
 		},
 		required: ['orgId'],
 	},
@@ -74,14 +76,7 @@ const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
 		},
 		required: ['orgId'],
 	},
-	buddy_list_workflow_executions: {
-		properties: {
-			orgId: { type: 'string', description: ORG_ID_DESC },
-			status: { type: 'string', description: 'Optional exact execution status filter.' },
-			limit: { type: 'number', description: 'Max executions to return (default 25, max 100).' },
-		},
-		required: ['orgId'],
-	},
+
 	buddy_find_executions_by_variable: {
 		properties: {
 			orgId: { type: 'string', description: ORG_ID_DESC },
@@ -123,14 +118,7 @@ const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
 		},
 		required: ['orgId', 'patchId'],
 	},
-	buddy_latest_workflow_execution: {
-		properties: {
-			orgId: { type: 'string', description: ORG_ID_DESC },
-			workflowId: { type: 'string', description: 'Workflow id to inspect.' },
-			status: { type: 'string', description: 'Optional exact execution status constraint.' },
-		},
-		required: ['orgId', 'workflowId'],
-	},
+
 	buddy_get_workflow_execution_stats: {
 		properties: {
 			orgId: { type: 'string', description: ORG_ID_DESC },
@@ -141,17 +129,7 @@ const LEGACY_SCHEMAS: Record<string, LegacySchema> = {
 		},
 		required: ['orgId', 'createdSince'],
 	},
-	buddy_find_action: {
-		properties: {
-			orgId: { type: 'string', description: ORG_ID_DESC },
-			filter: {
-				type: 'string',
-				description: "Optional text matched case-insensitively against the action's display name.",
-			},
-			limit: { type: 'number', description: 'Max flattened actions to return (default 25, max 100).' },
-		},
-		required: ['orgId'],
-	},
+
 	buddy_resolve_reference: {
 		properties: {
 			orgId: { type: 'string', description: ORG_ID_DESC },

--- a/src/capabilities/rewstReadCapabilities.test.ts
+++ b/src/capabilities/rewstReadCapabilities.test.ts
@@ -94,65 +94,39 @@ suite('Unit: rewstReadCapabilities', () => {
 		assert.ok(output.includes('api_key = ********  [secret, cascade]'));
 	});
 
-	test('buddy_find_action flattens pack actions, caps output, falls back to name, and includes pack names', async () => {
+	test('buddy_search_templates uses templates GraphQL query, maps name search, and formats results', async () => {
 		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
 		useRawGraphqlWrapper(session, wrapper);
 		wrapper.when('rawGraphql', {
 			data: {
 				data: {
-					searchInstalledPackActions: [
+					templates: [
 						{
-							id: 'pack-1',
-							name: 'Core Pack',
-							ref: 'core',
-							actions: [
-								{
-									id: 'action-1',
-									name: 'Create Ticket',
-									ref: null,
-									description: 'Open a ticket',
-								},
-								{
-									id: 'action-2',
-									name: 'Update Ticket',
-									ref: 'ticket_update',
-									description: 'Update a ticket',
-								},
-							],
-						},
-						{
-							id: 'pack-2',
-							name: 'Automation Pack',
-							ref: 'automation',
-							actions: [
-								{
-									id: 'action-3',
-									name: 'Close Ticket',
-									ref: 'ticket_close',
-									description: 'Close a ticket',
-								},
-							],
+							id: 't-1',
+							name: 'Welcome Email',
+							language: 'html',
+							contentType: 'email',
+							updatedAt: '2025-01-01T00:00:00Z',
 						},
 					],
 				},
 			},
 		});
-		const findAction = getCapability('buddy_find_action');
-		assert.ok(findAction, 'buddy_find_action is registered');
+		const searchTemplates = getCapability('buddy_search_templates');
+		assert.ok(searchTemplates, 'buddy_search_templates is registered');
 
-		const output = await findAction.run({ orgId: 'org-1', filter: 'ticket', limit: 2 }, {
+		const output = await searchTemplates.run({ orgId: 'org-1', search: 'welcome', limit: 10 }, {
 			session,
 			orgId: 'org-1',
 			sessions: [session],
 		} satisfies CapabilityContext);
 
-		const lines = output.split('\n');
-		assert.strictEqual(lines.length, 3);
-		assert.strictEqual(lines[0], 'Create Ticket (action-1) — Core Pack: Open a ticket');
-		assert.strictEqual(lines[1], 'ticket_update (action-2) — Core Pack: Update a ticket');
-		assert.strictEqual(lines[2], '…(1 more not shown; refine the filter)');
-		assert.ok(output.includes('Core Pack'), 'pack name is included in output');
-		assert.ok(!output.includes('ticket_close (action-3)'), 'output is capped to the requested limit');
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		assert.ok(calls[0].variables.query.includes('templates('), 'query uses templates');
+		assert.deepStrictEqual(calls[0].variables.variables.search, { name: { _ilike: '%welcome%' } });
+		assert.ok(output.includes('Welcome Email (t-1)'), 'output includes template name and id');
+		assert.ok(output.includes('html'), 'output includes language');
 	});
 
 	test('buddy_resolve_reference uses localReferenceOptions query, forwards model and search, and formats options', async () => {
@@ -202,41 +176,6 @@ suite('Unit: rewstReadCapabilities', () => {
 				} satisfies CapabilityContext),
 			/Invalid modelType "Widget". Valid modelType values: Crate, CustomDatabase, Organization, PackConfig, Role, Template, TemplateExport, User, Workflow, Trigger, Form, Site, Page/,
 		);
-	});
-
-	test('buddy_list_workflow_executions uses workflowExecutions query, maps status search, and formats executions', async () => {
-		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
-		useRawGraphqlWrapper(session, wrapper);
-		wrapper.when('rawGraphql', {
-			data: {
-				data: {
-					workflowExecutions: [
-						{
-							id: 'exec-1',
-							status: 'succeeded',
-							createdAt: '1735689600000',
-							workflow: { id: 'wf-1' },
-							numSuccessfulTasks: 4,
-						},
-					],
-				},
-			},
-		});
-		const listWorkflowExecutions = getCapability('buddy_list_workflow_executions');
-		assert.ok(listWorkflowExecutions, 'buddy_list_workflow_executions is registered');
-
-		const output = await listWorkflowExecutions.run({ orgId: 'org-1', status: 'succeeded', limit: 10 }, {
-			session,
-			orgId: 'org-1',
-			sessions: [session],
-		} satisfies CapabilityContext);
-
-		const calls = wrapper.getCallsFor('rawGraphql');
-		assert.strictEqual(calls.length, 1);
-		assert.ok(calls[0].variables.query.includes('workflowExecutions('), 'query uses workflowExecutions');
-		assert.ok(calls[0].variables.query.includes('workflow {'), 'query requests nested workflow id');
-		assert.deepStrictEqual(calls[0].variables.variables.search, { status: { _eq: 'succeeded' } });
-		assert.ok(output.includes('succeeded — exec-1 (workflow wf-1, 4 ok, created 1735689600000)'));
 	});
 
 	test('buddy_find_executions_by_variable scans conductor input and matches name and value', async () => {
@@ -411,32 +350,6 @@ suite('Unit: rewstReadCapabilities', () => {
 
 		assert.ok(out.includes('exec-1') && out.includes('ticket_id=12345'), 'matches a context variable');
 		assert.ok(/1 execution context fetch/.test(out), `expected skip note, got: ${out}`);
-	});
-
-	test('buddy_latest_workflow_execution uses latestWorkflowExecution query, forwards workflowId, and handles missing execution', async () => {
-		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
-		useRawGraphqlWrapper(session, wrapper);
-		wrapper.when('rawGraphql', {
-			data: {
-				data: {
-					latestWorkflowExecution: null,
-				},
-			},
-		});
-		const latestWorkflowExecution = getCapability('buddy_latest_workflow_execution');
-		assert.ok(latestWorkflowExecution, 'buddy_latest_workflow_execution is registered');
-
-		const output = await latestWorkflowExecution.run({ orgId: 'org-1', workflowId: 'wf-1' }, {
-			session,
-			orgId: 'org-1',
-			sessions: [session],
-		} satisfies CapabilityContext);
-
-		const calls = wrapper.getCallsFor('rawGraphql');
-		assert.strictEqual(calls.length, 1);
-		assert.ok(calls[0].variables.query.includes('latestWorkflowExecution('), 'query uses latestWorkflowExecution');
-		assert.strictEqual(calls[0].variables.variables.workflowId, 'wf-1');
-		assert.ok(output.includes('No execution found for workflow wf-1'));
 	});
 
 	test('buddy_get_workflow_execution_stats uses workflowExecutionStats query, forwards createdSince, and formats stats', async () => {

--- a/src/capabilities/rewstReadCapabilities.ts
+++ b/src/capabilities/rewstReadCapabilities.ts
@@ -26,18 +26,15 @@ import {
  */
 
 // Bounds list responses so a large org cannot flood an agent's context.
-const DEFAULT_TEMPLATE_LIMIT = 200;
 const DEFAULT_WORKFLOW_LIMIT = 100;
 const DEFAULT_REFERENCE_LIMIT = 25;
 const DEFAULT_ORG_VARIABLE_LIMIT = 50;
-const DEFAULT_ACTION_LIMIT = 25;
 const DEFAULT_EXECUTION_LIMIT = 25;
 const DEFAULT_TASK_LIMIT = 100;
 const DEFAULT_PATCH_LIMIT = 25;
 const MAX_WORKFLOW_LIMIT = 500;
 const MAX_REFERENCE_LIMIT = 100;
 const MAX_ORG_VARIABLE_LIMIT = 200;
-const MAX_ACTION_LIMIT = 100;
 const MAX_EXECUTION_LIMIT = 100;
 const MAX_TASK_LIMIT = 500;
 const MAX_PATCH_LIMIT = 100;
@@ -71,16 +68,6 @@ const listOrgsSpec: ToolSpec = {
 	description:
 		'List the Rewst organizations reachable through the signed-in VS Code sessions, with their ids and names. Call this first to learn which orgId to pass to the other tools.',
 	inputSchema: toInputSchema(listOrgsInputSchema),
-};
-
-const listTemplatesInputSchema = z.object({
-	orgId: ORG_ID_FIELD,
-});
-const listTemplatesSpec: ToolSpec = {
-	name: 'buddy_list_templates',
-	args: '{"orgId": string}',
-	description: 'List the templates in one Rewst organization (id and name). Use buddy_get_template for a full body.',
-	inputSchema: toInputSchema(listTemplatesInputSchema),
 };
 
 const getTemplateInputSchema = z.object({
@@ -122,21 +109,6 @@ const listOrgVariablesSpec: ToolSpec = {
 	description:
 		'List configuration variables for one Rewst organization (name, value, category, cascade). Secret-category values are returned masked. Optionally filter by a case-insensitive name substring.',
 	inputSchema: toInputSchema(listOrgVariablesInputSchema),
-};
-
-const listWorkflowExecutionsInputSchema = z.object({
-	orgId: ORG_ID_FIELD,
-	status: optionalStringField().describe('Optional exact execution status filter.'),
-	limit: optionalClampedInt(MAX_EXECUTION_LIMIT).describe(
-		`Max executions to return (default ${DEFAULT_EXECUTION_LIMIT}, max ${MAX_EXECUTION_LIMIT}).`,
-	),
-});
-const listWorkflowExecutionsSpec: ToolSpec = {
-	name: 'buddy_list_workflow_executions',
-	args: '{"orgId": string, "status"?: string, "limit"?: number}',
-	description:
-		'List recent workflow executions for one Rewst organization (id, status, workflowId, createdAt, numSuccessfulTasks), newest first. Optionally filter by an exact status (e.g. succeeded, failed, running). createdAt is an epoch-millisecond string.',
-	inputSchema: toInputSchema(listWorkflowExecutionsInputSchema),
 };
 
 const findExecutionsByVariableInputSchema = z.object({
@@ -207,19 +179,6 @@ const getWorkflowPatchSpec: ToolSpec = {
 	inputSchema: toInputSchema(getWorkflowPatchInputSchema),
 };
 
-const latestWorkflowExecutionInputSchema = z.object({
-	orgId: ORG_ID_FIELD,
-	workflowId: requiredStringField('workflowId').describe('Workflow id to inspect.'),
-	status: optionalStringField().describe('Optional exact execution status constraint.'),
-});
-const latestWorkflowExecutionSpec: ToolSpec = {
-	name: 'buddy_latest_workflow_execution',
-	args: '{"orgId": string, "workflowId": string, "status"?: string}',
-	description:
-		'Get the most recent execution of one workflow in a Rewst organization (id, status, createdAt, task counts). Optionally constrain to a specific status.',
-	inputSchema: toInputSchema(latestWorkflowExecutionInputSchema),
-};
-
 const getWorkflowExecutionStatsInputSchema = z.object({
 	orgId: ORG_ID_FIELD,
 	createdSince: requiredStringField('createdSince')
@@ -234,23 +193,6 @@ const getWorkflowExecutionStatsSpec: ToolSpec = {
 	description:
 		'Get aggregate workflow-execution status counts for one Rewst organization since a date (succeeded, failed, running, pending, paused, delayed, humanSecondsSaved). createdSince must be an ISO-8601 date string (e.g. 2025-01-01 or 2025-01-01T00:00:00Z) — epoch milliseconds are rejected.',
 	inputSchema: toInputSchema(getWorkflowExecutionStatsInputSchema),
-};
-
-const findActionInputSchema = z.object({
-	orgId: ORG_ID_FIELD,
-	filter: optionalStringField().describe(
-		"Optional text matched case-insensitively against the action's display name.",
-	),
-	limit: optionalClampedInt(MAX_ACTION_LIMIT).describe(
-		`Max flattened actions to return (default ${DEFAULT_ACTION_LIMIT}, max ${MAX_ACTION_LIMIT}).`,
-	),
-});
-const findActionSpec: ToolSpec = {
-	name: 'buddy_find_action',
-	args: '{"orgId": string, "filter"?: string, "limit"?: number}',
-	description:
-		"Search the actions available in one Rewst organization's installed packs. The filter is matched case-insensitively against each action's display name. Returns one line per match — `<ref> (<id>) — <pack>: <description>` — where `<id>` is the action id and `<ref>` is its callable reference; rows with no ref (workflow-as-action entries) show the action name in place of the ref. Capped to `limit`; omitting the filter returns many results, so prefer a filter. For the platform-wide action catalog rather than this org's installed packs, use buddy_action_search.",
-	inputSchema: toInputSchema(findActionInputSchema),
 };
 
 const resolveReferenceInputSchema = z.object({
@@ -321,18 +263,6 @@ const ORG_VARIABLES_QUERY = `query RewstBuddyMcpOrgVariables($orgId: ID!, $searc
   }
 }`;
 
-const WORKFLOW_EXECUTIONS_QUERY = `query RewstBuddyMcpWorkflowExecutions($orgId: ID!, $search: WorkflowExecutionSearchInput, $limit: Int) {
-  workflowExecutions(where: { orgId: $orgId }, search: $search, order: [["createdAt", "DESC"]], limit: $limit) {
-    id
-    status
-    createdAt
-    workflow {
-      id
-    }
-    numSuccessfulTasks
-  }
-}`;
-
 const EXECUTIONS_WITH_IO_QUERY = `query RewstBuddyMcpExecutionsWithIO($orgId: ID!, $workflowId: ID!, $limit: Int) {
   workflowExecutions(where: { orgId: $orgId, workflowId: $workflowId }, order: [["createdAt", "DESC"]], limit: $limit) {
     id
@@ -385,16 +315,6 @@ const WORKFLOW_PATCH_QUERY = `query RewstBuddyMcpWorkflowPatch($id: ID!) {
   }
 }`;
 
-const LATEST_WORKFLOW_EXECUTION_QUERY = `query RewstBuddyMcpLatestWorkflowExecution($orgId: ID!, $workflowId: ID!, $status: String) {
-  latestWorkflowExecution(workflowId: $workflowId, orgId: $orgId, status: $status) {
-    id
-    status
-    createdAt
-    numSuccessfulTasks
-    numAwaitingResponseTasks
-  }
-}`;
-
 const WORKFLOW_EXECUTION_STATS_QUERY = `query RewstBuddyMcpWorkflowExecutionStats($orgId: ID!, $createdSince: String!) {
   workflowExecutionStats(orgId: $orgId, createdSince: $createdSince) {
     succeeded
@@ -404,20 +324,6 @@ const WORKFLOW_EXECUTION_STATS_QUERY = `query RewstBuddyMcpWorkflowExecutionStat
     paused
     delayed
     humanSecondsSaved
-  }
-}`;
-
-const FIND_ACTION_QUERY = `query RewstBuddyMcpFindAction($orgId: ID!, $filter: String) {
-  searchInstalledPackActions(orgId: $orgId, actionFilter: $filter) {
-    id
-    name
-    ref
-    actions {
-      id
-      name
-      ref
-      description
-    }
   }
 }`;
 
@@ -452,19 +358,6 @@ async function runListOrgs(_input: Record<string, unknown>, ctx: CapabilityConte
 	}
 	if (orgs.size === 0) return 'No organizations are available. Sign in to Rewst in VS Code first.';
 	const lines = [...orgs.entries()].map(([id, name]) => `${name} (${id})`).sort();
-	return lines.join('\n');
-}
-
-async function runListTemplates(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const { orgId } = parseCapabilityInput(listTemplatesInputSchema, input);
-	const response = await ctx.session.sdk?.listTemplates({ orgId });
-	const templates = response?.templates ?? [];
-	if (templates.length === 0) return 'No templates found for this organization.';
-	const capped = templates.slice(0, DEFAULT_TEMPLATE_LIMIT);
-	const lines = capped.map(template => `${template?.name ?? '(unnamed)'} (${template?.id})`);
-	if (templates.length > capped.length) {
-		lines.push(`…(${templates.length - capped.length} more not shown; refine in Rewst or use buddy_graphql_query)`);
-	}
 	return lines.join('\n');
 }
 
@@ -519,30 +412,6 @@ async function runListOrgVariables(input: Record<string, unknown>, ctx: Capabili
 			const category = variable.category ?? 'unknown';
 			return `${variable.name ?? '(unnamed)'} = ${variable.value ?? ''}  [${category}${variable.cascade ? ', cascade' : ''}]`;
 		})
-		.join('\n');
-}
-
-async function runListWorkflowExecutions(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const { orgId, status, limit: rawLimit } = parseCapabilityInput(listWorkflowExecutionsInputSchema, input);
-	const limit = rawLimit ?? DEFAULT_EXECUTION_LIMIT;
-	const variables: Record<string, unknown> = { orgId, limit };
-	if (status) variables.search = { status: { _eq: status } };
-	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_EXECUTIONS_QUERY, variables);
-	const executions = ((data as { workflowExecutions?: unknown[] } | undefined)?.workflowExecutions ?? []) as {
-		id?: string;
-		status?: string;
-		createdAt?: string;
-		workflow?: { id?: string };
-		numSuccessfulTasks?: number;
-	}[];
-	if (executions.length === 0) return 'No workflow executions found for this organization.';
-	return executions
-		.map(
-			execution =>
-				`${execution.status ?? '(unknown status)'} — ${execution.id} (workflow ${execution.workflow?.id ?? '?'}, ${
-					execution.numSuccessfulTasks ?? 0
-				} ok, created ${execution.createdAt})`,
-		)
 		.join('\n');
 }
 
@@ -707,30 +576,6 @@ async function runGetWorkflowPatch(input: Record<string, unknown>, ctx: Capabili
 	return JSON.stringify(workflowPatch, null, 2);
 }
 
-async function runLatestWorkflowExecution(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const { orgId, workflowId, status } = parseCapabilityInput(latestWorkflowExecutionInputSchema, input);
-	const variables: Record<string, unknown> = { orgId, workflowId };
-	if (status) variables.status = status;
-	const data = await rawGraphqlOrThrow(ctx.session, LATEST_WORKFLOW_EXECUTION_QUERY, variables);
-	const execution = (
-		data as
-			| {
-					latestWorkflowExecution?: {
-						id?: string;
-						status?: string;
-						createdAt?: string;
-						numSuccessfulTasks?: number;
-						numAwaitingResponseTasks?: number;
-					} | null;
-			  }
-			| undefined
-	)?.latestWorkflowExecution;
-	if (!execution) return `No execution found for workflow ${workflowId}.`;
-	return `${execution.status ?? '(unknown status)'} — ${execution.id} (created ${
-		execution.createdAt
-	}, ${execution.numSuccessfulTasks ?? 0} ok, ${execution.numAwaitingResponseTasks ?? 0} awaiting response)`;
-}
-
 async function runGetWorkflowExecutionStats(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
 	const { orgId, createdSince } = parseCapabilityInput(getWorkflowExecutionStatsInputSchema, input);
 	const variables = { orgId, createdSince };
@@ -760,50 +605,6 @@ async function runGetWorkflowExecutionStats(input: Record<string, unknown>, ctx:
 		`delayed: ${stats.delayed ?? 0}`,
 		`humanSecondsSaved: ${stats.humanSecondsSaved ?? 0}`,
 	].join('\n');
-}
-
-async function runFindAction(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const { orgId, filter, limit: rawLimit } = parseCapabilityInput(findActionInputSchema, input);
-	const limit = rawLimit ?? DEFAULT_ACTION_LIMIT;
-	const variables: Record<string, unknown> = { orgId };
-	if (filter) variables.filter = filter;
-	const data = await rawGraphqlOrThrow(ctx.session, FIND_ACTION_QUERY, variables);
-	const packs = ((data as { searchInstalledPackActions?: unknown[] } | undefined)?.searchInstalledPackActions ??
-		[]) as {
-		id?: string;
-		name?: string;
-		ref?: string;
-		actions?: {
-			id?: string;
-			name?: string;
-			ref?: string | null;
-			description?: string | null;
-		}[];
-	}[];
-	const flattened: {
-		action: { id?: string; name?: string; ref?: string | null; description?: string | null };
-		packName: string;
-	}[] = [];
-	for (const pack of packs) {
-		const packName = pack.name ?? pack.ref ?? pack.id ?? '(unknown pack)';
-		for (const action of pack.actions ?? []) {
-			flattened.push({ action, packName });
-		}
-	}
-	if (flattened.length === 0) {
-		return `No actions found${filter ? ` matching "${filter}"` : ''} in this organization.`;
-	}
-	const capped = flattened.slice(0, limit);
-	const lines = capped.map(
-		({ action, packName }) =>
-			`${action.ref ?? action.name ?? '(unnamed)'} (${action.id}) — ${packName}${
-				action.description ? `: ${action.description}` : ''
-			}`,
-	);
-	if (flattened.length > limit) {
-		lines.push(`…(${flattened.length - limit} more not shown; refine the filter)`);
-	}
-	return lines.join('\n');
 }
 
 async function runResolveReference(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
@@ -856,18 +657,14 @@ async function runGraphqlQuery(input: Record<string, unknown>, ctx: CapabilityCo
 
 export const READ_CAPABILITIES: Capability[] = [
 	readCapability(listOrgsSpec, runListOrgs, { requiresOrg: false }),
-	readCapability(listTemplatesSpec, runListTemplates),
 	readCapability(getTemplateSpec, runGetTemplate),
 	readCapability(listWorkflowsSpec, runListWorkflows),
 	readCapability(listOrgVariablesSpec, runListOrgVariables),
-	readCapability(listWorkflowExecutionsSpec, runListWorkflowExecutions),
 	readCapability(findExecutionsByVariableSpec, runFindExecutionsByVariable),
 	readCapability(listWorkflowTasksSpec, runListWorkflowTasks),
 	readCapability(listWorkflowPatchesSpec, runListWorkflowPatches),
 	readCapability(getWorkflowPatchSpec, runGetWorkflowPatch),
-	readCapability(latestWorkflowExecutionSpec, runLatestWorkflowExecution),
 	readCapability(getWorkflowExecutionStatsSpec, runGetWorkflowExecutionStats),
-	readCapability(findActionSpec, runFindAction),
 	readCapability(resolveReferenceSpec, runResolveReference),
 	readCapability(getWorkflowSpec, runGetWorkflow),
 	readCapability(graphqlQuerySpec, runGraphqlQuery),

--- a/src/capabilities/tagMutateCapabilities.ts
+++ b/src/capabilities/tagMutateCapabilities.ts
@@ -1,8 +1,16 @@
+import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, asString, rawGraphqlOrThrow, requireResourceInOrg, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalStringField,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	requireResourceInOrg,
+	toInputSchema,
+} from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -56,28 +64,26 @@ async function requireTagInOrg(ctx: CapabilityContext, tagId: string, orgId: str
 	});
 }
 
-const createTagSpec: ToolSpec = {
+const createTagSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	name: z
+		.string({ error: 'Missing required string argument "name".' })
+		.trim()
+		.min(1, { error: 'Missing required string argument "name".' })
+		.describe('Tag name.'),
+	color: optionalStringField().describe('Optional color (hex, e.g. #4287f5).'),
+	description: optionalStringField().describe('Optional tag description.'),
+});
+
+const createTagSpec: ToolSpecDefinition = {
 	name: 'buddy_create_tag',
-	args: '{"orgId": string, "name": string, "color"?: string, "description"?: string}',
 	description:
 		'Create a tag in one Rewst organization. color is an optional hex string (e.g. #4287f5). Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			name: { type: 'string', description: 'Tag name.' },
-			color: { type: 'string', description: 'Optional color (hex, e.g. #4287f5).' },
-			description: { type: 'string', description: 'Optional tag description.' },
-		},
-		required: ['orgId', 'name'],
-	},
+	inputSchema: toInputSchema(createTagSchema),
 };
 
 async function runCreateTag(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const name = requireString(input, 'name');
-	const color = asString(input, 'color');
-	const description = asString(input, 'description');
+	const { orgId, name, color, description } = parseCapabilityInput(createTagSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const scope: MutationScope = { scopeId: orgId, scopeName: `new tag "${name}"`, orgId, orgName };
 	const summary = `Create tag "${name}" in org "${orgName}" (${orgId})`;
@@ -92,30 +98,33 @@ async function runCreateTag(input: Record<string, unknown>, ctx: CapabilityConte
 	});
 }
 
-const updateTagSpec: ToolSpec = {
+const updateTagSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	tagId: z
+		.string({ error: 'Missing required string argument "tagId".' })
+		.trim()
+		.min(1, { error: 'Missing required string argument "tagId".' })
+		.describe('Id of the tag to update.'),
+	name: optionalStringField().describe('Optional new name (defaults to the current name).'),
+	color: optionalStringField().describe('Optional new color (hex).'),
+	description: optionalStringField().describe('Optional new description.'),
+});
+
+const updateTagSpec: ToolSpecDefinition = {
 	name: 'buddy_update_tag',
-	args: '{"orgId": string, "tagId": string, "name"?: string, "color"?: string, "description"?: string}',
 	description:
 		'Update one existing tag (name, color, and/or description), identified by org and tag id. The tag must belong to the given org. Fields not supplied keep their current value. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			tagId: { type: 'string', description: 'Id of the tag to update.' },
-			name: { type: 'string', description: 'Optional new name (defaults to the current name).' },
-			color: { type: 'string', description: 'Optional new color (hex).' },
-			description: { type: 'string', description: 'Optional new description.' },
-		},
-		required: ['orgId', 'tagId'],
-	},
+	inputSchema: toInputSchema(updateTagSchema),
 };
 
 async function runUpdateTag(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const tagId = requireString(input, 'tagId');
-	const nameOverride = asString(input, 'name');
-	const colorOverride = asString(input, 'color');
-	const descriptionOverride = asString(input, 'description');
+	const {
+		orgId,
+		tagId,
+		name: nameOverride,
+		color: colorOverride,
+		description: descriptionOverride,
+	} = parseCapabilityInput(updateTagSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const current = await requireTagInOrg(ctx, tagId, orgId);
 	const name = nameOverride ?? current.name ?? '';
@@ -135,24 +144,24 @@ async function runUpdateTag(input: Record<string, unknown>, ctx: CapabilityConte
 	});
 }
 
-const deleteTagSpec: ToolSpec = {
+const deleteTagSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	tagId: z
+		.string({ error: 'Missing required string argument "tagId".' })
+		.trim()
+		.min(1, { error: 'Missing required string argument "tagId".' })
+		.describe('Id of the tag to delete.'),
+});
+
+const deleteTagSpec: ToolSpecDefinition = {
 	name: 'buddy_delete_tag',
-	args: '{"orgId": string, "tagId": string}',
 	description:
 		'Permanently delete one tag, identified by org and tag id. The tag must belong to the given org. This cannot be undone. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			tagId: { type: 'string', description: 'Id of the tag to delete.' },
-		},
-		required: ['orgId', 'tagId'],
-	},
+	inputSchema: toInputSchema(deleteTagSchema),
 };
 
 async function runDeleteTag(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const tagId = requireString(input, 'tagId');
+	const { orgId, tagId } = parseCapabilityInput(deleteTagSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const current = await requireTagInOrg(ctx, tagId, orgId);
 	const name = current.name ?? '(unnamed)';

--- a/src/capabilities/templateCloneCapabilities.test.ts
+++ b/src/capabilities/templateCloneCapabilities.test.ts
@@ -1,9 +1,9 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { createMockSession, initTestEnvironment } from '@test';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
 import { LinkManager } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
+import { createMockSession, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
 import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
 import {
 	defaultTemplateCloneDeps,

--- a/src/capabilities/templateCloneCapabilities.test.ts
+++ b/src/capabilities/templateCloneCapabilities.test.ts
@@ -108,6 +108,35 @@ suite('Unit: templateCloneCapabilities', () => {
 		LinkManager._resetForTesting();
 	});
 
+	// --- Zod parse tests ---
+	test('missing rootTemplateId throws before any fetch', async () => {
+		const { deps } = makeCloneDeps({});
+		await assert.rejects(() => runBundleClone({ orgId: 'tgt-org' }, makeCtx(), deps), /rootTemplateId/);
+	});
+
+	test('missing orgId throws before any fetch', async () => {
+		const { deps } = makeCloneDeps({});
+		await assert.rejects(() => runBundleClone({ rootTemplateId: A }, makeCtx(), deps), /orgId/);
+	});
+
+	test('maxTemplates floors and clamps to 200', async () => {
+		setMcpMutationApprover(async () => true);
+		const { deps } = makeCloneDeps({ [A]: tmpl(A) });
+		// Should not throw; 9999 clamps to 200
+		await assert.doesNotReject(() =>
+			runBundleClone({ orgId: 'tgt-org', rootTemplateId: A, maxTemplates: 9999 }, makeCtx(), deps),
+		);
+	});
+
+	test('buddy_template_bundle_clone derived schema has orgId and rootTemplateId required and args generated', () => {
+		const c = TEMPLATE_CLONE_CAPABILITIES.find(x => x.spec.name === 'buddy_template_bundle_clone');
+		assert.ok(c);
+		const schema = c.spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.ok(schema.required.includes('rootTemplateId'));
+		assert.strictEqual(c.spec.args, JSON.stringify(schema));
+	});
+
 	suite('rewriteReferences', () => {
 		test('rewrites mapped ids, leaves unmapped refs and surrounding Jinja intact', () => {
 			const map = new Map([[A, 'new-1']]);

--- a/src/capabilities/templateCloneCapabilities.ts
+++ b/src/capabilities/templateCloneCapabilities.ts
@@ -7,13 +7,11 @@ import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
 import {
-	asPositiveInt,
-	asString,
 	getTemplateFromAnySession,
 	json,
-	ORG_ID_FIELD,
 	optionalClampedInt,
 	optionalStringField,
+	ORG_ID_FIELD,
 	parseCapabilityInput,
 	requiredStringField,
 	toInputSchema,

--- a/src/capabilities/templateCloneCapabilities.ts
+++ b/src/capabilities/templateCloneCapabilities.ts
@@ -1,11 +1,23 @@
 import type { FullTemplateFragment, Session } from '@sessions';
 import { findAllTemplateReferences } from '@utils';
+import { z } from 'zod';
 import { TEMPLATE_PATTERN } from '../providers/templatePatternUtils';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
-import { asPositiveInt, asString, getTemplateFromAnySession, json, ORG_ID_PROP, requireString } from './inputHelpers';
+import {
+	asPositiveInt,
+	asString,
+	getTemplateFromAnySession,
+	json,
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	optionalStringField,
+	parseCapabilityInput,
+	requiredStringField,
+	toInputSchema,
+} from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -124,27 +136,39 @@ async function rollback(deps: TemplateCloneDeps, session: Session, created: read
 	return failed;
 }
 
+const bundleCloneInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	rootTemplateId: requiredStringField('rootTemplateId').describe('Id of the root template to deep-clone.'),
+	sourceOrgId: optionalStringField().describe(
+		'Optional id of the org the root and its references live in. Verified against the root; defaults to the root\u2019s org.',
+	),
+	namePrefix: optionalStringField().describe('Optional prefix for cloned template names.'),
+	nameSuffix: optionalStringField().describe('Optional suffix for cloned template names. Defaults to " (copy)".'),
+	maxTemplates: optionalClampedInt(MAX_MAX_TEMPLATES).describe(
+		'Max total templates to clone (root + references). Default 50, capped at 200.',
+	),
+	maxDepth: optionalClampedInt(MAX_MAX_DEPTH).describe('Max reference depth to walk. Default 10, capped at 25.'),
+});
+
 export async function runBundleClone(
 	input: Record<string, unknown>,
 	ctx: CapabilityContext,
 	deps: TemplateCloneDeps = defaultTemplateCloneDeps,
 ): Promise<string> {
-	const targetOrgId = requireString(input, 'orgId');
-	const rootId = requireString(input, 'rootTemplateId');
-	const sourceOrgIdArg = asString(input, 'sourceOrgId');
+	const {
+		orgId: targetOrgId,
+		rootTemplateId: rootId,
+		sourceOrgId: sourceOrgIdArg,
+		namePrefix: namePrefixRaw,
+		nameSuffix: nameSuffixRaw,
+		maxTemplates: maxTemplatesRaw,
+		maxDepth: maxDepthRaw,
+	} = parseCapabilityInput(bundleCloneInputSchema, input);
 
-	let namePrefix = '';
-	if (input.namePrefix !== undefined) {
-		if (typeof input.namePrefix !== 'string') throw new Error('"namePrefix" must be a string.');
-		namePrefix = input.namePrefix;
-	}
-	let nameSuffix = DEFAULT_NAME_SUFFIX;
-	if (input.nameSuffix !== undefined) {
-		if (typeof input.nameSuffix !== 'string') throw new Error('"nameSuffix" must be a string.');
-		nameSuffix = input.nameSuffix;
-	}
-	const maxTemplates = Math.min(asPositiveInt(input, 'maxTemplates') ?? DEFAULT_MAX_TEMPLATES, MAX_MAX_TEMPLATES);
-	const maxDepth = Math.min(asPositiveInt(input, 'maxDepth') ?? DEFAULT_MAX_DEPTH, MAX_MAX_DEPTH);
+	const namePrefix = namePrefixRaw ?? '';
+	const nameSuffix = nameSuffixRaw ?? DEFAULT_NAME_SUFFIX;
+	const maxTemplates = maxTemplatesRaw ?? DEFAULT_MAX_TEMPLATES;
+	const maxDepth = maxDepthRaw ?? DEFAULT_MAX_DEPTH;
 
 	// Phase 0 — fetch the root (from any session that can read it) and pin the source org.
 	const fetched = await getTemplateFromAnySession(ctx.sessions, deps.getTemplate, rootId);
@@ -276,34 +300,11 @@ export async function runBundleClone(
 	});
 }
 
-const bundleCloneSpec: ToolSpec = {
+const bundleCloneSpec: ToolSpecDefinition = {
 	name: 'buddy_template_bundle_clone',
-	args: '{"orgId": string, "rootTemplateId": string, "sourceOrgId"?: string, "namePrefix"?: string, "nameSuffix"?: string, "maxTemplates"?: number, "maxDepth"?: number}',
 	description:
 		"Deep-copy a Rewst template and the templates it references (transitively, via template('<id>') calls in the body) into NEW templates in a target org, rewriting every reference to the new template ids. Each clone copies the source name, body, contentType, language, JSON context and cloneOverrides; tags are NOT copied (they are org-scoped) and references inside context/cloneOverrides are not followed. orgId is the TARGET org the clones are created in — it must have write tools enabled, be on the write allowlist, and pass per-call approval. The source org is taken from the root template (verify it with sourceOrgId). References to templates in a different org, or that no longer exist, are left pointing at the original id and reported as foreignReferences / missingReferences. Nodes beyond maxTemplates (default 50, max 200) or maxDepth (default 10, max 25) are not cloned and are reported under skipped.cap / skipped.depth. On any failure mid-clone the templates created so far are deleted (rollback). Returns the old→new id map and the new root id; it does not create a local file link — use buddy_template_link for that.",
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			rootTemplateId: { type: 'string', description: 'Id of the root template to deep-clone.' },
-			sourceOrgId: {
-				type: 'string',
-				description:
-					'Optional id of the org the root and its references live in. Verified against the root; defaults to the root’s org.',
-			},
-			namePrefix: { type: 'string', description: 'Optional prefix for cloned template names.' },
-			nameSuffix: {
-				type: 'string',
-				description: 'Optional suffix for cloned template names. Defaults to " (copy)".',
-			},
-			maxTemplates: {
-				type: 'number',
-				description: 'Max total templates to clone (root + references). Default 50, capped at 200.',
-			},
-			maxDepth: { type: 'number', description: 'Max reference depth to walk. Default 10, capped at 25.' },
-		},
-		required: ['orgId', 'rootTemplateId'],
-	},
+	inputSchema: toInputSchema(bundleCloneInputSchema),
 };
 
 export const TEMPLATE_CLONE_CAPABILITIES: Capability[] = [

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -1,10 +1,10 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
 import type { CapabilityContext } from '@capabilities';
 import { LinkManager, SyncOnSaveManager, type TemplateLink } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
+import { initTestEnvironment } from '@test';
 import { getHash } from '@utils';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
 import vscode from 'vscode';
 import {
 	resolvePathToUri,

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -105,6 +105,41 @@ function addStaleOrgLink(fsPath: string): vscode.Uri {
 }
 
 suite('Unit: templateLinkCapabilities', () => {
+	// --- Zod parse tests ---
+	test('missing uri throws for buddy_template_link', async () => {
+		const ctx = makeCtx();
+		await assert.rejects(() => runLink({ templateId: 't1' }, ctx, makeLinkDeps().deps), /uri/);
+	});
+
+	test('missing templateId throws for buddy_template_link', async () => {
+		const ctx = makeCtx();
+		await assert.rejects(() => runLink({ uri: '/ws/file.j2' }, ctx, makeLinkDeps().deps), /templateId/);
+	});
+
+	test('optional orgId for buddy_template_link is accepted when absent', async () => {
+		const ctx = makeCtx();
+		const { deps } = makeLinkDeps();
+		// Should not throw on missing orgId (it is optional)
+		const out = JSON.parse(await runLink({ templateId: 't1', uri: '/ws/file.j2' }, ctx, deps));
+		assert.ok(
+			out.status === 'linked' ||
+				out.status === 'already_linked' ||
+				out.status === 'invalid_path' ||
+				out.status === 'file_not_found' ||
+				out.status === 'template_not_found',
+		);
+	});
+
+	test('TEMPLATE_LINK_CAPABILITIES derived schemas have args generated from inputSchema', () => {
+		for (const c of TEMPLATE_LINK_CAPABILITIES) {
+			assert.strictEqual(
+				c.spec.args,
+				JSON.stringify(c.spec.inputSchema),
+				`${c.spec.name}: args must equal JSON.stringify(inputSchema)`,
+			);
+		}
+	});
+
 	setup(() => {
 		initTestEnvironment();
 		LinkManager._resetForTesting();

--- a/src/capabilities/templateLinkCapabilities.test.ts
+++ b/src/capabilities/templateLinkCapabilities.test.ts
@@ -130,6 +130,15 @@ suite('Unit: templateLinkCapabilities', () => {
 		);
 	});
 
+	test('non-string orgId for buddy_template_link is rejected instead of ignored', async () => {
+		const ctx = makeCtx();
+		const { deps } = makeLinkDeps();
+		await assert.rejects(
+			() => runLink({ templateId: 't1', uri: '/ws/file.j2', orgId: 42 }, ctx, deps),
+			/"orgId" must be a string if provided/,
+		);
+	});
+
 	test('TEMPLATE_LINK_CAPABILITIES derived schemas have args generated from inputSchema', () => {
 		for (const c of TEMPLATE_LINK_CAPABILITIES) {
 			assert.strictEqual(

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -9,7 +9,6 @@ import { readCapability } from './capabilityFactories';
 import {
 	getTemplateFromAnySession,
 	json,
-	optionalStringField,
 	parseCapabilityInput,
 	requiredStringField,
 	toInputSchema,
@@ -80,9 +79,12 @@ const linkInputSchema = z.object({
 	uri: requiredStringField('uri').describe(
 		'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
 	),
-	orgId: optionalStringField().describe(
-		'Optional org id to verify the template belongs to. Defaults to the template\u2019s own org.',
-	),
+	orgId: z
+		.string({ error: '"orgId" must be a string if provided.' })
+		.trim()
+		.min(1, { error: '"orgId" must be a string if provided.' })
+		.optional()
+		.describe("Optional org id to verify the template belongs to. Defaults to the template's own org."),
 	overwrite: z
 		.boolean()
 		.optional()

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -75,7 +75,7 @@ export const defaultTemplateLinkDeps: TemplateLinkDeps = {
 
 const linkInputSchema = z.object({
 	templateId: requiredStringField('templateId').describe(
-		'Id of the existing Rewst template to link the file to (from buddy_list_templates).',
+		'Id of the existing Rewst template to link the file to (from buddy_search_templates).',
 	),
 	uri: requiredStringField('uri').describe(
 		'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -1,11 +1,19 @@
 import { buildTemplateLink, LinkManager, orgForTemplateLink, SyncOnSaveManager } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
 import { uriExists } from '@utils';
+import { z } from 'zod';
 import vscode from 'vscode';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asString, getTemplateFromAnySession, json, requireString } from './inputHelpers';
+import {
+	getTemplateFromAnySession,
+	json,
+	optionalStringField,
+	parseCapabilityInput,
+	requiredStringField,
+	toInputSchema,
+} from './inputHelpers';
 import { resolveLinkedUri } from './templateSyncCapabilities';
 
 /**
@@ -65,15 +73,53 @@ export const defaultTemplateLinkDeps: TemplateLinkDeps = {
 	getTemplate: (session, templateId) => session.getTemplate(templateId),
 };
 
+const linkInputSchema = z.object({
+	templateId: requiredStringField('templateId').describe(
+		'Id of the existing Rewst template to link the file to (from buddy_list_templates).',
+	),
+	uri: requiredStringField('uri').describe(
+		'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
+	),
+	orgId: optionalStringField().describe(
+		'Optional org id to verify the template belongs to. Defaults to the template\u2019s own org.',
+	),
+	overwrite: z
+		.boolean()
+		.optional()
+		.describe('If the file is already linked, replace the existing link instead of failing. Default false.'),
+});
+
+const unlinkInputSchema = z.object({
+	uri: requiredStringField('uri').describe(
+		'Path or file URI of the linked file, as shown by buddy_search_template_links.',
+	),
+});
+
+const syncOnSaveInputSchema = z.object({
+	uri: requiredStringField('uri').describe('Path or file URI of the linked file.'),
+	enabled: z
+		.boolean({ error: '"enabled" must be a boolean (true to enable sync-on-save, false to disable).' })
+		.describe('true to enable sync-on-save (upload on save), false to disable.'),
+});
+
+const linkStatusInputSchema = z.object({
+	uri: requiredStringField('uri').describe(
+		'Absolute path, workspace-relative path, or file:// URI of the local file to check.',
+	),
+});
+
 export async function runLink(
 	input: Record<string, unknown>,
 	ctx: CapabilityContext,
 	deps: TemplateLinkDeps = defaultTemplateLinkDeps,
 ): Promise<string> {
-	const templateId = requireString(input, 'templateId');
-	const rawUri = requireString(input, 'uri');
-	const requestedOrgId = asString(input, 'orgId');
-	const overwrite = input.overwrite === true;
+	const {
+		templateId,
+		uri: rawUri,
+		orgId: requestedOrgId,
+		overwrite: overwriteRaw,
+	} = parseCapabilityInput(linkInputSchema, input);
+	const overwrite = overwriteRaw === true;
 
 	const uri = deps.resolvePathToUri(rawUri);
 	if (!uri) {
@@ -148,7 +194,7 @@ export async function runLink(
 }
 
 export async function runUnlink(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
-	const rawUri = requireString(input, 'uri');
+	const { uri: rawUri } = parseCapabilityInput(unlinkInputSchema, input);
 	const resolved = resolveLinkedUri(rawUri);
 	if (!resolved) {
 		return json({
@@ -183,7 +229,7 @@ export async function runUnlink(input: Record<string, unknown>, _ctx: Capability
  * file is definitely unlinked.
  */
 export function runLinkStatus(input: Record<string, unknown>): string {
-	const rawUri = requireString(input, 'uri');
+	const { uri: rawUri } = parseCapabilityInput(linkStatusInputSchema, input);
 	const resolved = resolveLinkedUri(rawUri);
 	if (!resolved) {
 		return json({
@@ -210,11 +256,7 @@ export function runLinkStatus(input: Record<string, unknown>): string {
 }
 
 export async function runSyncOnSave(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
-	const rawUri = requireString(input, 'uri');
-	const enabled = input.enabled;
-	if (typeof enabled !== 'boolean') {
-		throw new Error('"enabled" must be a boolean (true to enable sync-on-save, false to disable).');
-	}
+	const { uri: rawUri, enabled } = parseCapabilityInput(syncOnSaveInputSchema, input);
 	const resolved = resolveLinkedUri(rawUri);
 	if (!resolved) {
 		return json({
@@ -245,87 +287,32 @@ export async function runSyncOnSave(input: Record<string, unknown>, _ctx: Capabi
 	});
 }
 
-const linkSpec: ToolSpec = {
+const linkSpec: ToolSpecDefinition = {
 	name: 'buddy_template_link',
-	args: '{"templateId": string, "uri": string, "orgId"?: string, "overwrite"?: boolean}',
 	description:
 		'Associate an existing local file with an existing Rewst template, so it can be synced. Does not create the file or the template. Identify the file by an absolute path, a workspace-relative path, or a file:// URI. The link starts out-of-sync on purpose — afterwards call buddy_template_sync_status to compare, or buddy_template_sync to reconcile. Returns already_linked unless overwrite is true, and invalid_path / file_not_found / template_not_found / org_mismatch on the obvious failures. This changes only local link state (no Rewst write).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			templateId: {
-				type: 'string',
-				description: 'Id of the existing Rewst template to link the file to (from buddy_list_templates).',
-			},
-			uri: {
-				type: 'string',
-				description:
-					'Absolute path, workspace-relative path, or file:// URI of the existing local file to link.',
-			},
-			orgId: {
-				type: 'string',
-				description: 'Optional org id to verify the template belongs to. Defaults to the template’s own org.',
-			},
-			overwrite: {
-				type: 'boolean',
-				description:
-					'If the file is already linked, replace the existing link instead of failing. Default false.',
-			},
-		},
-		required: ['templateId', 'uri'],
-	},
+	inputSchema: toInputSchema(linkInputSchema),
 };
 
-const unlinkSpec: ToolSpec = {
+const unlinkSpec: ToolSpecDefinition = {
 	name: 'buddy_template_unlink',
-	args: '{"uri": string}',
 	description:
 		'Remove the link between a local file and its Rewst template. The local file and the remote template are left untouched; only the local association (and its sync-on-save setting) is removed. Identify the file by the path shown in buddy_search_template_links or its file URI. Returns not_linked if no template is linked to it.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			uri: {
-				type: 'string',
-				description: 'Path or file URI of the linked file, as shown by buddy_search_template_links.',
-			},
-		},
-		required: ['uri'],
-	},
+	inputSchema: toInputSchema(unlinkInputSchema),
 };
 
-const syncOnSaveSpec: ToolSpec = {
+const syncOnSaveSpec: ToolSpecDefinition = {
 	name: 'buddy_template_sync_on_save',
-	args: '{"uri": string, "enabled": boolean}',
 	description:
 		'Enable or disable sync-on-save for a linked file: when on, saving the file in VS Code uploads it to its Rewst template. The file must already be linked (see buddy_template_link). Returns the effective syncOnSave state, which also depends on the rewst-buddy.syncOnSaveByDefault setting. This changes only local state (no Rewst write).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			uri: { type: 'string', description: 'Path or file URI of the linked file.' },
-			enabled: {
-				type: 'boolean',
-				description: 'true to enable sync-on-save (upload on save), false to disable.',
-			},
-		},
-		required: ['uri', 'enabled'],
-	},
+	inputSchema: toInputSchema(syncOnSaveInputSchema),
 };
 
-const linkStatusSpec: ToolSpec = {
+const linkStatusSpec: ToolSpecDefinition = {
 	name: 'buddy_template_link_status',
-	args: '{"uri": string}',
 	description:
 		'Report whether one local file is linked to a Rewst template, reading only local link state (no network or remote comparison). Identify the file by an absolute path, a workspace-relative path, or a file:// URI. Returns linked:false when nothing is linked; otherwise the template id and name, org id and name, and whether sync-on-save is on. For an up-to-date comparison with the Rewst template use buddy_template_sync_status; to list linked files use buddy_search_template_links.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			uri: {
-				type: 'string',
-				description: 'Absolute path, workspace-relative path, or file:// URI of the local file to check.',
-			},
-		},
-		required: ['uri'],
-	},
+	inputSchema: toInputSchema(linkStatusInputSchema),
 };
 
 export const TEMPLATE_LINK_CAPABILITIES: Capability[] = [

--- a/src/capabilities/templateLinkCapabilities.ts
+++ b/src/capabilities/templateLinkCapabilities.ts
@@ -1,8 +1,8 @@
 import { buildTemplateLink, LinkManager, orgForTemplateLink, SyncOnSaveManager } from '@models';
 import type { FullTemplateFragment, Session } from '@sessions';
 import { uriExists } from '@utils';
-import { z } from 'zod';
 import vscode from 'vscode';
+import { z } from 'zod';
 import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';

--- a/src/capabilities/templateMutateCapabilities.ts
+++ b/src/capabilities/templateMutateCapabilities.ts
@@ -1,8 +1,16 @@
+import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, requireResourceInOrg, requireString, requireStringAllowEmpty } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	parseCapabilityInput,
+	requiredStringAllowEmptyField,
+	requiredStringField,
+	requireResourceInOrg,
+	toInputSchema,
+} from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -40,29 +48,23 @@ async function requireTemplateInOrg(
 	return { name: typeof name === 'string' && name.length > 0 ? name : '(unnamed)' };
 }
 
-const createTemplateSpec: ToolSpec = {
+const createTemplateSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	name: requiredStringField('name').describe('Name for the new template.'),
+	body: requiredStringAllowEmptyField('body').describe(
+		'Template body (Jinja/text); pass an empty string for a blank template.',
+	),
+});
+
+const createTemplateSpec: ToolSpecDefinition = {
 	name: 'buddy_create_template',
-	args: '{"orgId": string, "name": string, "body": string}',
 	description:
 		'Create a new Rewst template in one organization from a name and body, returning the new template id and name. Requires write tools to be enabled and per-call approval in VS Code. Pass an empty string for body to start a blank template.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			name: { type: 'string', description: 'Name for the new template.' },
-			body: {
-				type: 'string',
-				description: 'Template body (Jinja/text); pass an empty string for a blank template.',
-			},
-		},
-		required: ['orgId', 'name', 'body'],
-	},
+	inputSchema: toInputSchema(createTemplateSchema),
 };
 
 async function runCreateTemplate(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const name = requireString(input, 'name');
-	const body = requireStringAllowEmpty(input, 'body');
+	const { orgId, name, body } = parseCapabilityInput(createTemplateSchema, input);
 	const orgName = orgDisplayName(ctx);
 	// No resource id exists before creation, so the approval scope is the org; the
 	// first create in an org prompts and later creates reuse that session approval.
@@ -78,26 +80,21 @@ async function runCreateTemplate(input: Record<string, unknown>, ctx: Capability
 	});
 }
 
-const updateTemplateBodySpec: ToolSpec = {
+const updateTemplateBodySchema = z.object({
+	orgId: ORG_ID_FIELD,
+	templateId: requiredStringField('templateId').describe('Id of the template whose body to replace.'),
+	body: requiredStringAllowEmptyField('body').describe('New template body; pass an empty string to clear it.'),
+});
+
+const updateTemplateBodySpec: ToolSpecDefinition = {
 	name: 'buddy_update_template_body',
-	args: '{"orgId": string, "templateId": string, "body": string}',
 	description:
 		'Replace the body of one existing Rewst template, identified by org and template id. The template must belong to the given org. Requires write tools to be enabled and per-call approval in VS Code. Pass an empty string to clear the body.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			templateId: { type: 'string', description: 'Id of the template whose body to replace.' },
-			body: { type: 'string', description: 'New template body; pass an empty string to clear it.' },
-		},
-		required: ['orgId', 'templateId', 'body'],
-	},
+	inputSchema: toInputSchema(updateTemplateBodySchema),
 };
 
 async function runUpdateTemplateBody(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const templateId = requireString(input, 'templateId');
-	const body = requireStringAllowEmpty(input, 'body');
+	const { orgId, templateId, body } = parseCapabilityInput(updateTemplateBodySchema, input);
 	const orgName = orgDisplayName(ctx);
 	// Verify org ownership before prompting or mutating, so a template in a sibling
 	// org the session also manages can never be reached by id.
@@ -114,26 +111,21 @@ async function runUpdateTemplateBody(input: Record<string, unknown>, ctx: Capabi
 	});
 }
 
-const renameTemplateSpec: ToolSpec = {
+const renameTemplateSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	templateId: requiredStringField('templateId').describe('Id of the template to rename.'),
+	name: requiredStringField('name').describe('New name for the template.'),
+});
+
+const renameTemplateSpec: ToolSpecDefinition = {
 	name: 'buddy_rename_template',
-	args: '{"orgId": string, "templateId": string, "name": string}',
 	description:
 		'Rename one existing Rewst template, identified by org and template id. The template must belong to the given org. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			templateId: { type: 'string', description: 'Id of the template to rename.' },
-			name: { type: 'string', description: 'New name for the template.' },
-		},
-		required: ['orgId', 'templateId', 'name'],
-	},
+	inputSchema: toInputSchema(renameTemplateSchema),
 };
 
 async function runRenameTemplate(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const templateId = requireString(input, 'templateId');
-	const name = requireString(input, 'name');
+	const { orgId, templateId, name } = parseCapabilityInput(renameTemplateSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const { name: currentName } = await requireTemplateInOrg(ctx, templateId, orgId);
 	const scope: MutationScope = { scopeId: templateId, scopeName: currentName, orgId, orgName };
@@ -148,24 +140,20 @@ async function runRenameTemplate(input: Record<string, unknown>, ctx: Capability
 	});
 }
 
-const deleteTemplateSpec: ToolSpec = {
+const deleteTemplateSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	templateId: requiredStringField('templateId').describe('Id of the template to delete.'),
+});
+
+const deleteTemplateSpec: ToolSpecDefinition = {
 	name: 'buddy_delete_template',
-	args: '{"orgId": string, "templateId": string}',
 	description:
 		'Permanently delete one Rewst template, identified by org and template id. The template must belong to the given org. This cannot be undone. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			templateId: { type: 'string', description: 'Id of the template to delete.' },
-		},
-		required: ['orgId', 'templateId'],
-	},
+	inputSchema: toInputSchema(deleteTemplateSchema),
 };
 
 async function runDeleteTemplate(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const templateId = requireString(input, 'templateId');
+	const { orgId, templateId } = parseCapabilityInput(deleteTemplateSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const { name } = await requireTemplateInOrg(ctx, templateId, orgId);
 	const scope: MutationScope = { scopeId: templateId, scopeName: name, orgId, orgName };

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -127,6 +127,20 @@ suite('Unit: templateSyncCapabilities', () => {
 		_resetMcpMutationApproverForTesting();
 	});
 
+	// --- Zod parse tests ---
+	test('missing uri throws for buddy_template_sync_status', async () => {
+		const { deps } = makeDeps(null);
+		await assert.rejects(() => runSyncStatus({}, makeCtx(), deps), /uri/);
+	});
+
+	test('buddy_template_sync_status derived schema has uri required and args generated', () => {
+		const statusCap = TEMPLATE_SYNC_CAPABILITIES.find(c => c.spec.name === 'buddy_template_sync_status');
+		assert.ok(statusCap);
+		const schema = statusCap.spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('uri'));
+		assert.strictEqual(statusCap.spec.args, JSON.stringify(schema));
+	});
+
 	suite('buddy_template_sync_status', () => {
 		test('reports unlinked files without touching Rewst', async () => {
 			const { deps } = makeDeps(null);

--- a/src/capabilities/templateSyncCapabilities.test.ts
+++ b/src/capabilities/templateSyncCapabilities.test.ts
@@ -1,9 +1,9 @@
-import * as assert from 'assert';
-import * as Mocha from 'mocha';
-import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import { _resetMcpMutationApproverForTesting, setMcpMutationApprover, type CapabilityContext } from '@capabilities';
 import { LinkManager, type SyncDecision, type SyncDecisionContext, type TemplateLink } from '@models';
 import { SessionManager, type FullTemplateFragment, type Session } from '@sessions';
+import { createMockSession, Fixtures, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
 import vscode from 'vscode';
 import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
 import {

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -9,11 +9,12 @@ import {
 } from '@models';
 import { SessionManager } from '@sessions';
 import vscode from 'vscode';
+import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpec, ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability, writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, requireString } from './inputHelpers';
+import { ORG_ID_PROP, parseCapabilityInput, requiredStringField, requireString, toInputSchema } from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -205,12 +206,18 @@ function resolveEffectiveAction(direction: SyncDirection, action: SyncDecision['
 	return 'conflict';
 }
 
+const syncStatusInputSchema = z.object({
+	uri: requiredStringField('uri').describe(
+		'Path or file URI of the local file, as shown by buddy_search_template_links.',
+	),
+});
+
 export async function runSyncStatus(
 	input: Record<string, unknown>,
 	_ctx: CapabilityContext,
 	deps: TemplateSyncDeps = defaultTemplateSyncDeps,
 ): Promise<string> {
-	const uri = requireString(input, 'uri');
+	const { uri } = parseCapabilityInput(syncStatusInputSchema, input);
 	const prepared = await deps.prepare(uri);
 	if (prepared.kind === 'unlinked') {
 		return JSON.stringify(
@@ -363,21 +370,11 @@ export async function runSync(
 	});
 }
 
-const syncStatusSpec: ToolSpec = {
+const syncStatusSpec: ToolSpecDefinition = {
 	name: 'buddy_template_sync_status',
-	args: '{"uri": string}',
 	description:
 		'Report whether a local file is linked to a Rewst template and how it compares to the remote template, without changing anything. Identify the file by the path shown in buddy_search_template_links (workspace-relative or absolute) or its file URI. Returns linked:false when no template is linked. When linked, returns the org id and template id to pass to buddy_template_sync, whether sync-on-save is on, and a status of "in-sync", "remote-only" (the local file is empty), "local-ahead" (safe to upload), or "conflict" (both changed since the last sync), plus a recommended direction.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			uri: {
-				type: 'string',
-				description: 'Path or file URI of the local file, as shown by buddy_search_template_links.',
-			},
-		},
-		required: ['uri'],
-	},
+	inputSchema: toInputSchema(syncStatusInputSchema),
 };
 
 const syncSpec: ToolSpec = {

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -1,8 +1,8 @@
 import {
 	LinkManager,
+	orgForTemplateLink,
 	SyncManager,
 	SyncOnSaveManager,
-	orgForTemplateLink,
 	type SyncDecision,
 	type SyncDecisionContext,
 	type TemplateLink,

--- a/src/capabilities/templateSyncCapabilities.ts
+++ b/src/capabilities/templateSyncCapabilities.ts
@@ -11,10 +11,10 @@ import { SessionManager } from '@sessions';
 import vscode from 'vscode';
 import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec, ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability, writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, parseCapabilityInput, requiredStringField, requireString, toInputSchema } from './inputHelpers';
+import { ORG_ID_FIELD, parseCapabilityInput, requiredStringField, toInputSchema } from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -261,9 +261,8 @@ export async function runSync(
 	ctx: CapabilityContext,
 	deps: TemplateSyncDeps = defaultTemplateSyncDeps,
 ): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const uri = requireString(input, 'uri');
-	const direction = parseDirection(input.direction);
+	const { orgId, uri, direction: rawDirection } = parseCapabilityInput(syncInputSchema, input);
+	const direction = parseDirection(rawDirection);
 
 	const prepared = await deps.prepare(uri);
 	if (prepared.kind === 'unlinked') {
@@ -377,28 +376,26 @@ const syncStatusSpec: ToolSpecDefinition = {
 	inputSchema: toInputSchema(syncStatusInputSchema),
 };
 
-const syncSpec: ToolSpec = {
+const syncInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	uri: requiredStringField('uri').describe(
+		'Path or file URI of the linked local file, as shown by buddy_search_template_links.',
+	),
+	direction: z
+		.enum(['auto', 'upload', 'download'], {
+			error: '"direction" must be one of auto, upload, download.',
+		})
+		.optional()
+		.describe(
+			'auto (default) resolves the safe direction and stops on a conflict; upload overwrites Rewst with the local file; download overwrites the local file with Rewst.',
+		),
+});
+
+const syncSpec: ToolSpecDefinition = {
 	name: 'buddy_template_sync',
-	args: '{"orgId": string, "uri": string, "direction"?: "auto" | "upload" | "download"}',
 	description:
 		'Synchronize one linked local file with its Rewst template. Identify the file by the path from buddy_search_template_links or its file URI; orgId must be the org the file is linked to (buddy_template_sync_status returns it). direction defaults to "auto": it uploads when only the local file changed, downloads when the local file is empty, refreshes metadata when the bodies already match, and on a conflict (both changed since the last sync) it changes nothing and asks you to choose. Pass direction:"upload" to overwrite the Rewst template with the local file, or direction:"download" to overwrite the local file with the Rewst template. This is a write tool: every direction (including download) requires write tools to be enabled in VS Code and the org to be on the write allowlist. Only uploading additionally needs per-call approval and changes Rewst; downloading and metadata refreshes rewrite local state only.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			uri: {
-				type: 'string',
-				description: 'Path or file URI of the linked local file, as shown by buddy_search_template_links.',
-			},
-			direction: {
-				type: 'string',
-				enum: ['auto', 'upload', 'download'],
-				description:
-					'auto (default) resolves the safe direction and stops on a conflict; upload overwrites Rewst with the local file; download overwrites the local file with Rewst.',
-			},
-		},
-		required: ['orgId', 'uri'],
-	},
+	inputSchema: toInputSchema(syncInputSchema),
 };
 
 export const TEMPLATE_SYNC_CAPABILITIES: Capability[] = [

--- a/src/capabilities/triggerFormCapabilities.test.ts
+++ b/src/capabilities/triggerFormCapabilities.test.ts
@@ -7,6 +7,64 @@ const { fakeCtx, cap } = createCapabilityTestHarness(TRIGGER_FORM_CAPABILITIES);
 suite('Unit: triggerFormCapabilities', () => {
 	setup(() => initTestEnvironment());
 
+	// --- Zod parse tests ---
+	test('missing orgId throws before GraphQL', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_list_triggers').run({}, ctx), /orgId/);
+	});
+
+	test('non-number limit falls back to default (no throw)', async () => {
+		const { ctx } = fakeCtx({ data: { triggers: [] } });
+		await assert.doesNotReject(() => cap('buddy_list_triggers').run({ orgId: 'org-1', limit: 'bad' }, ctx));
+	});
+
+	test('fractional limit is floored', async () => {
+		const { ctx, calls } = fakeCtx({ data: { triggers: [] } });
+		await cap('buddy_list_triggers').run({ orgId: 'org-1', limit: 7.9 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 7);
+	});
+
+	test('over-max limit is clamped to 200', async () => {
+		const { ctx, calls } = fakeCtx({ data: { triggers: [] } });
+		await cap('buddy_list_triggers').run({ orgId: 'org-1', limit: 9999 }, ctx);
+		assert.strictEqual(calls[0].variables!.limit, 200);
+	});
+
+	test('buddy_list_triggers derived schema has orgId required and limit optional', () => {
+		const schema = cap('buddy_list_triggers').spec.inputSchema as {
+			required: string[];
+			properties: Record<string, unknown>;
+		};
+		assert.ok(schema.required.includes('orgId'));
+		assert.ok('limit' in schema.properties);
+		assert.strictEqual(cap('buddy_list_triggers').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_forms derived schema has orgId required', () => {
+		const schema = cap('buddy_list_forms').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_forms').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_tags derived schema has orgId required', () => {
+		const schema = cap('buddy_list_tags').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_tags').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_list_org_trigger_instances derived schema has orgId required', () => {
+		const schema = cap('buddy_list_org_trigger_instances').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.strictEqual(cap('buddy_list_org_trigger_instances').spec.args, JSON.stringify(schema));
+	});
+
+	test('buddy_get_trigger_error_status derived schema has orgId and triggerIds required', () => {
+		const schema = cap('buddy_get_trigger_error_status').spec.inputSchema as { required: string[] };
+		assert.ok(schema.required.includes('orgId'));
+		assert.ok(schema.required.includes('triggerIds'));
+		assert.strictEqual(cap('buddy_get_trigger_error_status').spec.args, JSON.stringify(schema));
+	});
+
 	test('buddy_list_triggers uses triggers query and formats trigger rows', async () => {
 		const { ctx, calls } = fakeCtx({
 			data: {

--- a/src/capabilities/triggerFormCapabilities.test.ts
+++ b/src/capabilities/triggerFormCapabilities.test.ts
@@ -65,6 +65,19 @@ suite('Unit: triggerFormCapabilities', () => {
 		assert.strictEqual(cap('buddy_get_trigger_error_status').spec.args, JSON.stringify(schema));
 	});
 
+	test('missing triggerIds throws before GraphQL for buddy_get_trigger_error_status', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(() => cap('buddy_get_trigger_error_status').run({ orgId: 'org-1' }, ctx), /triggerIds/);
+	});
+
+	test('empty triggerIds array throws before GraphQL for buddy_get_trigger_error_status', async () => {
+		const { ctx } = fakeCtx({ data: {} });
+		await assert.rejects(
+			() => cap('buddy_get_trigger_error_status').run({ orgId: 'org-1', triggerIds: [] }, ctx),
+			/triggerIds/,
+		);
+	});
+
 	test('buddy_list_triggers uses triggers query and formats trigger rows', async () => {
 		const { ctx, calls } = fakeCtx({
 			data: {

--- a/src/capabilities/triggerFormCapabilities.test.ts
+++ b/src/capabilities/triggerFormCapabilities.test.ts
@@ -1,6 +1,6 @@
+import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { createCapabilityTestHarness, initTestEnvironment } from '@test';
 import { TRIGGER_FORM_CAPABILITIES } from './triggerFormCapabilities';
 const { suite, test, setup } = Mocha;
 const { fakeCtx, cap } = createCapabilityTestHarness(TRIGGER_FORM_CAPABILITIES);

--- a/src/capabilities/triggerFormCapabilities.ts
+++ b/src/capabilities/triggerFormCapabilities.ts
@@ -1,7 +1,14 @@
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
-import { asPositiveInt, asString, ORG_ID_PROP, rawGraphqlOrThrow, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalClampedInt,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	toInputSchema,
+} from './inputHelpers';
 
 const DEFAULT_TRIGGER_LIMIT = 50;
 const MAX_TRIGGER_LIMIT = 200;
@@ -18,107 +25,83 @@ const LIST_TAGS_QUERY = `query($orgId: ID!, $limit: Int){ tags(where:{ orgId:$or
 const LIST_ORG_TRIGGER_INSTANCES_QUERY = `query($orgId: ID!, $limit: Int){ orgTriggerInstances(where:{ orgId:$orgId }, limit:$limit){ id triggerId nextFireTime isManualActivation } }`;
 const GET_TRIGGER_ERROR_STATUS_QUERY = `query($triggerIds: [ID!]){ getTriggerErrorStatus(triggerIds:$triggerIds) }`;
 
-const listTriggersSpec: ToolSpec = {
+const listTriggersInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_TRIGGER_LIMIT).describe(
+		`Max triggers to return (default ${DEFAULT_TRIGGER_LIMIT}, max ${MAX_TRIGGER_LIMIT}).`,
+	),
+});
+
+const listFormsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_FORM_LIMIT).describe(
+		`Max forms to return (default ${DEFAULT_FORM_LIMIT}, max ${MAX_FORM_LIMIT}).`,
+	),
+});
+
+const listTagsInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_TAG_LIMIT).describe(
+		`Max tags to return (default ${DEFAULT_TAG_LIMIT}, max ${MAX_TAG_LIMIT}).`,
+	),
+});
+
+const listOrgTriggerInstancesInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	limit: optionalClampedInt(MAX_ORG_TRIGGER_INSTANCE_LIMIT).describe(
+		`Max trigger activation instances to return (default ${DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT}, max ${MAX_ORG_TRIGGER_INSTANCE_LIMIT}).`,
+	),
+});
+
+const TRIGGER_IDS_ERROR = 'Missing required non-empty string array argument "triggerIds".';
+
+const getTriggerErrorStatusInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	triggerIds: z
+		.preprocess(
+			raw => (raw === undefined || raw === null ? [] : raw),
+			z.array(z.string(), { error: TRIGGER_IDS_ERROR }).min(1, { error: TRIGGER_IDS_ERROR }),
+		)
+		.describe('Trigger ids to check.'),
+});
+
+const listTriggersSpec: ToolSpecDefinition = {
 	name: 'buddy_list_triggers',
-	args: '{"orgId": string, "limit"?: number}',
 	description:
 		'List the triggers in one Rewst organization (id, name, enabled, triggerTypeId, workflowId). Triggers are how workflows are invoked.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: {
-				type: 'number',
-				description: `Max triggers to return (default ${DEFAULT_TRIGGER_LIMIT}, max ${MAX_TRIGGER_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listTriggersInputSchema),
 };
 
-const listFormsSpec: ToolSpec = {
+const listFormsSpec: ToolSpecDefinition = {
 	name: 'buddy_list_forms',
-	args: '{"orgId": string, "limit"?: number}',
 	description: 'List the forms in one Rewst organization (id, name, updatedAt).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: {
-				type: 'number',
-				description: `Max forms to return (default ${DEFAULT_FORM_LIMIT}, max ${MAX_FORM_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listFormsInputSchema),
 };
 
-const listTagsSpec: ToolSpec = {
+const listTagsSpec: ToolSpecDefinition = {
 	name: 'buddy_list_tags',
-	args: '{"orgId": string, "limit"?: number}',
 	description:
 		'List the tags in one Rewst organization (id, name, color). Use the ids for tag filters on other tools.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: {
-				type: 'number',
-				description: `Max tags to return (default ${DEFAULT_TAG_LIMIT}, max ${MAX_TAG_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listTagsInputSchema),
 };
 
-const listOrgTriggerInstancesSpec: ToolSpec = {
+const listOrgTriggerInstancesSpec: ToolSpecDefinition = {
 	name: 'buddy_list_org_trigger_instances',
-	args: '{"orgId": string, "limit"?: number}',
 	description:
 		'List trigger activation instances for one Rewst organization (id, triggerId, nextFireTime, isManualActivation). nextFireTime is an epoch-millisecond string.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			limit: {
-				type: 'number',
-				description: `Max trigger activation instances to return (default ${DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT}, max ${MAX_ORG_TRIGGER_INSTANCE_LIMIT}).`,
-			},
-		},
-		required: ['orgId'],
-	},
+	inputSchema: toInputSchema(listOrgTriggerInstancesInputSchema),
 };
 
-const getTriggerErrorStatusSpec: ToolSpec = {
+const getTriggerErrorStatusSpec: ToolSpecDefinition = {
 	name: 'buddy_get_trigger_error_status',
-	args: '{"orgId": string, "triggerIds": string[]}',
 	description:
 		'Batch health check for triggers: given trigger ids, returns whether each currently has errors (true = has errors).',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			triggerIds: { type: 'array', items: { type: 'string' }, description: 'Trigger ids to check.' },
-		},
-		required: ['orgId', 'triggerIds'],
-	},
+	inputSchema: toInputSchema(getTriggerErrorStatusInputSchema),
 };
 
-function requireStringArray(input: Record<string, unknown>, key: string): string[] {
-	const value = input[key];
-	if (!Array.isArray(value) || value.length === 0) {
-		throw new Error(`Missing required non-empty string array argument "${key}".`);
-	}
-	const strings = value.map((_, index) => asString({ value: value[index] }, 'value'));
-	if (strings.some(value => !value)) {
-		throw new Error(`Missing required non-empty string array argument "${key}".`);
-	}
-	return strings as string[];
-}
-
 async function runListTriggers(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_TRIGGER_LIMIT, MAX_TRIGGER_LIMIT);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listTriggersInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_TRIGGER_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_TRIGGERS_QUERY, variables);
 	const triggers = ((data as { triggers?: unknown[] } | undefined)?.triggers ?? []) as {
@@ -141,8 +124,8 @@ async function runListTriggers(input: Record<string, unknown>, ctx: CapabilityCo
 }
 
 async function runListForms(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_FORM_LIMIT, MAX_FORM_LIMIT);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listFormsInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_FORM_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_FORMS_QUERY, variables);
 	const forms = ((data as { forms?: unknown[] } | undefined)?.forms ?? []) as {
@@ -155,8 +138,8 @@ async function runListForms(input: Record<string, unknown>, ctx: CapabilityConte
 }
 
 async function runListTags(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(asPositiveInt(input, 'limit') ?? DEFAULT_TAG_LIMIT, MAX_TAG_LIMIT);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listTagsInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_TAG_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_TAGS_QUERY, variables);
 	const tags = ((data as { tags?: unknown[] } | undefined)?.tags ?? []) as {
@@ -169,11 +152,8 @@ async function runListTags(input: Record<string, unknown>, ctx: CapabilityContex
 }
 
 async function runListOrgTriggerInstances(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const limit = Math.min(
-		asPositiveInt(input, 'limit') ?? DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT,
-		MAX_ORG_TRIGGER_INSTANCE_LIMIT,
-	);
+	const { orgId, limit: rawLimit } = parseCapabilityInput(listOrgTriggerInstancesInputSchema, input);
+	const limit = rawLimit ?? DEFAULT_ORG_TRIGGER_INSTANCE_LIMIT;
 	const variables = { orgId, limit };
 	const data = await rawGraphqlOrThrow(ctx.session, LIST_ORG_TRIGGER_INSTANCES_QUERY, variables);
 	const instances = ((data as { orgTriggerInstances?: unknown[] } | undefined)?.orgTriggerInstances ?? []) as {
@@ -196,8 +176,7 @@ async function runListOrgTriggerInstances(input: Record<string, unknown>, ctx: C
 
 // orgId is validated to select the session; result scoping is enforced server-side by the session's org access, so the query filters by trigger ids alone.
 async function runGetTriggerErrorStatus(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	requireString(input, 'orgId');
-	const triggerIds = requireStringArray(input, 'triggerIds');
+	const { triggerIds } = parseCapabilityInput(getTriggerErrorStatusInputSchema, input);
 	const variables = { triggerIds };
 	const data = await rawGraphqlOrThrow(ctx.session, GET_TRIGGER_ERROR_STATUS_QUERY, variables);
 	const statuses = ((data as { getTriggerErrorStatus?: Record<string, boolean> } | undefined)

--- a/src/capabilities/triggerMutateCapabilities.ts
+++ b/src/capabilities/triggerMutateCapabilities.ts
@@ -1,8 +1,15 @@
+import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, rawGraphqlOrThrow, requireResourceInOrg, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	requireResourceInOrg,
+	toInputSchema,
+} from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -28,13 +35,6 @@ interface TriggerRow {
 	orgId?: string;
 }
 
-/** Reads a required boolean argument; non-booleans are an error, not coerced. */
-function requireBoolean(input: Record<string, unknown>, key: string): boolean {
-	const value = input[key];
-	if (typeof value !== 'boolean') throw new Error(`Missing required boolean argument "${key}".`);
-	return value;
-}
-
 /**
  * Fetches a trigger by id and fails closed unless it belongs to the requested
  * org. Returns the current name for the approval scope.
@@ -54,26 +54,27 @@ async function requireTriggerInOrg(ctx: CapabilityContext, triggerId: string, or
 	});
 }
 
-const setTriggerEnabledSpec: ToolSpec = {
+const setTriggerEnabledSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	triggerId: z
+		.string({ error: 'Missing required string argument "triggerId".' })
+		.trim()
+		.min(1, { error: 'Missing required string argument "triggerId".' })
+		.describe('Id of the trigger to enable or disable.'),
+	enabled: z
+		.boolean({ error: 'Missing required boolean argument "enabled".' })
+		.describe('true to enable the trigger, false to disable it.'),
+});
+
+const setTriggerEnabledSpec: ToolSpecDefinition = {
 	name: 'buddy_set_trigger_enabled',
-	args: '{"orgId": string, "triggerId": string, "enabled": boolean}',
 	description:
 		'Enable or disable one Rewst workflow trigger, identified by org and trigger id. The trigger must belong to the given org. Pass enabled=true to turn it on, false to turn it off. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			triggerId: { type: 'string', description: 'Id of the trigger to enable or disable.' },
-			enabled: { type: 'boolean', description: 'true to enable the trigger, false to disable it.' },
-		},
-		required: ['orgId', 'triggerId', 'enabled'],
-	},
+	inputSchema: toInputSchema(setTriggerEnabledSchema),
 };
 
 async function runSetTriggerEnabled(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const triggerId = requireString(input, 'triggerId');
-	const enabled = requireBoolean(input, 'enabled');
+	const { orgId, triggerId, enabled } = parseCapabilityInput(setTriggerEnabledSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const current = await requireTriggerInOrg(ctx, triggerId, orgId);
 	const name = current.name ?? '(unnamed)';
@@ -94,6 +95,4 @@ async function runSetTriggerEnabled(input: Record<string, unknown>, ctx: Capabil
 	});
 }
 
-export const TRIGGER_MUTATE_CAPABILITIES: Capability[] = [
-	writeCapability(setTriggerEnabledSpec, runSetTriggerEnabled),
-];
+export const TRIGGER_MUTATE_CAPABILITIES: Capability[] = [writeCapability(setTriggerEnabledSpec, runSetTriggerEnabled)];

--- a/src/capabilities/workflowCrudCapabilities.ts
+++ b/src/capabilities/workflowCrudCapabilities.ts
@@ -1,9 +1,17 @@
 import { CRATE_REUSE_STEERING } from '@workflow';
+import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
-import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
 import type { Capability, CapabilityContext } from './Capability';
 import { writeCapability } from './capabilityFactories';
-import { ORG_ID_PROP, asString, rawGraphqlOrThrow, requireResourceInOrg, requireString } from './inputHelpers';
+import {
+	ORG_ID_FIELD,
+	optionalStringField,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	requireResourceInOrg,
+	toInputSchema,
+} from './inputHelpers';
 import { orgDisplayName, withMutationApproval } from './mutationApproval';
 
 /**
@@ -52,33 +60,34 @@ async function requireWorkflowInOrg(ctx: CapabilityContext, workflowId: string, 
 	});
 }
 
-const createWorkflowSpec: ToolSpec = {
+const createWorkflowSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	name: z
+		.string({ error: 'Missing required string argument "name".' })
+		.trim()
+		.min(1, { error: 'Missing required string argument "name".' })
+		.describe('Name for the new workflow.'),
+	description: optionalStringField()
+		.pipe(
+			z
+				.string()
+				.max(WORKFLOW_DESCRIPTION_MAX_LENGTH, {
+					error: `Workflow description must be ${WORKFLOW_DESCRIPTION_MAX_LENGTH} characters or fewer.`,
+				})
+				.optional(),
+		)
+		.describe(`Optional workflow description, up to ${WORKFLOW_DESCRIPTION_MAX_LENGTH} characters.`),
+});
+
+const createWorkflowSpec: ToolSpecDefinition = {
 	name: 'buddy_create_workflow',
-	args: '{"orgId": string, "name": string, "description"?: string}',
 	description: `Create a new, empty Rewst workflow in one organization, returning its id and name. Description is optional and limited to ${WORKFLOW_DESCRIPTION_MAX_LENGTH} characters. Add tasks and transitions afterwards with buddy_workflow_edit. Requires write tools to be enabled and per-call approval in VS Code. ${CRATE_REUSE_STEERING}`,
 	// NOTE: CRATE_REUSE_STEERING is embedded verbatim above — do not paraphrase it here.
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			name: { type: 'string', description: 'Name for the new workflow.' },
-			description: {
-				type: 'string',
-				maxLength: WORKFLOW_DESCRIPTION_MAX_LENGTH,
-				description: `Optional workflow description, up to ${WORKFLOW_DESCRIPTION_MAX_LENGTH} characters.`,
-			},
-		},
-		required: ['orgId', 'name'],
-	},
+	inputSchema: toInputSchema(createWorkflowSchema),
 };
 
 async function runCreateWorkflow(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const name = requireString(input, 'name');
-	const description = asString(input, 'description');
-	if (description !== undefined && description.length > WORKFLOW_DESCRIPTION_MAX_LENGTH) {
-		throw new Error(`Workflow description must be ${WORKFLOW_DESCRIPTION_MAX_LENGTH} characters or fewer.`);
-	}
+	const { orgId, name, description } = parseCapabilityInput(createWorkflowSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const scope: MutationScope = { scopeId: orgId, scopeName: `new workflow "${name}"`, orgId, orgName };
 	const summary = `Create workflow "${name}" in org "${orgName}" (${orgId})`;
@@ -92,24 +101,24 @@ async function runCreateWorkflow(input: Record<string, unknown>, ctx: Capability
 	});
 }
 
-const deleteWorkflowSpec: ToolSpec = {
+const deleteWorkflowSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: z
+		.string({ error: 'Missing required string argument "workflowId".' })
+		.trim()
+		.min(1, { error: 'Missing required string argument "workflowId".' })
+		.describe('Id of the workflow to delete.'),
+});
+
+const deleteWorkflowSpec: ToolSpecDefinition = {
 	name: 'buddy_delete_workflow',
-	args: '{"orgId": string, "workflowId": string}',
 	description:
 		'Permanently delete one Rewst workflow, identified by org and workflow id. The workflow must belong to the given org. This also removes its triggers, tasks, and execution history and cannot be undone. Requires write tools to be enabled and per-call approval in VS Code.',
-	inputSchema: {
-		type: 'object',
-		properties: {
-			...ORG_ID_PROP,
-			workflowId: { type: 'string', description: 'Id of the workflow to delete.' },
-		},
-		required: ['orgId', 'workflowId'],
-	},
+	inputSchema: toInputSchema(deleteWorkflowSchema),
 };
 
 async function runDeleteWorkflow(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
-	const orgId = requireString(input, 'orgId');
-	const workflowId = requireString(input, 'workflowId');
+	const { orgId, workflowId } = parseCapabilityInput(deleteWorkflowSchema, input);
 	const orgName = orgDisplayName(ctx);
 	const current = await requireWorkflowInOrg(ctx, workflowId, orgId);
 	const name = current.name ?? '(unnamed)';

--- a/src/capabilities/workflowInputProfileCapabilities.test.ts
+++ b/src/capabilities/workflowInputProfileCapabilities.test.ts
@@ -1,0 +1,93 @@
+import { clearMockContext, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import type { CapabilityContext } from './Capability';
+import { getCapability } from './registry';
+
+const { suite, test, setup } = Mocha;
+
+// Minimal mock session for local-state capabilities (no GraphQL needed)
+function makeMockCtx(orgId = 'org-1'): CapabilityContext {
+	return { session: {} as never, orgId, sessions: [] };
+}
+
+suite('Unit: workflowInputProfileCapabilities', () => {
+	setup(() => {
+		const ctx = initTestEnvironment();
+		clearMockContext(ctx);
+	});
+
+	test('buddy_save_workflow_input_profile saves and returns summary', async () => {
+		const cap = getCapability('buddy_save_workflow_input_profile');
+		assert.ok(cap, 'capability registered');
+		assert.strictEqual(cap.access, 'read', 'local-state capability uses read access');
+		const ctx = makeMockCtx();
+		const output = await cap.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'smoke', input: { x: 1 } }, ctx);
+		assert.ok(output.includes('smoke'), 'output mentions profile name');
+		assert.ok(output.includes('wf-1'), 'output mentions workflow id');
+	});
+
+	test('buddy_list_workflow_input_profiles lists saved profiles', async () => {
+		const saveCap = getCapability('buddy_save_workflow_input_profile');
+		const listCap = getCapability('buddy_list_workflow_input_profiles');
+		assert.ok(saveCap && listCap);
+		const ctx = makeMockCtx();
+		await saveCap.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'alpha', input: { a: 1 } }, ctx);
+		await saveCap.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'beta', input: { b: 2 } }, ctx);
+		const output = await listCap.run({ orgId: 'org-1', workflowId: 'wf-1' }, ctx);
+		assert.ok(output.includes('alpha'), 'output includes alpha');
+		assert.ok(output.includes('beta'), 'output includes beta');
+		assert.ok(output.includes('2 profile'), 'output mentions count');
+	});
+
+	test('buddy_list_workflow_input_profiles returns empty message when none saved', async () => {
+		const listCap = getCapability('buddy_list_workflow_input_profiles');
+		assert.ok(listCap);
+		const output = await listCap.run({ orgId: 'org-1', workflowId: 'wf-empty' }, makeMockCtx());
+		assert.ok(output.includes('No saved'), 'output mentions no profiles');
+	});
+
+	test('buddy_delete_workflow_input_profile deletes a profile', async () => {
+		const saveCap = getCapability('buddy_save_workflow_input_profile');
+		const deleteCap = getCapability('buddy_delete_workflow_input_profile');
+		const listCap = getCapability('buddy_list_workflow_input_profiles');
+		assert.ok(saveCap && deleteCap && listCap);
+		const ctx = makeMockCtx();
+		await saveCap.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'to-delete', input: {} }, ctx);
+		const deleteOutput = await deleteCap.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'to-delete' }, ctx);
+		assert.ok(deleteOutput.includes('Deleted'), 'output confirms deletion');
+		const listOutput = await listCap.run({ orgId: 'org-1', workflowId: 'wf-1' }, ctx);
+		assert.ok(listOutput.includes('No saved'), 'profile no longer listed');
+	});
+
+	test('buddy_delete_workflow_input_profile returns not-found message for missing profile', async () => {
+		const deleteCap = getCapability('buddy_delete_workflow_input_profile');
+		assert.ok(deleteCap);
+		const output = await deleteCap.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'missing' }, makeMockCtx());
+		assert.ok(output.includes('No profile'), 'output mentions not found');
+	});
+
+	test('buddy_save_workflow_input_profile rejects missing orgId', async () => {
+		const cap = getCapability('buddy_save_workflow_input_profile');
+		assert.ok(cap);
+		await assert.rejects(
+			() => cap.run({ workflowId: 'wf-1', name: 'smoke', input: {} }, makeMockCtx()),
+			(err: Error) => {
+				assert.ok(err.message.includes('orgId'));
+				return true;
+			},
+		);
+	});
+
+	test('buddy_save_workflow_input_profile rejects non-object input', async () => {
+		const cap = getCapability('buddy_save_workflow_input_profile');
+		assert.ok(cap);
+		await assert.rejects(
+			() => cap.run({ orgId: 'org-1', workflowId: 'wf-1', name: 'smoke', input: 'not-an-object' }, makeMockCtx()),
+			(err: Error) => {
+				assert.ok(err.message.length > 0);
+				return true;
+			},
+		);
+	});
+});

--- a/src/capabilities/workflowInputProfileCapabilities.ts
+++ b/src/capabilities/workflowInputProfileCapabilities.ts
@@ -1,0 +1,93 @@
+import { z } from 'zod';
+import { WorkflowInputProfileStore } from '../models/WorkflowInputProfileStore';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { readCapability } from './capabilityFactories';
+import { ORG_ID_FIELD, parseCapabilityInput, requiredStringField, toInputSchema } from './inputHelpers';
+
+// ---------------------------------------------------------------------------
+// Shared schema fragments
+// ---------------------------------------------------------------------------
+
+const baseProfileSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: requiredStringField('workflowId').describe('The workflow this profile belongs to.'),
+	name: requiredStringField('name').describe('The profile name (case-sensitive).'),
+});
+
+// ---------------------------------------------------------------------------
+// buddy_save_workflow_input_profile
+// ---------------------------------------------------------------------------
+
+const saveInputSchema = baseProfileSchema.extend({
+	input: z
+		.record(z.string(), z.unknown())
+		.describe('The input payload to save (a JSON object mapping input names to values).'),
+});
+
+const saveSpec: ToolSpecDefinition = {
+	name: 'buddy_save_workflow_input_profile',
+	description:
+		'Save a named input payload for a workflow so it can be reused with buddy_workflow_run. ' +
+		'Creates or overwrites the profile. Profiles are stored locally in VS Code and are ' +
+		'scoped to the org and workflow.',
+	inputSchema: toInputSchema(saveInputSchema),
+};
+
+async function runSave(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
+	const { orgId, workflowId, name, input: payload } = parseCapabilityInput(saveInputSchema, input);
+	const profile = WorkflowInputProfileStore.save(orgId, workflowId, name, payload);
+	return `Saved profile "${profile.name}" for workflow ${workflowId} (org ${orgId}). Updated at ${profile.updatedAt}.`;
+}
+
+export const saveWorkflowInputProfileCapability: Capability = readCapability(saveSpec, runSave);
+
+// ---------------------------------------------------------------------------
+// buddy_list_workflow_input_profiles
+// ---------------------------------------------------------------------------
+
+const listInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: requiredStringField('workflowId').describe('The workflow whose profiles to list.'),
+});
+
+const listSpec: ToolSpecDefinition = {
+	name: 'buddy_list_workflow_input_profiles',
+	description: 'List the saved input profiles for a workflow. Returns profile names and their stored input payloads.',
+	inputSchema: toInputSchema(listInputSchema),
+};
+
+async function runList(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
+	const { orgId, workflowId } = parseCapabilityInput(listInputSchema, input);
+	const profiles = WorkflowInputProfileStore.list(orgId, workflowId);
+	if (profiles.length === 0) {
+		return `No saved input profiles for workflow ${workflowId} (org ${orgId}).`;
+	}
+	const lines = profiles.map(p => `- "${p.name}" (updated ${p.updatedAt}): ${JSON.stringify(p.input)}`);
+	return `${profiles.length} profile(s) for workflow ${workflowId}:\n${lines.join('\n')}`;
+}
+
+export const listWorkflowInputProfilesCapability: Capability = readCapability(listSpec, runList);
+
+// ---------------------------------------------------------------------------
+// buddy_delete_workflow_input_profile
+// ---------------------------------------------------------------------------
+
+const deleteInputSchema = baseProfileSchema;
+
+const deleteSpec: ToolSpecDefinition = {
+	name: 'buddy_delete_workflow_input_profile',
+	description: 'Delete a saved input profile for a workflow.',
+	inputSchema: toInputSchema(deleteInputSchema),
+};
+
+async function runDelete(input: Record<string, unknown>, _ctx: CapabilityContext): Promise<string> {
+	const { orgId, workflowId, name } = parseCapabilityInput(deleteInputSchema, input);
+	const deleted = WorkflowInputProfileStore.delete(orgId, workflowId, name);
+	if (!deleted) {
+		return `No profile named "${name}" found for workflow ${workflowId} (org ${orgId}).`;
+	}
+	return `Deleted profile "${name}" for workflow ${workflowId} (org ${orgId}).`;
+}
+
+export const deleteWorkflowInputProfileCapability: Capability = readCapability(deleteSpec, runDelete);

--- a/src/capabilities/workflowLintCapability.test.ts
+++ b/src/capabilities/workflowLintCapability.test.ts
@@ -1,0 +1,180 @@
+import type { Session } from '@sessions';
+import { createMockSession, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import type { CapabilityContext } from './Capability';
+import { getCapability } from './registry';
+
+const { suite, test, setup } = Mocha;
+
+function useRawGraphqlWrapper(session: Session, wrapper: ReturnType<typeof createMockSession>['wrapper']): void {
+	const wrap = wrapper.getWrapper();
+	(session as { rawGraphql: Session['rawGraphql'] }).rawGraphql = async (query, variables) => {
+		return wrap(
+			async () => ({ data: undefined, errors: undefined }),
+			'rawGraphql',
+			'query RewstBuddyMcpWorkflowLint',
+			{
+				query,
+				variables,
+			},
+		);
+	};
+}
+
+suite('Unit: workflowLintCapability', () => {
+	setup(() => {
+		initTestEnvironment();
+	});
+
+	test('registered as a read capability with a derived schema', () => {
+		const cap = getCapability('buddy_workflow_lint');
+		assert.ok(cap, 'capability is registered');
+		assert.strictEqual(cap.access, 'read');
+		assert.strictEqual(cap.requiresOrg, undefined);
+		assert.strictEqual(cap.scopedSessions, undefined);
+		const schema = cap.spec.inputSchema as { required?: string[] };
+		assert.deepStrictEqual(schema.required?.sort(), ['orgId', 'workflowId']);
+		assert.strictEqual(cap.spec.args, JSON.stringify(cap.spec.inputSchema));
+	});
+
+	test('reports issues for a violating workflow', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflow: {
+						id: 'wf-1',
+						name: 'My Workflow',
+						orgId: 'org-1',
+						tasks: [
+							{
+								id: 'entry',
+								name: 'entry',
+								next: [{ when: '{{ SUCCEEDED }}', do: ['reachable'] }],
+							},
+							{
+								id: 'reachable',
+								name: 'reachable',
+								isMocked: true,
+							},
+							{
+								id: 'orphan',
+								name: 'orphan task',
+							},
+						],
+					},
+				},
+			},
+		});
+		const cap = getCapability('buddy_workflow_lint');
+		assert.ok(cap);
+		const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+		const output = await cap.run({ orgId: 'org-1', workflowId: 'wf-1' }, ctx);
+
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1, 'exactly one rawGraphql call');
+		const vars = (calls[0].variables as { variables?: { where?: { id?: string; orgId?: string } } })?.variables;
+		assert.strictEqual(vars?.where?.id, 'wf-1', 'query passes workflowId');
+		assert.strictEqual(vars?.where?.orgId, 'org-1', 'query passes orgId');
+		assert.ok(output.includes('orphan task'), 'output mentions unreachable task name');
+		assert.ok(output.includes('mock'), 'output mentions mock');
+		assert.ok(output.length > 0, 'output is non-empty');
+	});
+
+	test('clean workflow → no issues message', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					workflow: {
+						id: 'wf-2',
+						name: 'Clean Workflow',
+						orgId: 'org-1',
+						tasks: [
+							{
+								id: 'entry',
+								name: 'entry',
+								next: [{ when: '{{ SUCCEEDED }}', do: ['done'] }],
+							},
+							{ id: 'done', name: 'done' },
+						],
+					},
+				},
+			},
+		});
+		const cap = getCapability('buddy_workflow_lint');
+		assert.ok(cap);
+		const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+		const output = await cap.run({ orgId: 'org-1', workflowId: 'wf-2' }, ctx);
+		assert.match(output, /No issues found/);
+	});
+
+	test('unknown workflow fails closed', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', { data: { data: { workflow: null } } });
+		const cap = getCapability('buddy_workflow_lint');
+		assert.ok(cap);
+		const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+		await assert.rejects(
+			() => cap.run({ orgId: 'org-1', workflowId: 'wf-missing' }, ctx),
+			(err: Error) => {
+				assert.ok(err.message.includes('wf-missing'), 'error names workflowId');
+				assert.ok(err.message.includes('org-1'), 'error names orgId');
+				return true;
+			},
+		);
+	});
+
+	test('GraphQL errors propagate with context', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', { data: { data: undefined, errors: [{ message: 'boom' }] } });
+		const cap = getCapability('buddy_workflow_lint');
+		assert.ok(cap);
+		const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+		await assert.rejects(
+			() => cap.run({ orgId: 'org-1', workflowId: 'wf-1' }, ctx),
+			(err: Error) => {
+				assert.ok(err.message.toLowerCase().includes('graphql'), 'error mentions GraphQL');
+				assert.ok(err.message.includes('boom'), 'error includes upstream message');
+				return true;
+			},
+		);
+	});
+
+	test('missing orgId rejected, no GraphQL call', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		const cap = getCapability('buddy_workflow_lint');
+		assert.ok(cap);
+		const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+		await assert.rejects(
+			() => cap.run({ workflowId: 'wf-1' }, ctx),
+			(err: Error) => {
+				assert.ok(err.message.includes('orgId'), 'error names orgId');
+				return true;
+			},
+		);
+		assert.strictEqual(wrapper.getCallsFor('rawGraphql').length, 0, 'no GraphQL call made');
+	});
+
+	test('missing workflowId rejected, no GraphQL call', async () => {
+		const { session, wrapper } = createMockSession({ profile: { org: { id: 'org-1', name: 'Acme' } } });
+		useRawGraphqlWrapper(session, wrapper);
+		const cap = getCapability('buddy_workflow_lint');
+		assert.ok(cap);
+		const ctx: CapabilityContext = { session, orgId: 'org-1', sessions: [session] };
+		await assert.rejects(
+			() => cap.run({ orgId: 'org-1' }, ctx),
+			(err: Error) => {
+				assert.ok(err.message.includes('workflowId'), 'error names workflowId');
+				return true;
+			},
+		);
+		assert.strictEqual(wrapper.getCallsFor('rawGraphql').length, 0, 'no GraphQL call made');
+	});
+});

--- a/src/capabilities/workflowLintCapability.ts
+++ b/src/capabilities/workflowLintCapability.ts
@@ -1,0 +1,46 @@
+import { z } from 'zod';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
+import type { Capability, CapabilityContext } from './Capability';
+import { WORKFLOW_GET_QUERY } from '../workflow/graphMutations';
+import { formatLintReport, lintWorkflow } from '../workflow/lint';
+import type { RawWorkflow } from '../workflow/types';
+import { readCapability } from './capabilityFactories';
+import {
+	ORG_ID_FIELD,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	requiredStringField,
+	toInputSchema,
+} from './inputHelpers';
+
+const inputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	workflowId: requiredStringField('workflowId').describe('The workflow to audit.'),
+});
+
+const spec: ToolSpecDefinition = {
+	name: 'buddy_workflow_lint',
+	description:
+		'Run a read-only structural audit of one Rewst workflow and return its issues without changing it: ' +
+		'tasks unreachable from the entry, transitions whose {{ SUCCEEDED }}/default path is listed before a custom ' +
+		'condition (which shadows it under FOLLOW_FIRST), tasks with transitions but no success/default path, action ' +
+		'tasks lacking both retry and timeout, tasks with mock input still enabled, and a size heuristic that recommends ' +
+		'sub-workflow extraction for large workflows. Use this when asked to review or check a workflow.',
+	inputSchema: toInputSchema(inputSchema),
+};
+
+async function run(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const { orgId, workflowId } = parseCapabilityInput(inputSchema, input);
+
+	const data = await rawGraphqlOrThrow(ctx.session, WORKFLOW_GET_QUERY, { where: { id: workflowId, orgId } });
+	const workflow = (data as { workflow?: RawWorkflow | null } | undefined)?.workflow ?? null;
+
+	if (!workflow) {
+		throw new Error(`Workflow ${workflowId} not found in org ${orgId}.`);
+	}
+
+	const findings = lintWorkflow(workflow);
+	return formatLintReport(workflow, findings);
+}
+
+export const workflowLintCapability: Capability = readCapability(spec, run);

--- a/src/capabilities/workflowLintCapability.ts
+++ b/src/capabilities/workflowLintCapability.ts
@@ -1,9 +1,9 @@
 import { z } from 'zod';
 import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
-import type { Capability, CapabilityContext } from './Capability';
 import { WORKFLOW_GET_QUERY } from '../workflow/graphMutations';
 import { formatLintReport, lintWorkflow } from '../workflow/lint';
 import type { RawWorkflow } from '../workflow/types';
+import type { Capability, CapabilityContext } from './Capability';
 import { readCapability } from './capabilityFactories';
 import {
 	ORG_ID_FIELD,

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -156,7 +156,7 @@ suite('Unit: McpActions', () => {
 		test('exposes the read tools and hides the GraphQL chat/write tools', () => {
 			const names = listTools(settings()).map(tool => tool.name);
 			assert.ok(names.includes('buddy_list_orgs'));
-			assert.ok(names.includes('buddy_list_templates'));
+			assert.ok(names.includes('buddy_search_templates'));
 			assert.ok(names.includes('buddy_get_template'));
 			assert.ok(names.includes('buddy_list_workflows'));
 			assert.ok(names.includes('buddy_get_workflow'));
@@ -178,27 +178,39 @@ suite('Unit: McpActions', () => {
 			assert.ok(!result.isError);
 		});
 
-		test('buddy_list_templates returns template names for the org', async () => {
-			const { wrapper } = useSession('org-1');
-			wrapper.when('listTemplates', {
-				data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-1', name: 'Welcome' })]),
+		test('buddy_search_templates returns template names for the org', async () => {
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', {
+				data: {
+					data: {
+						templates: [
+							{ id: 't-1', name: 'Welcome', language: 'html', contentType: 'email', updatedAt: null },
+						],
+					},
+				},
 			});
-			const result = await callTool({ name: 'buddy_list_templates', arguments: { orgId: 'org-1' } }, settings());
+			const result = await callTool(
+				{ name: 'buddy_search_templates', arguments: { orgId: 'org-1' } },
+				settings(),
+			);
 			assert.ok(result.text.includes('Welcome (t-1)'));
-			assert.strictEqual(wrapper.getCallsFor('listTemplates').length, 1);
+			assert.strictEqual(wrapper.getCallsFor('rawGraphql').length, 1);
 		});
 
 		test('oversized tool output returns a cached preview that buddy_result_read can page', async () => {
-			const { wrapper } = useSession('org-1');
-			const templates = Array.from({ length: 200 }, (_, i) =>
-				Fixtures.template({
-					id: `template-${i + 1}`,
-					name: `Template ${i + 1} ${'x'.repeat(180)}`,
-				}),
-			);
-			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery(templates) });
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			const templates = Array.from({ length: 200 }, (_, i) => ({
+				id: `template-${i + 1}`,
+				name: `Template ${i + 1} ${'x'.repeat(180)}`,
+				language: 'html',
+				contentType: 'email',
+				updatedAt: null,
+			}));
+			wrapper.when('rawGraphql', { data: { data: { templates } } });
 
-			const first = await callTool({ name: 'buddy_list_templates', arguments: { orgId: 'org-1' } }, settings());
+			const first = await callTool({ name: 'buddy_search_templates', arguments: { orgId: 'org-1' } }, settings());
 			const id = /"id":"([^"]+)"/.exec(first.text)?.[1];
 
 			assert.ok(id, 'oversized output includes a cached result id');
@@ -208,12 +220,12 @@ suite('Unit: McpActions', () => {
 			assert.ok(
 				first.text.length < templates.map(template => `${template.name} (${template.id})`).join('\n').length,
 			);
-			const listCalls = wrapper.getCallsFor('listTemplates');
-			assert.strictEqual(listCalls.length, 1, 'the org templates are fetched once for the oversized call');
+			const rawCalls = wrapper.getCallsFor('rawGraphql');
+			assert.strictEqual(rawCalls.length, 1, 'the org templates are fetched once for the oversized call');
 			assert.strictEqual(
-				listCalls[0].variables.orgId,
+				rawCalls[0].variables.variables.orgId,
 				'org-1',
-				'buddy_list_templates is scoped to the requested org',
+				'buddy_search_templates is scoped to the requested org',
 			);
 
 			const second = await callTool(
@@ -222,11 +234,11 @@ suite('Unit: McpActions', () => {
 			);
 
 			assert.ok(!second.isError);
-			assert.ok(second.text.startsWith(`Cached result "${id}" (buddy_list_templates)`));
+			assert.ok(second.text.startsWith(`Cached result "${id}" (buddy_search_templates)`));
 			assert.ok(second.text.includes(`characters ${MCP_MAX_OUTPUT_CHARS}-`));
 			assert.ok(second.text.includes('Template'));
 			assert.strictEqual(
-				wrapper.getCallsFor('listTemplates').length,
+				wrapper.getCallsFor('rawGraphql').length,
 				1,
 				'paging serves from the in-memory cache without re-hitting the API',
 			);
@@ -444,27 +456,32 @@ suite('Unit: McpActions', () => {
 			WorkingScopeManager.setOrgs(['org-other']);
 
 			await assert.rejects(
-				callTool({ name: 'buddy_list_templates', arguments: { orgId: 'org-1' } }, settings()),
+				callTool({ name: 'buddy_search_templates', arguments: { orgId: 'org-1' } }, settings()),
 				(error: unknown) => error instanceof McpError && error.code === 'org_out_of_scope',
 			);
 		});
 
 		test('reads stay cross-org when nothing is pinned', async () => {
-			const { wrapper } = useSession('org-1');
-			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery([]) });
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', { data: { data: { templates: [] } } });
 
-			const result = await callTool({ name: 'buddy_list_templates', arguments: { orgId: 'org-1' } }, settings());
+			const result = await callTool(
+				{ name: 'buddy_search_templates', arguments: { orgId: 'org-1' } },
+				settings(),
+			);
 
 			assert.ok(!result.isError);
 		});
 
 		test('writes-only scope leaves reads unrestricted even when a working org is pinned', async () => {
-			const { wrapper } = useSession('org-1');
-			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery([]) });
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', { data: { data: { templates: [] } } });
 			WorkingScopeManager.setOrgs(['org-other']);
 
 			const result = await callTool(
-				{ name: 'buddy_list_templates', arguments: { orgId: 'org-1' } },
+				{ name: 'buddy_search_templates', arguments: { orgId: 'org-1' } },
 				settings({ workingOrgScope: 'writes' }),
 			);
 
@@ -472,16 +489,23 @@ suite('Unit: McpActions', () => {
 		});
 
 		test('omitting orgId targets the sole pinned working org', async () => {
-			const { wrapper } = useSession('org-1');
-			wrapper.when('listTemplates', {
-				data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-1', name: 'Welcome' })]),
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', {
+				data: {
+					data: {
+						templates: [
+							{ id: 't-1', name: 'Welcome', language: 'html', contentType: 'email', updatedAt: null },
+						],
+					},
+				},
 			});
 			WorkingScopeManager.setOrgs(['org-1']);
 
-			const result = await callTool({ name: 'buddy_list_templates' }, settings());
+			const result = await callTool({ name: 'buddy_search_templates' }, settings());
 
 			assert.ok(result.text.includes('Welcome (t-1)'));
-			assert.strictEqual(wrapper.getCallsFor('listTemplates')[0].variables.orgId, 'org-1');
+			assert.strictEqual(wrapper.getCallsFor('rawGraphql')[0].variables.variables.orgId, 'org-1');
 		});
 
 		test('the working scope does not restrict org-discovery tools', async () => {
@@ -504,7 +528,7 @@ suite('Unit: McpActions', () => {
 			};
 
 			await assert.rejects(
-				callTool({ name: 'buddy_list_templates', arguments: { orgId: 'org-1' } }, settings()),
+				callTool({ name: 'buddy_search_templates', arguments: { orgId: 'org-1' } }, settings()),
 				(error: unknown) => error instanceof McpError && error.code === 'org_out_of_scope',
 			);
 			assert.strictEqual(validated, 0, 'no authenticated session I/O happens for an out-of-scope request');
@@ -832,7 +856,7 @@ suite('Unit: McpActions', () => {
 		test('an org-scoped tool without orgId throws org_required', async () => {
 			useSession('org-1');
 			await assert.rejects(
-				callTool({ name: 'buddy_list_templates' }, settings()),
+				callTool({ name: 'buddy_search_templates' }, settings()),
 				(error: unknown) => error instanceof McpError && error.code === 'org_required',
 			);
 		});
@@ -840,7 +864,7 @@ suite('Unit: McpActions', () => {
 		test('an unmanaged org throws org_not_found', async () => {
 			useSession('org-1');
 			await assert.rejects(
-				callTool({ name: 'buddy_list_templates', arguments: { orgId: 'org-999' } }, settings()),
+				callTool({ name: 'buddy_search_templates', arguments: { orgId: 'org-999' } }, settings()),
 				(error: unknown) => error instanceof McpError && error.code === 'org_not_found',
 			);
 		});
@@ -1036,17 +1060,25 @@ suite('Unit: McpActions', () => {
 		});
 
 		test('readResource reads a collection', async () => {
-			const { wrapper } = useSession('org-1');
-			wrapper.when('listTemplates', {
-				data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-1', name: 'Welcome' })]),
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', {
+				data: {
+					data: {
+						templates: [
+							{ id: 't-1', name: 'Welcome', language: 'html', contentType: 'email', updatedAt: null },
+						],
+					},
+				},
 			});
 			const content = await readResource('rewst://org-1/templates', settings());
 			assert.ok(content.text.includes('Welcome (t-1)'));
 		});
 
 		test('readResource is rate-limited after a burst', async () => {
-			const { wrapper } = useSession('org-1');
-			wrapper.when('listTemplates', { data: Fixtures.listTemplatesQuery([]) });
+			const { session, wrapper } = useSession('org-1');
+			useRawGraphqlWrapper(session, wrapper);
+			wrapper.when('rawGraphql', { data: { data: { templates: [] } } });
 			let limited = false;
 			for (let i = 0; i < 40 && !limited; i++) {
 				try {
@@ -1079,20 +1111,27 @@ suite('Unit: MCP audit logging', () => {
 	});
 
 	test('successful tool call logs tool, resolved orgId, ok outcome, and duration', async () => {
-		const { wrapper } = useSession('org-1');
-		wrapper.when('listTemplates', {
-			data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-1', name: 'Welcome' })]),
+		const { session, wrapper } = useSession('org-1');
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					templates: [
+						{ id: 't-1', name: 'Welcome', language: 'html', contentType: 'email', updatedAt: null },
+					],
+				},
+			},
 		});
 		const capture = captureInfoLogs();
 		try {
-			await callTool({ name: 'buddy_list_templates', arguments: { orgId: 'org-1' } }, settings());
+			await callTool({ name: 'buddy_search_templates', arguments: { orgId: 'org-1' } }, settings());
 		} finally {
 			capture.restore();
 		}
 
 		const lines = auditLines(capture.messages);
 		assert.strictEqual(lines.length, 1);
-		assert.ok(lines[0].includes('tool=buddy_list_templates'));
+		assert.ok(lines[0].includes('tool=buddy_search_templates'));
 		assert.ok(lines[0].includes('orgId=org-1'));
 		assert.ok(lines[0].includes('outcome=ok'));
 		assert.match(lines[0], /durationMs=\d+/);
@@ -1103,7 +1142,7 @@ suite('Unit: MCP audit logging', () => {
 		const capture = captureInfoLogs();
 		try {
 			await assert.rejects(
-				callTool({ name: 'buddy_list_templates' }, settings()),
+				callTool({ name: 'buddy_search_templates' }, settings()),
 				(error: unknown) => error instanceof McpError && error.code === 'org_required',
 			);
 		} finally {
@@ -1112,7 +1151,7 @@ suite('Unit: MCP audit logging', () => {
 
 		const lines = auditLines(capture.messages);
 		assert.strictEqual(lines.length, 1);
-		assert.ok(lines[0].includes('tool=buddy_list_templates'));
+		assert.ok(lines[0].includes('tool=buddy_search_templates'));
 		assert.ok(lines[0].includes('orgId=—'));
 		assert.ok(lines[0].includes('outcome=error:org_required'));
 		assert.match(lines[0], /durationMs=\d+/);
@@ -1157,15 +1196,22 @@ suite('Unit: MCP audit logging', () => {
 	});
 
 	test('audit logs do not include arguments or secrets', async () => {
-		const { wrapper } = useSession('org-1');
-		wrapper.when('listTemplates', {
-			data: Fixtures.listTemplatesQuery([Fixtures.template({ id: 't-1', name: 'Welcome' })]),
+		const { session, wrapper } = useSession('org-1');
+		useRawGraphqlWrapper(session, wrapper);
+		wrapper.when('rawGraphql', {
+			data: {
+				data: {
+					templates: [
+						{ id: 't-1', name: 'Welcome', language: 'html', contentType: 'email', updatedAt: null },
+					],
+				},
+			},
 		});
 		const capture = captureInfoLogs();
 		try {
 			await callTool(
 				{
-					name: 'buddy_list_templates',
+					name: 'buddy_search_templates',
 					arguments: {
 						orgId: 'org-1',
 						apiToken: 'audit-secret-token',

--- a/src/mcp/McpActions.ts
+++ b/src/mcp/McpActions.ts
@@ -1,6 +1,5 @@
 import {
 	CAPABILITY_REGISTRY,
-	MCP_MAX_OUTPUT_CHARS,
 	formatMcpOutput,
 	getCapability,
 	runWithApprovalOrigin,
@@ -422,7 +421,7 @@ export async function callTool(
 export function listResources(settings: McpSettings = readMcpSettings()): McpResourceDescriptor[] {
 	// Only advertise a collection when its backing list capability is exposed, so
 	// resources honour the same allowlist/exposure gates as tools.
-	const templatesExposed = isCapabilityExposed('buddy_list_templates', settings);
+	const templatesExposed = isCapabilityExposed('buddy_search_templates', settings);
 	const workflowsExposed = isCapabilityExposed('buddy_list_workflows', settings);
 	if (!templatesExposed && !workflowsExposed) return [];
 	const resources: McpResourceDescriptor[] = [];
@@ -460,7 +459,7 @@ export async function readResource(uri: string, settings: McpSettings = readMcpS
 		parsed.collection === 'templates'
 			? parsed.id
 				? 'buddy_get_template'
-				: 'buddy_list_templates'
+				: 'buddy_search_templates'
 			: parsed.id
 				? 'buddy_get_workflow'
 				: 'buddy_list_workflows';

--- a/src/mcp/mcpServer.test.ts
+++ b/src/mcp/mcpServer.test.ts
@@ -86,7 +86,7 @@ suite('Unit: mcpServer', () => {
 			await client.connect(clientTransport);
 
 			try {
-				const result = await client.callTool({ name: 'buddy_list_templates', arguments: {} });
+				const result = await client.callTool({ name: 'buddy_search_templates', arguments: {} });
 				assert.strictEqual(result.isError, true);
 				const text = (result.content as { type: string; text: string }[]).map(part => part.text).join('');
 				assert.ok(/orgId/i.test(text), 'explains the missing orgId');

--- a/src/models/WorkflowInputProfileStore.test.ts
+++ b/src/models/WorkflowInputProfileStore.test.ts
@@ -58,10 +58,22 @@ suite('Unit: WorkflowInputProfileStore', () => {
 		assert.throws(() => WorkflowInputProfileStore.save('org-1', 'wf-1', '  ', { x: 1 }), /blank/);
 	});
 
+	test('trims a profile name before saving and lookup', () => {
+		const profile = WorkflowInputProfileStore.save('org-1', 'wf-1', ' smoke ', { x: 1 });
+		assert.strictEqual(profile.name, 'smoke');
+		assert.deepStrictEqual(WorkflowInputProfileStore.get('org-1', 'wf-1', 'smoke')?.input, { x: 1 });
+		assert.strictEqual(WorkflowInputProfileStore.get('org-1', 'wf-1', ' smoke '), undefined);
+	});
+
 	test('persists under RewstWorkflowInputProfiles key', () => {
+		const ctx = initTestEnvironment();
+		clearMockContext(ctx);
 		WorkflowInputProfileStore.save('org-1', 'wf-1', 'test', { x: 1 });
-		// The key is used by context.globalState — verify the constant matches
-		assert.strictEqual(WORKFLOW_INPUT_PROFILES_KEY, 'RewstWorkflowInputProfiles');
+		const stored = ctx.globalState.get(WORKFLOW_INPUT_PROFILES_KEY) as Record<string, unknown>;
+		assert.ok(
+			stored && Object.keys(stored).some(key => key.includes('test')),
+			'profile persisted under the documented key',
+		);
 	});
 
 	test('profiles are scoped by orgId and workflowId', () => {

--- a/src/models/WorkflowInputProfileStore.test.ts
+++ b/src/models/WorkflowInputProfileStore.test.ts
@@ -1,0 +1,78 @@
+import { clearMockContext, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { WORKFLOW_INPUT_PROFILES_KEY, WorkflowInputProfileStore } from './WorkflowInputProfileStore';
+
+const { suite, test, setup } = Mocha;
+
+suite('Unit: WorkflowInputProfileStore', () => {
+	setup(() => {
+		const ctx = initTestEnvironment();
+		clearMockContext(ctx);
+	});
+
+	test('saves a profile and retrieves it', () => {
+		const profile = WorkflowInputProfileStore.save('org-1', 'wf-1', 'smoke', { x: 1 });
+		assert.strictEqual(profile.name, 'smoke');
+		assert.deepStrictEqual(profile.input, { x: 1 });
+		const retrieved = WorkflowInputProfileStore.get('org-1', 'wf-1', 'smoke');
+		assert.ok(retrieved);
+		assert.deepStrictEqual(retrieved.input, { x: 1 });
+	});
+
+	test('overwrites a profile with the same name', () => {
+		WorkflowInputProfileStore.save('org-1', 'wf-1', 'smoke', { x: 1 });
+		WorkflowInputProfileStore.save('org-1', 'wf-1', 'smoke', { x: 2 });
+		const retrieved = WorkflowInputProfileStore.get('org-1', 'wf-1', 'smoke');
+		assert.ok(retrieved);
+		assert.deepStrictEqual(retrieved.input, { x: 2 }, 'second save overwrites first');
+		const list = WorkflowInputProfileStore.list('org-1', 'wf-1');
+		assert.strictEqual(list.length, 1, 'only one profile after overwrite');
+	});
+
+	test('lists profiles sorted by name', () => {
+		WorkflowInputProfileStore.save('org-1', 'wf-1', 'zebra', { z: 1 });
+		WorkflowInputProfileStore.save('org-1', 'wf-1', 'alpha', { a: 1 });
+		WorkflowInputProfileStore.save('org-1', 'wf-1', 'middle', { m: 1 });
+		const list = WorkflowInputProfileStore.list('org-1', 'wf-1');
+		assert.deepStrictEqual(
+			list.map(p => p.name),
+			['alpha', 'middle', 'zebra'],
+			'profiles sorted by name',
+		);
+	});
+
+	test('deletes a profile', () => {
+		WorkflowInputProfileStore.save('org-1', 'wf-1', 'to-delete', { x: 1 });
+		const deleted = WorkflowInputProfileStore.delete('org-1', 'wf-1', 'to-delete');
+		assert.strictEqual(deleted, true);
+		assert.strictEqual(WorkflowInputProfileStore.get('org-1', 'wf-1', 'to-delete'), undefined);
+	});
+
+	test('delete returns false for non-existent profile', () => {
+		const deleted = WorkflowInputProfileStore.delete('org-1', 'wf-1', 'missing');
+		assert.strictEqual(deleted, false);
+	});
+
+	test('rejects blank name', () => {
+		assert.throws(() => WorkflowInputProfileStore.save('org-1', 'wf-1', '  ', { x: 1 }), /blank/);
+	});
+
+	test('persists under RewstWorkflowInputProfiles key', () => {
+		WorkflowInputProfileStore.save('org-1', 'wf-1', 'test', { x: 1 });
+		// The key is used by context.globalState — verify the constant matches
+		assert.strictEqual(WORKFLOW_INPUT_PROFILES_KEY, 'RewstWorkflowInputProfiles');
+	});
+
+	test('profiles are scoped by orgId and workflowId', () => {
+		WorkflowInputProfileStore.save('org-1', 'wf-1', 'shared-name', { org: 1 });
+		WorkflowInputProfileStore.save('org-2', 'wf-1', 'shared-name', { org: 2 });
+		WorkflowInputProfileStore.save('org-1', 'wf-2', 'shared-name', { wf: 2 });
+		const list1 = WorkflowInputProfileStore.list('org-1', 'wf-1');
+		assert.strictEqual(list1.length, 1);
+		assert.deepStrictEqual(list1[0].input, { org: 1 });
+		const list2 = WorkflowInputProfileStore.list('org-2', 'wf-1');
+		assert.strictEqual(list2.length, 1);
+		assert.deepStrictEqual(list2[0].input, { org: 2 });
+	});
+});

--- a/src/models/WorkflowInputProfileStore.ts
+++ b/src/models/WorkflowInputProfileStore.ts
@@ -33,7 +33,8 @@ export const WorkflowInputProfileStore = {
 	 * Rejects blank names.
 	 */
 	save(orgId: string, workflowId: string, name: string, input: Record<string, unknown>): WorkflowInputProfile {
-		if (!name.trim()) throw new Error('Profile name must not be blank.');
+		name = name.trim();
+		if (!name) throw new Error('Profile name must not be blank.');
 		const map = loadAll();
 		const key = profileKey(orgId, workflowId, name);
 		const profile: WorkflowInputProfile = {

--- a/src/models/WorkflowInputProfileStore.ts
+++ b/src/models/WorkflowInputProfileStore.ts
@@ -1,0 +1,80 @@
+import { context } from '@global';
+import { log } from '@utils';
+
+export const WORKFLOW_INPUT_PROFILES_KEY = 'RewstWorkflowInputProfiles';
+
+export interface WorkflowInputProfile {
+	orgId: string;
+	workflowId: string;
+	name: string;
+	input: Record<string, unknown>;
+	updatedAt: string;
+}
+
+type ProfileMap = Record<string, WorkflowInputProfile>;
+
+function profileKey(orgId: string, workflowId: string, name: string): string {
+	return `${orgId}::${workflowId}::${name}`;
+}
+
+function loadAll(): ProfileMap {
+	return context.globalState.get<ProfileMap>(WORKFLOW_INPUT_PROFILES_KEY) ?? {};
+}
+
+function saveAll(map: ProfileMap): void {
+	Promise.resolve(context.globalState.update(WORKFLOW_INPUT_PROFILES_KEY, map)).catch(error =>
+		log.error('WorkflowInputProfileStore: failed to persist profiles', error),
+	);
+}
+
+export const WorkflowInputProfileStore = {
+	/**
+	 * Save (create or overwrite) a named profile for a workflow.
+	 * Rejects blank names.
+	 */
+	save(orgId: string, workflowId: string, name: string, input: Record<string, unknown>): WorkflowInputProfile {
+		if (!name.trim()) throw new Error('Profile name must not be blank.');
+		const map = loadAll();
+		const key = profileKey(orgId, workflowId, name);
+		const profile: WorkflowInputProfile = {
+			orgId,
+			workflowId,
+			name,
+			input,
+			updatedAt: new Date().toISOString(),
+		};
+		map[key] = profile;
+		saveAll(map);
+		return profile;
+	},
+
+	/**
+	 * List all profiles for a workflow, sorted by name.
+	 */
+	list(orgId: string, workflowId: string): WorkflowInputProfile[] {
+		const map = loadAll();
+		return Object.values(map)
+			.filter(p => p.orgId === orgId && p.workflowId === workflowId)
+			.sort((a, b) => a.name.localeCompare(b.name));
+	},
+
+	/**
+	 * Get a single profile by name. Returns undefined if not found.
+	 */
+	get(orgId: string, workflowId: string, name: string): WorkflowInputProfile | undefined {
+		const map = loadAll();
+		return map[profileKey(orgId, workflowId, name)];
+	},
+
+	/**
+	 * Delete a profile. Returns true if it existed, false if not found.
+	 */
+	delete(orgId: string, workflowId: string, name: string): boolean {
+		const map = loadAll();
+		const key = profileKey(orgId, workflowId, name);
+		if (!(key in map)) return false;
+		delete map[key];
+		saveAll(map);
+		return true;
+	},
+};

--- a/src/sessions/Session.test.ts
+++ b/src/sessions/Session.test.ts
@@ -35,6 +35,7 @@ suite('Unit: Session', () => {
 
 	test('rawGraphql sends the session cookie stored in extension secrets', async () => {
 		const orgId = 'org-raw-graphql';
+		const userId = 'user-1';
 		const expectedCookie = 'appSession=test-cookie; other=value';
 		let receivedCookie = '';
 		let receivedBody: { query?: string; variables?: Record<string, unknown> } | undefined;
@@ -55,7 +56,8 @@ suite('Unit: Session', () => {
 		const port = await listen(server);
 
 		const context = initTestEnvironment();
-		await context.secrets.store(orgId, expectedCookie);
+		// D4: cookies are keyed by user id, not org id.
+		await context.secrets.store(userId, expectedCookie);
 
 		const profile: SessionProfile = {
 			region: {
@@ -67,7 +69,7 @@ suite('Unit: Session', () => {
 			org: { id: orgId, name: 'Raw GraphQL Org' },
 			allManagedOrgs: [{ id: orgId, name: 'Raw GraphQL Org' }],
 			label: 'Raw GraphQL Session',
-			user: { id: 'user-1' } as SessionProfile['user'],
+			user: { id: userId } as SessionProfile['user'],
 		};
 
 		const session = new Session(undefined, profile);
@@ -242,7 +244,8 @@ suite('Unit: Session', () => {
 			servers.push(server);
 
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, 'appSession=stale-cookie');
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', 'appSession=stale-cookie');
 			// No sdk yet, so validate() fails immediately without a network call,
 			// exactly like a session whose cached User() query previously failed.
 			const session = new Session(undefined, refreshableSessionProfile(orgId, port, 'user-1'));
@@ -300,7 +303,8 @@ suite('Unit: Session', () => {
 			const port = await listen(server);
 
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, oldCookie);
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', oldCookie);
 
 			const profile: SessionProfile = {
 				region: {
@@ -321,7 +325,7 @@ suite('Unit: Session', () => {
 			await session.refreshToken();
 
 			assert.strictEqual(receivedLoginCookie, oldCookie);
-			assert.strictEqual(await context.secrets.get(orgId), newCookie);
+			assert.strictEqual(await context.secrets.get('user-1'), newCookie);
 			assert.notStrictEqual(session.sdk, undefined, 'refreshToken should replace the in-memory SDK');
 			assert.strictEqual(receivedGraphqlCookie, newCookie);
 		});
@@ -352,11 +356,12 @@ suite('Unit: Session', () => {
 			const port = await listen(server);
 
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, oldCookie);
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', oldCookie);
 			const session = new Session(undefined, refreshProfile(orgId, port));
 
 			await assert.rejects(() => session.refreshToken(), /status 500/);
-			assert.strictEqual(await context.secrets.get(orgId), oldCookie, 'stored secret is unchanged');
+			assert.strictEqual(await context.secrets.get('user-1'), oldCookie, 'stored secret is unchanged');
 			assert.strictEqual(session.sdk, undefined, 'in-memory SDK is not set');
 		});
 
@@ -371,11 +376,12 @@ suite('Unit: Session', () => {
 			const port = await listen(server);
 
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, oldCookie);
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', oldCookie);
 			const session = new Session(undefined, refreshProfile(orgId, port));
 
 			await assert.rejects(() => session.refreshToken(), /missing set-cookie header/);
-			assert.strictEqual(await context.secrets.get(orgId), oldCookie, 'stored secret is unchanged');
+			assert.strictEqual(await context.secrets.get('user-1'), oldCookie, 'stored secret is unchanged');
 		});
 
 		test('throws when the refreshed cookie fails SDK validation', async () => {
@@ -400,12 +406,13 @@ suite('Unit: Session', () => {
 			const port = await listen(server);
 
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, oldCookie);
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', oldCookie);
 			const session = new Session(undefined, refreshProfile(orgId, port));
 
 			await assert.rejects(() => session.refreshToken(), /new SDK validation failed/);
 			assert.strictEqual(
-				await context.secrets.get(orgId),
+				await context.secrets.get('user-1'),
 				oldCookie,
 				'secret is not overwritten on validation failure',
 			);
@@ -418,7 +425,8 @@ suite('Unit: Session', () => {
 			servers.push(server);
 
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, 'appSession=stale-cookie');
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', 'appSession=stale-cookie');
 			const session = new Session(undefined, refreshableSessionProfile(orgId, port, 'user-1'));
 
 			await Promise.all([session.refreshToken(), session.refreshToken(), session.refreshToken()]);
@@ -464,7 +472,8 @@ suite('Unit: Session', () => {
 			servers.push(server);
 			const port = await listen(server);
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, 'appSession=dead-cookie');
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', 'appSession=dead-cookie');
 
 			let notificationCount = 0;
 			let focusSidebarCount = 0;
@@ -507,7 +516,8 @@ suite('Unit: Session', () => {
 			const port = await listen(server);
 
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, 'appSession=stale-cookie');
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', 'appSession=stale-cookie');
 			const session = new Session(undefined, refreshProfile(orgId, port));
 
 			await assert.rejects(() => session.refreshToken(), /status 500/);
@@ -532,7 +542,8 @@ suite('Unit: Session', () => {
 			const port = await listen(server);
 
 			const context = initTestEnvironment();
-			await context.secrets.store(orgId, 'appSession=dead-cookie');
+			// D4: cookies are keyed by user id, not org id.
+			await context.secrets.store('user-1', 'appSession=dead-cookie');
 			restores.push(
 				stub(
 					vscode.window,

--- a/src/sessions/Session.ts
+++ b/src/sessions/Session.ts
@@ -210,7 +210,7 @@ export default class Session {
 			}
 
 			log.trace('refreshToken: storing new cookie');
-			await this.secrets.store(this.profile.org.id, cookieString);
+			await this.secrets.store(this.secretKey(), cookieString);
 			this.sdk = sdk;
 			this.lastValidated = Date.now();
 			this.consecutiveRefreshFailures = 0;
@@ -223,14 +223,21 @@ export default class Session {
 	}
 
 	private async getCookiesForRefresh(): Promise<string> {
-		log.trace('refreshToken: retrieving stored cookie for org', this.profile.org.id);
-		const token = await this.secrets.get(this.profile.org.id);
+		log.trace('refreshToken: retrieving stored cookie for user', this.profile.user.id);
+		const token = await this.secrets.get(this.secretKey());
 
 		if (typeof token !== 'string') {
-			throw log.error(`refreshToken: no token found for ${this.profile.org.id}`);
+			throw log.error(`refreshToken: no token found for ${this.profile.user.id}`);
 		}
 
 		return token;
+	}
+
+	/** D4: session cookies are keyed by user id, not org id — see SessionManager's secret migration. */
+	private secretKey(): string {
+		const userId = this.profile.user.id;
+		if (!userId) throw log.error('Session: profile has no user id for secret storage');
+		return userId;
 	}
 
 	private recordRefreshFailure(error: unknown): void {
@@ -274,12 +281,12 @@ export default class Session {
 			});
 	}
 
-	public static async getCookies(orgId: string): Promise<string> {
-		log.trace('getCookies: retrieving for org', orgId);
-		const token = await context.secrets.get(orgId);
+	public static async getCookies(key: string): Promise<string> {
+		log.trace('getCookies: retrieving for', key);
+		const token = await context.secrets.get(key);
 
 		if (typeof token !== 'string') {
-			throw log.notifyError(`getCookies: no token found for ${orgId}`);
+			throw log.notifyError(`getCookies: no token found for ${key}`);
 		}
 
 		log.trace('getCookies: retrieved successfully');
@@ -287,7 +294,7 @@ export default class Session {
 	}
 
 	async getCookies(): Promise<string> {
-		return await Session.getCookies(this.profile.org.id);
+		return await Session.getCookies(this.secretKey());
 	}
 
 	/**

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -806,6 +806,77 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(first.length, 1);
 		});
 
+		test('startup load emits one saved event after batching restored sessions', async () => {
+			const userA: MockUser = {
+				id: 'user-load-a',
+				username: 'load-a',
+				organization: { id: 'org-load-a', name: 'Load A' },
+				allManagedOrgs: [{ id: 'org-load-a', name: 'Load A' }],
+			};
+			const userB: MockUser = {
+				id: 'user-load-b',
+				username: 'load-b',
+				organization: { id: 'org-load-b', name: 'Load B' },
+				allManagedOrgs: [{ id: 'org-load-b', name: 'Load B' }],
+			};
+			const server = createServer((request, response) => {
+				const cookieHeader = request.headers.cookie ?? '';
+				const user = cookieHeader.includes('load-cookie-b')
+					? userB
+					: cookieHeader.includes('load-cookie-a')
+						? userA
+						: null;
+				request.on('data', () => {});
+				request.on('end', () => {
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(JSON.stringify({ data: { user } }));
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const region = {
+				name: 'Local Test',
+				cookieName: 'appSession',
+				graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+				loginUrl: `http://127.0.0.1:${port}`,
+			};
+			await vscode.workspace
+				.getConfiguration('rewst-buddy')
+				.update('regions', [region], vscode.ConfigurationTarget.Global);
+
+			const profileA: SessionProfile = {
+				region,
+				org: userA.organization,
+				allManagedOrgs: userA.allManagedOrgs,
+				label: 'load-a (Load A)',
+				user: { id: userA.id } as SessionProfile['user'],
+			};
+			const profileB: SessionProfile = {
+				region,
+				org: userB.organization,
+				allManagedOrgs: userB.allManagedOrgs,
+				label: 'load-b (Load B)',
+				user: { id: userB.id } as SessionProfile['user'],
+			};
+			await context.globalState.update('SessionProfiles', [profileA, profileB]);
+			await context.secrets.store(userA.id, 'appSession=load-cookie-a');
+			await context.secrets.store(userB.id, 'appSession=load-cookie-b');
+
+			const savedEvents: number[] = [];
+			const disposable = SessionManager.onSessionChange(event => {
+				if (event.type === 'saved') savedEvents.push(event.activeProfiles.length);
+			});
+			try {
+				const sessions = await SessionManager.loadSessions();
+				assert.strictEqual(sessions.length, 2);
+			} finally {
+				disposable.dispose();
+			}
+
+			assert.deepStrictEqual(savedEvents, [2], 'startup restore should publish one final saved event');
+		});
+
 		test('a rejected load clears the in-flight promise so a later call retries', async () => {
 			const manager = SessionManager as unknown as SessionProfileSaver;
 			const originalSaveProfiles = manager.saveProfiles.bind(SessionManager);

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -965,6 +965,49 @@ suite('Unit: SessionManager', () => {
 			assert.deepStrictEqual(context.globalState.get('SessionProfiles'), []);
 			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
 		});
+
+		test('deletes user-id keyed secrets for both an active session and a known-only profile', async () => {
+			// D4: clearProfiles must delete the current user-keyed secret for every
+			// active and known profile, not merely legacy org-keyed leftovers.
+			const { session } = createMockSession({
+				profile: {
+					user: Fixtures.userFragment({ id: 'user-clear-active' }),
+					org: { id: 'org-clear-active', name: 'Active' },
+					allManagedOrgs: [{ id: 'org-clear-active', name: 'Active' }],
+				},
+			});
+			const knownOnlyProfile: SessionProfile = {
+				region: {
+					name: 'Local Test',
+					cookieName: 'appSession',
+					graphqlUrl: 'http://127.0.0.1/graphql',
+					loginUrl: 'http://127.0.0.1',
+				},
+				org: { id: 'org-clear-known', name: 'Known' },
+				allManagedOrgs: [{ id: 'org-clear-known', name: 'Known' }],
+				label: 'known-user (Known)',
+				user: { id: 'user-clear-known' } as SessionProfile['user'],
+			};
+
+			await context.secrets.store('user-clear-active', 'cookie-active-user');
+			await context.secrets.store('user-clear-known', 'cookie-known-user');
+
+			SessionManager._setSessionsForTesting([session]);
+			SessionManager._setKnownProfilesForTesting([session.profile, knownOnlyProfile]);
+
+			await SessionManager.clearProfiles();
+
+			assert.strictEqual(
+				await context.secrets.get('user-clear-active'),
+				undefined,
+				"the active session's user-keyed secret is deleted",
+			);
+			assert.strictEqual(
+				await context.secrets.get('user-clear-known'),
+				undefined,
+				"the known-only profile's user-keyed secret is deleted",
+			);
+		});
 	});
 
 	suite('removeSession()', () => {

--- a/src/sessions/SessionManager.test.ts
+++ b/src/sessions/SessionManager.test.ts
@@ -62,6 +62,10 @@ interface SessionExpirationHarness {
 	handleSessionExpired(session: Session): void;
 }
 
+interface SessionProfileSaver {
+	saveProfiles(): Promise<void>;
+}
+
 suite('Unit: SessionManager', () => {
 	setup(() => {
 		initTestEnvironment();
@@ -188,7 +192,8 @@ suite('Unit: SessionManager', () => {
 			const { server, port } = await createRefreshableSessionServer('user-recovers');
 
 			try {
-				await context.secrets.store(orgId, 'appSession=stale-cookie');
+				// D4: cookies are keyed by user id, not org id.
+				await context.secrets.store('user-recovers', 'appSession=stale-cookie');
 				// No sdk yet: validate() fails immediately, exactly like a session
 				// whose cached User() query previously failed.
 				const session = new Session(undefined, refreshableSessionProfile(orgId, port, 'user-recovers'));
@@ -286,7 +291,8 @@ suite('Unit: SessionManager', () => {
 			const { server, port } = await createRefreshableSessionServer('user-region-recovers');
 
 			try {
-				await context.secrets.store(orgId, 'appSession=stale-cookie');
+				// D4: cookies are keyed by user id, not org id.
+				await context.secrets.store('user-region-recovers', 'appSession=stale-cookie');
 				// No sdk yet: validate() fails immediately, exactly like a session
 				// whose cached User() query previously failed.
 				const session = new Session(undefined, refreshableSessionProfile(orgId, port, 'user-region-recovers'));
@@ -412,7 +418,13 @@ suite('Unit: SessionManager', () => {
 
 			assert.strictEqual(session.profile.label, 'jdoe (Acme Co)');
 			assert.strictEqual(await SessionManager.getSessionForOrg('org-create'), session);
-			assert.strictEqual(await context.secrets.get('org-create'), 'appSession=raw-test-token');
+			// D4: cookies are keyed by user id, and the legacy org-id key is cleaned up.
+			assert.strictEqual(await context.secrets.get('user-1'), 'appSession=raw-test-token');
+			assert.strictEqual(
+				await context.secrets.get('org-create'),
+				undefined,
+				'no live secret should remain under the legacy org-id key',
+			);
 		});
 
 		test('user query asks for recursive managed sub-orgs and indexes deep descendants', async () => {
@@ -532,6 +544,67 @@ suite('Unit: SessionManager', () => {
 
 			assert.strictEqual(SessionManager.getActiveSessions().length, 0);
 		});
+
+		test('two users sharing the same primary org get separate user-keyed secrets', async () => {
+			const users = [
+				{ id: 'user-shared-a', username: 'user-a' },
+				{ id: 'user-shared-b', username: 'user-b' },
+			];
+			// Key the response off the cookie's token rather than call order: each
+			// createSession() call makes two requests (newSdk's internal validation
+			// plus its own explicit User() call), so counting calls would misalign.
+			const server = createServer((request, response) => {
+				const cookieHeader = request.headers.cookie ?? '';
+				const user = cookieHeader.includes('token-a') ? users[0] : users[1];
+				request.on('data', () => {});
+				request.on('end', () => {
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(
+						JSON.stringify({
+							data: {
+								user: {
+									id: user.id,
+									username: user.username,
+									organization: { id: 'org-shared', name: 'Shared Org' },
+									allManagedOrgs: [{ id: 'org-shared', name: 'Shared Org' }],
+								},
+							},
+						}),
+					);
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			await vscode.workspace.getConfiguration('rewst-buddy').update(
+				'regions',
+				[
+					{
+						name: 'Local Test',
+						cookieName: 'appSession',
+						graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+						loginUrl: `http://127.0.0.1:${port}`,
+					},
+				],
+				vscode.ConfigurationTarget.Global,
+			);
+
+			await SessionManager.createSession('token-a');
+			const sessionB = await SessionManager.createSession('token-b');
+
+			assert.strictEqual(await context.secrets.get('user-shared-a'), 'appSession=token-a');
+			assert.strictEqual(await context.secrets.get('user-shared-b'), 'appSession=token-b');
+
+			await SessionManager.removeSession('user-shared-a');
+
+			assert.strictEqual(await context.secrets.get('user-shared-a'), undefined);
+			assert.strictEqual(
+				await context.secrets.get('user-shared-b'),
+				'appSession=token-b',
+				"the other user's secret survives even though both share the primary org id",
+			);
+			assert.strictEqual(await SessionManager.getSessionForOrg('org-shared'), sessionB);
+		});
 	});
 
 	suite('loadSessions()', () => {
@@ -595,6 +668,171 @@ suite('Unit: SessionManager', () => {
 			assert.strictEqual(sessions[0].profile.org.id, 'org-restore');
 			assert.strictEqual(promptCalled, false, 'loadSessions must not prompt for a cookie');
 			assert.strictEqual(await SessionManager.getSessionForOrg('org-restore'), sessions[0]);
+			// D4: a legacy org-keyed cookie is migrated to the user-id key on restore.
+			// (Substring, not exact-equality: newSdk tries several equally-acceptable
+			// cookie-string variants against this always-accepting mock server, so the
+			// winning candidate's exact prefix isn't significant here — only that the
+			// migrated value lives under the user-id key now.)
+			assert.match(
+				(await context.secrets.get('user-1')) ?? '',
+				/restored-cookie/,
+				'legacy org-keyed cookie must be migrated to the user-id key',
+			);
+			assert.strictEqual(
+				await context.secrets.get('org-restore'),
+				undefined,
+				'legacy org-keyed cookie is cleaned up once migrated',
+			);
+		});
+
+		test('prefers a user-keyed cookie over a legacy org-keyed cookie when both exist', async () => {
+			const server = createServer((request, response) => {
+				const cookieHeader = request.headers.cookie ?? '';
+				let body = '';
+				request.on('data', chunk => {
+					body += String(chunk);
+				});
+				request.on('end', () => {
+					response.writeHead(200, { 'content-type': 'application/json' });
+					// Only the user-keyed cookie value should ever be sent; a legacy
+					// org-keyed read would send the wrong value and fail to resolve a user.
+					if (cookieHeader.includes('user-key-cookie')) {
+						response.end(
+							JSON.stringify({
+								data: {
+									user: {
+										id: 'user-both',
+										username: 'both-user',
+										organization: { id: 'org-both', name: 'Both Org' },
+										allManagedOrgs: [{ id: 'org-both', name: 'Both Org' }],
+									},
+								},
+							}),
+						);
+					} else {
+						response.end(JSON.stringify({ data: { user: null } }));
+					}
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const region = {
+				name: 'Local Test',
+				cookieName: 'appSession',
+				graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+				loginUrl: `http://127.0.0.1:${port}`,
+			};
+			await vscode.workspace
+				.getConfiguration('rewst-buddy')
+				.update('regions', [region], vscode.ConfigurationTarget.Global);
+
+			const savedProfile: SessionProfile = {
+				region,
+				org: { id: 'org-both', name: 'Both Org' },
+				allManagedOrgs: [{ id: 'org-both', name: 'Both Org' }],
+				label: 'both-user (Both Org)',
+				user: { id: 'user-both' } as SessionProfile['user'],
+			};
+			await context.globalState.update('SessionProfiles', [savedProfile]);
+			await context.secrets.store('user-both', 'appSession=user-key-cookie');
+			await context.secrets.store('org-both', 'appSession=legacy-org-key-cookie');
+
+			const sessions = await SessionManager.loadSessions();
+
+			assert.strictEqual(sessions.length, 1, 'the user-keyed cookie must be the one used to restore the session');
+			assert.strictEqual(sessions[0].profile.user.id, 'user-both');
+		});
+
+		test('concurrent loadSessions() calls share one in-flight promise and create each session once', async () => {
+			let requestCount = 0;
+			const server = createServer((request, response) => {
+				request.on('data', () => {});
+				request.on('end', () => {
+					requestCount++;
+					response.writeHead(200, { 'content-type': 'application/json' });
+					response.end(
+						JSON.stringify({
+							data: {
+								user: {
+									id: 'user-concurrent',
+									username: 'concurrent-user',
+									organization: { id: 'org-concurrent', name: 'Concurrent Org' },
+									allManagedOrgs: [{ id: 'org-concurrent', name: 'Concurrent Org' }],
+								},
+							},
+						}),
+					);
+				});
+			});
+			servers.push(server);
+			const port = await listen(server);
+
+			const region = {
+				name: 'Local Test',
+				cookieName: 'appSession',
+				graphqlUrl: `http://127.0.0.1:${port}/graphql`,
+				loginUrl: `http://127.0.0.1:${port}`,
+			};
+			await vscode.workspace
+				.getConfiguration('rewst-buddy')
+				.update('regions', [region], vscode.ConfigurationTarget.Global);
+
+			const savedProfile: SessionProfile = {
+				region,
+				org: { id: 'org-concurrent', name: 'Concurrent Org' },
+				allManagedOrgs: [{ id: 'org-concurrent', name: 'Concurrent Org' }],
+				label: 'concurrent-user (Concurrent Org)',
+				user: { id: 'user-concurrent' } as SessionProfile['user'],
+			};
+			await context.globalState.update('SessionProfiles', [savedProfile]);
+			await context.secrets.store('user-concurrent', 'appSession=concurrent-cookie');
+
+			const [first, second] = await Promise.all([SessionManager.loadSessions(), SessionManager.loadSessions()]);
+
+			// createSession() makes two requests per profile (newSdk's internal
+			// validation, then its own explicit User() call) — 2, not 4, proves
+			// createSession ran once despite two concurrent loadSessions() callers.
+			assert.strictEqual(
+				requestCount,
+				2,
+				'createSession must run once per profile even under concurrent callers',
+			);
+			assert.strictEqual(
+				first,
+				second,
+				'concurrent callers receive the same resolved result via the shared promise',
+			);
+			assert.strictEqual(first.length, 1);
+		});
+
+		test('a rejected load clears the in-flight promise so a later call retries', async () => {
+			const manager = SessionManager as unknown as SessionProfileSaver;
+			const originalSaveProfiles = manager.saveProfiles.bind(SessionManager);
+			let calls = 0;
+			Object.defineProperty(SessionManager, 'saveProfiles', {
+				value: async () => {
+					calls++;
+					if (calls === 1) throw new Error('boom');
+					return originalSaveProfiles();
+				},
+				configurable: true,
+				writable: true,
+			});
+
+			try {
+				await assert.rejects(SessionManager.loadSessions(), /boom/);
+				await assert.doesNotReject(
+					SessionManager.loadSessions(),
+					'a later call must retry rather than reuse the rejected promise',
+				);
+			} finally {
+				Object.defineProperty(SessionManager, 'saveProfiles', {
+					value: originalSaveProfiles,
+					configurable: true,
+					writable: true,
+				});
+			}
 		});
 
 		test('a session removed while loadSessions is in flight is not resurrected by the load', async () => {
@@ -657,6 +895,11 @@ suite('Unit: SessionManager', () => {
 				await context.secrets.get('org-late'),
 				undefined,
 				'the removed session cookie must not be re-stored by the load',
+			);
+			assert.strictEqual(
+				await context.secrets.get('user-late'),
+				undefined,
+				'the migrated user-keyed cookie must not survive the purge either',
 			);
 			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
 			await assert.rejects(SessionManager.getSessionForOrg('org-late'));
@@ -766,8 +1009,13 @@ suite('Unit: SessionManager', () => {
 					],
 				},
 			});
+			// D4: removeSession deletes the user-id key plus the profile's own legacy
+			// org-id key. A secret sitting under a *managed*-org id was never written
+			// by any real create/load path even pre-D4 (createSession only ever wrote
+			// under the profile's own primary org id), so there's nothing to clean up
+			// there anymore — that coverage is superseded by the user-keyed scheme.
+			await context.secrets.store('user-remove', 'cookie-user');
 			await context.secrets.store('org-remove-primary', 'cookie-primary');
-			await context.secrets.store('org-remove-managed', 'cookie-managed');
 
 			const saver = SessionManager as unknown as SessionSaver;
 			await saver.saveSession(session);
@@ -775,8 +1023,8 @@ suite('Unit: SessionManager', () => {
 
 			await SessionManager.removeSession('user-remove');
 
+			assert.strictEqual(await context.secrets.get('user-remove'), undefined);
 			assert.strictEqual(await context.secrets.get('org-remove-primary'), undefined);
-			assert.strictEqual(await context.secrets.get('org-remove-managed'), undefined);
 			assert.strictEqual(SessionManager.getActiveSessions().length, 0);
 			assert.strictEqual(SessionManager.getAllKnownProfiles().length, 0);
 			await assert.rejects(SessionManager.getSessionForOrg('org-remove-primary'));
@@ -853,7 +1101,11 @@ suite('Unit: SessionManager', () => {
 			await assert.rejects(SessionManager.removeSession('does-not-exist'));
 		});
 
-		test('keeps a secret still needed by another profile whose org overlaps the removed session', async () => {
+		test('another session is unaffected when removing a session whose managed orgs overlap it', async () => {
+			// D4: secrets are keyed by user id, so two profiles overlapping on an org
+			// id (parent manages org-child, child's own primary org is org-child) can
+			// never collide on the same secret key the way the old org-keyed scheme
+			// could — this asserts that invariant plus the still-relevant org-index behavior.
 			const { session: parent } = createMockSession({
 				profile: {
 					user: Fixtures.userFragment({ id: 'user-parent' }),
@@ -871,8 +1123,8 @@ suite('Unit: SessionManager', () => {
 					allManagedOrgs: [{ id: 'org-child', name: 'Child' }],
 				},
 			});
-			await context.secrets.store('org-parent', 'cookie-parent');
-			await context.secrets.store('org-child', 'cookie-child');
+			await context.secrets.store('user-parent', 'cookie-parent');
+			await context.secrets.store('user-child', 'cookie-child');
 
 			const saver = SessionManager as unknown as SessionSaver;
 			await saver.saveSession(parent);
@@ -881,14 +1133,14 @@ suite('Unit: SessionManager', () => {
 			await SessionManager.removeSession('user-parent');
 
 			assert.strictEqual(
-				await context.secrets.get('org-parent'),
+				await context.secrets.get('user-parent'),
 				undefined,
 				"the removed session's own cookie is deleted",
 			);
 			assert.strictEqual(
-				await context.secrets.get('org-child'),
+				await context.secrets.get('user-child'),
 				'cookie-child',
-				"another session's cookie stored under a shared org id must survive",
+				"another session's user-keyed cookie survives even though its org overlaps the removed session",
 			);
 			assert.strictEqual(await SessionManager.getSessionForOrg('org-child'), child);
 		});

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -86,7 +86,7 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		return session;
 	}
 
-	async createSession(cookies?: string): Promise<Session> {
+	async createSession(cookies?: string, options: { persist?: boolean } = {}): Promise<Session> {
 		log.trace('createSession: starting', { hasCookies: !!cookies });
 
 		let sdk;
@@ -151,14 +151,18 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		};
 		const session = new Session(sdk, profile);
 
-		log.trace('createSession: storing cookie and saving session');
+		log.trace('createSession: storing cookie and registering session');
 		// D4: store under user id so two users with the same primary org get separate secrets.
 		const userId = profile.user.id;
 		if (!userId) throw log.error('createSession: user has no id');
 		await context.secrets.store(userId, cookieString.value);
 		// Clean up any legacy org-keyed secret now that we have the user-keyed one.
 		await context.secrets.delete(org.id);
-		await this.saveSession(session);
+		if (options.persist === false) {
+			this.registerSession(session);
+		} else {
+			await this.saveSession(session);
+		}
 
 		log.debug('createSession: completed', { label: profile.label });
 		return session;
@@ -272,7 +276,7 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 						log.error(`loadSessions: no cookie found for profile ${profile.label}`);
 						return undefined;
 					}
-					return await this.createSession(cookies);
+					return await this.createSession(cookies, { persist: false });
 				} catch (err) {
 					log.error(`loadSessions: failed to create session for ${profile.org.id}: ${err}`);
 					return undefined;
@@ -355,9 +359,15 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 
 	private async saveSession(session: Session): Promise<void> {
 		log.trace('saveSession: saving', { label: session.profile.label });
+		this.registerSession(session);
 
+		await this.saveProfiles();
+		log.trace('saveSession: saved', { sessionMapSize: this.sessionMap.size });
+	}
+
+	private registerSession(session: Session): void {
 		if (typeof session.profile.user.id !== 'string') {
-			throw log.error('saveSession: user has no id');
+			throw log.error('registerSession: user has no id');
 		}
 
 		this.setAnyActiveSessions(true);
@@ -368,9 +378,6 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		}
 		this.sessionMap.set(session.profile.user.id, session);
 		this.indexSession(session);
-
-		await this.saveProfiles();
-		log.trace('saveSession: saved', { sessionMapSize: this.sessionMap.size });
 	}
 
 	private indexSession(session: Session): void {

--- a/src/sessions/SessionManager.ts
+++ b/src/sessions/SessionManager.ts
@@ -21,14 +21,18 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 	private orgSessionIndex = new Map<string, Session[]>();
 	private sessionExpiredDisposables = new Map<Session, vscode.Disposable>();
 	private knownProfilesCache: SessionProfile[] | undefined;
-	private suppressProfileSaves = false;
+	// Single promise shared by all concurrent loadSessions() callers.
+	// Undefined means not yet started; set to the in-flight promise while loading;
+	// resolves to the loaded sessions and stays set afterwards.
+	private loadPromise: Promise<Session[]> | undefined;
+	// True only while _doLoad is actually running (not merely while loadPromise is set),
+	// so removeSession can tell whether a removal races an in-flight load.
+	private loadInFlight = false;
 	// User ids removed while loadSessions was in flight; the load reconciles
 	// these afterwards so a completed createSession cannot resurrect them.
 	private removedDuringLoad = new Set<string>();
 
 	private readonly sessionChangeEmitter = new vscode.EventEmitter<SessionChangeEvent>();
-	private loaded = false;
-	private loading = false;
 	readonly onSessionChange = this.sessionChangeEmitter.event;
 	private anyActiveSessions = false;
 
@@ -148,7 +152,12 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		const session = new Session(sdk, profile);
 
 		log.trace('createSession: storing cookie and saving session');
-		await context.secrets.store(org.id, cookieString.value);
+		// D4: store under user id so two users with the same primary org get separate secrets.
+		const userId = profile.user.id;
+		if (!userId) throw log.error('createSession: user has no id');
+		await context.secrets.store(userId, cookieString.value);
+		// Clean up any legacy org-keyed secret now that we have the user-keyed one.
+		await context.secrets.delete(org.id);
 		await this.saveSession(session);
 
 		log.debug('createSession: completed', { label: profile.label });
@@ -220,64 +229,76 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 	async loadSessions(): Promise<Session[]> {
 		log.trace('loadSessions: starting');
 
-		const startTime = Date.now();
-		const maxWaitMs = 10000; // 10 seconds
-
-		while (this.loading) {
-			if (Date.now() - startTime > maxWaitMs) {
-				throw log.error('loadSessions: timeout waiting for concurrent load to complete');
-			}
-			await new Promise(resolve => setTimeout(resolve, 500));
-		}
-		if (this.loaded) {
-			log.debug('loadSessions: already loaded, skipping');
-			return this.getActiveSessions();
+		// D4: share a single promise across concurrent callers — no polling.
+		if (this.loadPromise !== undefined) {
+			log.debug('loadSessions: returning shared in-flight or completed promise');
+			return this.loadPromise;
 		}
 
-		this.loading = true;
+		this.loadPromise = this._doLoad().catch(err => {
+			// Clear the promise on failure so a later call can retry.
+			this.loadPromise = undefined;
+			throw err;
+		});
+		return this.loadPromise;
+	}
+
+	private async _doLoad(): Promise<Session[]> {
+		this.loadInFlight = true;
 		try {
 			const newProfiles = await this.newProfiles();
 			log.debug('loadSessions: profiles to load', newProfiles.length);
 
-			// Defer profile persistence to the single saveProfiles() below
-			this.suppressProfileSaves = true;
-			try {
-				const resultsPromises = newProfiles.map(async profile => {
-					log.trace('loadSessions: loading profile', { label: profile.label, orgId: profile.org.id });
-					try {
-						return await this.createSession(await Session.getCookies(profile.org.id));
-					} catch (err) {
-						log.error(`loadSessions: failed to create session for ${profile.org.id}: ${err}`);
+			const resultsPromises = newProfiles.map(async profile => {
+				log.trace('loadSessions: loading profile', { label: profile.label, orgId: profile.org.id });
+				try {
+					// D4: try user-id key first, fall back to legacy org-id key for migration.
+					const userId = profile.user.id;
+					let cookies: string | undefined;
+					if (userId) {
+						cookies = await context.secrets.get(userId);
+					}
+					if (!cookies) {
+						// Legacy org-id key: migrate by reading and re-storing under user-id.
+						cookies = await context.secrets.get(profile.org.id);
+						if (cookies && userId) {
+							log.debug('loadSessions: migrating legacy org-keyed secret to user-keyed', {
+								userId,
+								orgId: profile.org.id,
+							});
+						}
+					}
+					if (!cookies) {
+						log.error(`loadSessions: no cookie found for profile ${profile.label}`);
 						return undefined;
 					}
-				});
-
-				await Promise.all(resultsPromises);
-			} finally {
-				this.suppressProfileSaves = false;
-			}
-			this.loaded = true;
-
-			await this.saveProfiles();
-
-			// A profile removed while its cookie-driven load was still in flight
-			// may have been resurrected by createSession completing afterwards;
-			// purge it again now that the load has settled.
-			const toPurge = Array.from(this.removedDuringLoad);
-			this.removedDuringLoad.clear();
-			for (const userId of toPurge) {
-				if (this.sessionMap.has(userId)) {
-					log.debug('loadSessions: purging session resurrected past its removal', userId);
-					await this.removeSession(userId);
+					return await this.createSession(cookies);
+				} catch (err) {
+					log.error(`loadSessions: failed to create session for ${profile.org.id}: ${err}`);
+					return undefined;
 				}
-			}
-			this.removedDuringLoad.clear();
+			});
 
-			log.debug('loadSessions: completed', { sessionCount: this.sessionMap.size });
-			return this.getActiveSessions();
+			await Promise.all(resultsPromises);
+			await this.saveProfiles();
 		} finally {
-			this.loading = false;
+			this.loadInFlight = false;
 		}
+
+		// A profile removed while its cookie-driven load was still in flight may
+		// have been resurrected by createSession completing afterwards; purge it
+		// again now that the load has settled.
+		const toPurge = Array.from(this.removedDuringLoad);
+		this.removedDuringLoad.clear();
+		for (const userId of toPurge) {
+			if (this.sessionMap.has(userId)) {
+				log.debug('loadSessions: purging session resurrected past its removal', userId);
+				await this.removeSession(userId);
+			}
+		}
+
+		log.debug('loadSessions: completed', { sessionCount: this.sessionMap.size });
+		return this.getActiveSessions();
 	}
 
 	getActiveSessions() {
@@ -348,9 +369,7 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		this.sessionMap.set(session.profile.user.id, session);
 		this.indexSession(session);
 
-		if (!this.suppressProfileSaves) {
-			await this.saveProfiles();
-		}
+		await this.saveProfiles();
 		log.trace('saveSession: saved', { sessionMapSize: this.sessionMap.size });
 	}
 
@@ -458,15 +477,17 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 			.concat(this.getAllKnownProfiles())
 			.concat(this.getSavedProfiles());
 
-		const orgIdsToClear = new Set<string>();
+		// D4: delete user-id keyed secrets (plus legacy org-id keys for cleanup).
+		const secretKeysToClear = new Set<string>();
 		for (const profile of profilesToClear) {
-			orgIdsToClear.add(profile.org.id);
+			if (profile.user.id) secretKeysToClear.add(profile.user.id);
+			secretKeysToClear.add(profile.org.id); // legacy cleanup
 			for (const managedOrg of profile.allManagedOrgs) {
-				orgIdsToClear.add(managedOrg.id);
+				secretKeysToClear.add(managedOrg.id); // legacy cleanup
 			}
 		}
 
-		await Promise.all(Array.from(orgIdsToClear).map(orgId => context.secrets.delete(orgId)));
+		await Promise.all(Array.from(secretKeysToClear).map(key => context.secrets.delete(key)));
 
 		await context.globalState.update('SessionProfiles', []);
 		await context.globalState.update('RewstAllKnownProfiles', []);
@@ -483,7 +504,7 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 			activeProfiles: [],
 		});
 
-		log.trace('clearProfiles: cleared', { secretsCleared: orgIdsToClear.size });
+		log.trace('clearProfiles: cleared', { secretsCleared: secretKeysToClear.size });
 	}
 
 	/**
@@ -513,28 +534,13 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		// A load in flight may have already read this profile's cookie and can
 		// re-create the session after this removal completes; mark it so
 		// loadSessions purges any such resurrection once the load finishes.
-		if (this.loading) {
+		if (this.loadInFlight) {
 			this.removedDuringLoad.add(userId);
 		}
 
-		// Only delete secrets no remaining profile still needs: another session
-		// can legitimately store its cookie under one of this profile's org ids
-		// (e.g. this session managed the other session's primary org).
-		const retainedOrgIds = new Set<string>();
-		const remainingProfiles = this.getActiveSessions()
-			.map(s => s.profile)
-			.concat(this.getAllKnownProfiles().filter(known => known.user.id !== userId))
-			.concat(this.getSavedProfiles().filter(saved => saved.user.id !== userId));
-		for (const remaining of remainingProfiles) {
-			retainedOrgIds.add(remaining.org.id);
-			for (const org of remaining.allManagedOrgs) {
-				retainedOrgIds.add(org.id);
-			}
-		}
-		const orgIdsToClear = [profile.org.id, ...profile.allManagedOrgs.map(org => org.id)].filter(
-			orgId => !retainedOrgIds.has(orgId),
-		);
-		await Promise.all(orgIdsToClear.map(orgId => context.secrets.delete(orgId)));
+		// D4: delete the user-id keyed secret. Also clean up any legacy org-id key.
+		await context.secrets.delete(userId);
+		await context.secrets.delete(profile.org.id);
 
 		await context.globalState.update(
 			'SessionProfiles',
@@ -632,10 +638,9 @@ export const SessionManager = new (class _ implements vscode.Disposable {
 		this.knownProfileOrgIndex.clear();
 		this.orgSessionIndex.clear();
 		this.knownProfilesCache = undefined;
-		this.suppressProfileSaves = false;
+		this.loadPromise = undefined;
+		this.loadInFlight = false;
 		this.removedDuringLoad.clear();
-		this.loaded = false;
-		this.loading = false;
 		this.setAnyActiveSessions(false);
 		this.sessionChangeEmitter.fire({
 			type: 'cleared',

--- a/src/test/helpers/testSession.ts
+++ b/src/test/helpers/testSession.ts
@@ -60,9 +60,13 @@ export async function getTestSession(): Promise<Session> {
 	if (!profile.org.id) {
 		throw new Error('getTestSession: the test token resolved no primary org id.');
 	}
+	const userId = profile.user.id;
+	if (!userId) {
+		throw new Error('getTestSession: the test token resolved no user id.');
+	}
 	// Store the validated cookie so session.rawGraphql (which reads the cookie from
-	// secrets via getCookies) works in integration tests, not just the typed SDK.
-	await context.secrets.store(profile.org.id, cookieString.value);
+	// secrets via getCookies, keyed by user id) works in integration tests, not just the typed SDK.
+	await context.secrets.store(userId, cookieString.value);
 
 	cachedSession = new Session(sdk, profile);
 	return cachedSession;

--- a/src/utils/templateUrl.test.ts
+++ b/src/utils/templateUrl.test.ts
@@ -1,6 +1,6 @@
+import { initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { initTestEnvironment } from '@test';
 import { getTemplateURLParams } from './templateUrl';
 
 const { suite, test, setup } = Mocha;

--- a/src/workflow/executions.ts
+++ b/src/workflow/executions.ts
@@ -491,7 +491,26 @@ export async function runWorkflowRun(request: ToolRequest, deps: GraphqlToolDeps
 	const workflowId = asStringArg(request.args, 'workflowId');
 	const orgId = asStringArg(request.args, 'orgId');
 	if (!workflowId || !orgId) throw new Error('buddy_workflow_run requires "workflowId" and "orgId".');
-	const input = request.args.input && typeof request.args.input === 'object' ? request.args.input : undefined;
+
+	const profileName = asStringArg(request.args, 'profile');
+	const inlineInput = request.args.input && typeof request.args.input === 'object' ? request.args.input : undefined;
+
+	if (profileName !== undefined && inlineInput !== undefined) {
+		throw new Error('Pass either "profile" or "input", not both.');
+	}
+
+	let input: Record<string, unknown> | undefined = inlineInput as Record<string, unknown> | undefined;
+	if (profileName !== undefined) {
+		const { WorkflowInputProfileStore } = await import('../models/WorkflowInputProfileStore');
+		const profile = WorkflowInputProfileStore.get(orgId, workflowId, profileName);
+		if (!profile) {
+			throw new Error(
+				`No input profile named "${profileName}" found for workflow ${workflowId} (org ${orgId}). ` +
+					`Save one first with buddy_save_workflow_input_profile.`,
+			);
+		}
+		input = profile.input;
+	}
 	const result = await deps.execute(TEST_WORKFLOW_MUTATION, { id: workflowId, orgId, input });
 	const error = firstErrorMessage(result as ExecResult);
 	if (error) throw new Error(`testWorkflow failed: ${error}`);

--- a/src/workflow/index.ts
+++ b/src/workflow/index.ts
@@ -1,8 +1,8 @@
 // Barrel re-export for src/workflow — consumers can import from '@workflow'
 export * from './executions';
 export * from './graphMutations';
-export * from './lint';
 export * from './layout';
+export * from './lint';
 export * from './mutationScope';
 export * from './operationGrammar';
 export * from './searchIndex';

--- a/src/workflow/index.ts
+++ b/src/workflow/index.ts
@@ -1,6 +1,7 @@
 // Barrel re-export for src/workflow — consumers can import from '@workflow'
 export * from './executions';
 export * from './graphMutations';
+export * from './lint';
 export * from './layout';
 export * from './mutationScope';
 export * from './operationGrammar';

--- a/src/workflow/lint.test.ts
+++ b/src/workflow/lint.test.ts
@@ -53,6 +53,14 @@ suite('Unit: workflowLint', () => {
 		assert.ok(!findings.some(f => f.taskId === 'entry'));
 	});
 
+	test('derives the entry task from incoming transitions when tasks are unordered', () => {
+		const child = makeTask('child');
+		const entry = makeTask('entry', { next: [{ when: '{{ SUCCEEDED }}', do: ['child'] }] });
+		const wf = makeWorkflow([child, entry]);
+		const findings = lintWorkflow(wf);
+		assert.ok(!findings.some(f => f.rule === 'unreachable-task'), 'entry and child are reachable');
+	});
+
 	test('cycle-only island flagged unreachable', () => {
 		// E is terminal (no edges); A↔B cycle, no edge from E
 		const entry = makeTask('entry');
@@ -89,6 +97,21 @@ suite('Unit: workflowLint', () => {
 		assert.strictEqual(shadowed.length, 1);
 		assert.strictEqual(shadowed[0].severity, 'error');
 		assert.strictEqual(shadowed[0].taskId, 't1');
+	});
+
+	test('success transition before custom is not shadowed under FOLLOW_ALL', () => {
+		const task = makeTask('t1', {
+			transitionMode: 'FOLLOW_ALL',
+			next: [
+				{ when: '{{ SUCCEEDED }}', do: ['t2'] },
+				{ when: '{{ x }}', do: ['t3'] },
+			],
+		});
+		const t2 = makeTask('t2');
+		const t3 = makeTask('t3');
+		const wf = makeWorkflow([task, t2, t3]);
+		const findings = lintWorkflow(wf);
+		assert.ok(!findings.some(f => f.rule === 'success-transition-shadowed'));
 	});
 
 	test('custom before success is NOT shadowed', () => {

--- a/src/workflow/lint.test.ts
+++ b/src/workflow/lint.test.ts
@@ -1,7 +1,7 @@
 import * as assert from 'assert';
 import { suite, test } from '../test/tdd';
-import type { RawTask, RawWorkflow } from './types';
 import { formatLintReport, lintWorkflow, MONOLITH_DEPTH_THRESHOLD, MONOLITH_TASK_THRESHOLD, rankDepth } from './lint';
+import type { RawTask, RawWorkflow } from './types';
 
 // ---------------------------------------------------------------------------
 // Fixture helpers

--- a/src/workflow/lint.test.ts
+++ b/src/workflow/lint.test.ts
@@ -1,0 +1,295 @@
+import * as assert from 'assert';
+import { suite, test } from '../test/tdd';
+import type { RawTask, RawWorkflow } from './types';
+import { formatLintReport, lintWorkflow, MONOLITH_DEPTH_THRESHOLD, MONOLITH_TASK_THRESHOLD, rankDepth } from './lint';
+
+// ---------------------------------------------------------------------------
+// Fixture helpers
+// ---------------------------------------------------------------------------
+
+function makeTask(id: string, over: Partial<RawTask> = {}): RawTask {
+	return { id, name: id, ...over };
+}
+
+function makeWorkflow(tasks: RawTask[], over: Partial<RawWorkflow> = {}): RawWorkflow {
+	return { id: 'wf-1', name: 'Test Workflow', orgId: 'org-1', tasks, ...over };
+}
+
+// ---------------------------------------------------------------------------
+// Suite
+// ---------------------------------------------------------------------------
+
+suite('Unit: workflowLint', () => {
+	test('clean workflow yields no findings', () => {
+		const entry = makeTask('entry', {
+			action: { ref: 'msgraph.x' },
+			retry: { count: '3' },
+			next: [{ when: '{{ SUCCEEDED }}', do: ['terminal'] }],
+		});
+		const terminal = makeTask('terminal');
+		const wf = makeWorkflow([entry, terminal]);
+		const findings = lintWorkflow(wf);
+		assert.deepStrictEqual(findings, []);
+		const report = formatLintReport(wf, findings);
+		assert.match(report, /No issues found/);
+		assert.ok(report.includes(wf.name));
+		assert.ok(report.includes(wf.id));
+	});
+
+	test('empty tasks yields no findings', () => {
+		const wf = makeWorkflow([]);
+		assert.deepStrictEqual(lintWorkflow(wf), []);
+	});
+
+	test('unreachable disconnected task flagged', () => {
+		const entry = makeTask('entry'); // no edges to X
+		const orphan = makeTask('orphan');
+		const wf = makeWorkflow([entry, orphan]);
+		const findings = lintWorkflow(wf);
+		assert.strictEqual(findings.length, 1);
+		assert.strictEqual(findings[0].rule, 'unreachable-task');
+		assert.strictEqual(findings[0].taskId, 'orphan');
+		// entry is never flagged
+		assert.ok(!findings.some(f => f.taskId === 'entry'));
+	});
+
+	test('cycle-only island flagged unreachable', () => {
+		// E is terminal (no edges); A↔B cycle, no edge from E
+		const entry = makeTask('entry');
+		const a = makeTask('a', { next: [{ when: '{{ SUCCEEDED }}', do: ['b'] }] });
+		const b = makeTask('b', { next: [{ when: '{{ SUCCEEDED }}', do: ['a'] }] });
+		const wf = makeWorkflow([entry, a, b]);
+		const findings = lintWorkflow(wf);
+		const unreachable = findings.filter(f => f.rule === 'unreachable-task');
+		assert.ok(
+			unreachable.some(f => f.taskId === 'a'),
+			'a flagged unreachable',
+		);
+		assert.ok(
+			unreachable.some(f => f.taskId === 'b'),
+			'b flagged unreachable',
+		);
+		// rankDepth must not hang on the cycle
+		const depth = rankDepth([entry, a, b]);
+		assert.ok(typeof depth === 'number' && isFinite(depth));
+	});
+
+	test('success transition before custom is shadowed', () => {
+		const task = makeTask('t1', {
+			next: [
+				{ when: '{{ SUCCEEDED }}', do: ['t2'] },
+				{ when: '{{ x }}', do: ['t3'] },
+			],
+		});
+		const t2 = makeTask('t2');
+		const t3 = makeTask('t3');
+		const wf = makeWorkflow([task, t2, t3]);
+		const findings = lintWorkflow(wf);
+		const shadowed = findings.filter(f => f.rule === 'success-transition-shadowed');
+		assert.strictEqual(shadowed.length, 1);
+		assert.strictEqual(shadowed[0].severity, 'error');
+		assert.strictEqual(shadowed[0].taskId, 't1');
+	});
+
+	test('custom before success is NOT shadowed', () => {
+		const task = makeTask('t1', {
+			next: [
+				{ when: '{{ x }}', do: ['t3'] },
+				{ when: '{{ SUCCEEDED }}', do: ['t2'] },
+			],
+		});
+		const t2 = makeTask('t2');
+		const t3 = makeTask('t3');
+		const wf = makeWorkflow([task, t2, t3]);
+		const findings = lintWorkflow(wf);
+		assert.ok(!findings.some(f => f.rule === 'success-transition-shadowed'));
+	});
+
+	test('missing success/default path flagged', () => {
+		const task = makeTask('t1', {
+			next: [{ when: '{{ x }}', do: ['t2'] }],
+		});
+		const t2 = makeTask('t2');
+		const wf = makeWorkflow([task, t2]);
+		const findings = lintWorkflow(wf);
+		const missing = findings.filter(f => f.rule === 'missing-success-transition');
+		assert.strictEqual(missing.length, 1);
+		assert.strictEqual(missing[0].severity, 'warning');
+		assert.strictEqual(missing[0].taskId, 't1');
+	});
+
+	test('task with success transition is NOT missing-success-transition', () => {
+		const task = makeTask('t1', {
+			next: [{ when: '{{ SUCCEEDED }}', do: ['t2'] }],
+		});
+		const t2 = makeTask('t2');
+		const wf = makeWorkflow([task, t2]);
+		const findings = lintWorkflow(wf);
+		assert.ok(!findings.some(f => f.rule === 'missing-success-transition'));
+	});
+
+	test('task with zero transitions is NOT missing-success-transition', () => {
+		const task = makeTask('t1'); // no next
+		const wf = makeWorkflow([task]);
+		const findings = lintWorkflow(wf);
+		assert.ok(!findings.some(f => f.rule === 'missing-success-transition'));
+	});
+
+	test('action task without retry/timeout flagged', () => {
+		const task = makeTask('t1', { action: { ref: 'msgraph.x' } });
+		const wf = makeWorkflow([task]);
+		const findings = lintWorkflow(wf);
+		const noGuard = findings.filter(f => f.rule === 'action-without-guard');
+		assert.strictEqual(noGuard.length, 1);
+		assert.strictEqual(noGuard[0].severity, 'info');
+	});
+
+	test('action task with retry is NOT action-without-guard', () => {
+		const task = makeTask('t1', { action: { ref: 'msgraph.x' }, retry: { count: '3' } });
+		const wf = makeWorkflow([task]);
+		assert.ok(!lintWorkflow(wf).some(f => f.rule === 'action-without-guard'));
+	});
+
+	test('action task with timeout is NOT action-without-guard', () => {
+		const task = makeTask('t1', { action: { ref: 'msgraph.x' }, timeout: 30 });
+		const wf = makeWorkflow([task]);
+		assert.ok(!lintWorkflow(wf).some(f => f.rule === 'action-without-guard'));
+	});
+
+	test('non-action task with no guards is NOT action-without-guard', () => {
+		const task = makeTask('t1'); // no action ref, no actionId
+		const wf = makeWorkflow([task]);
+		assert.ok(!lintWorkflow(wf).some(f => f.rule === 'action-without-guard'));
+	});
+
+	test('enabled mock input flagged', () => {
+		const task = makeTask('t1', { isMocked: true });
+		const wf = makeWorkflow([task]);
+		const findings = lintWorkflow(wf);
+		const mocked = findings.filter(f => f.rule === 'mock-input-enabled');
+		assert.strictEqual(mocked.length, 1);
+		assert.strictEqual(mocked[0].severity, 'warning');
+	});
+
+	test('isMocked false/absent is NOT mock-input-enabled', () => {
+		const t1 = makeTask('t1', { isMocked: false });
+		const t2 = makeTask('t2');
+		const wf = makeWorkflow([t1, t2]);
+		assert.ok(!lintWorkflow(wf).some(f => f.rule === 'mock-input-enabled'));
+	});
+
+	test('monolith by task count', () => {
+		// Build MONOLITH_TASK_THRESHOLD tasks in a linear chain
+		const tasks: RawTask[] = [];
+		for (let i = 0; i < MONOLITH_TASK_THRESHOLD; i++) {
+			const id = `t${i}`;
+			const next = i < MONOLITH_TASK_THRESHOLD - 1 ? [{ when: '{{ SUCCEEDED }}', do: [`t${i + 1}`] }] : undefined;
+			tasks.push(makeTask(id, { next }));
+		}
+		const wf = makeWorkflow(tasks);
+		const findings = lintWorkflow(wf);
+		const monolith = findings.filter(f => f.rule === 'monolith');
+		assert.strictEqual(monolith.length, 1);
+		assert.ok(monolith[0].message.includes(String(MONOLITH_TASK_THRESHOLD)));
+	});
+
+	test('one below monolith task threshold is NOT monolith', () => {
+		const tasks: RawTask[] = [];
+		for (let i = 0; i < MONOLITH_TASK_THRESHOLD - 1; i++) {
+			tasks.push(makeTask(`t${i}`));
+		}
+		const wf = makeWorkflow(tasks);
+		assert.ok(!lintWorkflow(wf).some(f => f.rule === 'monolith'));
+	});
+
+	test('monolith by depth', () => {
+		// Build a linear chain of MONOLITH_DEPTH_THRESHOLD tasks
+		const tasks: RawTask[] = [];
+		for (let i = 0; i < MONOLITH_DEPTH_THRESHOLD; i++) {
+			const id = `t${i}`;
+			const next =
+				i < MONOLITH_DEPTH_THRESHOLD - 1 ? [{ when: '{{ SUCCEEDED }}', do: [`t${i + 1}`] }] : undefined;
+			tasks.push(makeTask(id, { next }));
+		}
+		const wf = makeWorkflow(tasks);
+		const findings = lintWorkflow(wf);
+		assert.ok(
+			findings.some(f => f.rule === 'monolith'),
+			'monolith finding present',
+		);
+	});
+
+	test('short chain is NOT monolith', () => {
+		const entry = makeTask('entry', { next: [{ when: '{{ SUCCEEDED }}', do: ['t1'] }] });
+		const t1 = makeTask('t1');
+		const wf = makeWorkflow([entry, t1]);
+		assert.ok(!lintWorkflow(wf).some(f => f.rule === 'monolith'));
+	});
+
+	test('findings ordered error → warning → info', () => {
+		// Create a workflow that triggers one of each severity:
+		// - success-transition-shadowed (error)
+		// - mock-input-enabled (warning)
+		// - action-without-guard (info)
+		const task = makeTask('t1', {
+			action: { ref: 'msgraph.x' }, // triggers action-without-guard (info)
+			isMocked: true, // triggers mock-input-enabled (warning)
+			next: [
+				{ when: '{{ SUCCEEDED }}', do: ['t2'] }, // triggers success-transition-shadowed (error)
+				{ when: '{{ x }}', do: ['t3'] },
+			],
+		});
+		const t2 = makeTask('t2');
+		const t3 = makeTask('t3');
+		const wf = makeWorkflow([task, t2, t3]);
+		const findings = lintWorkflow(wf);
+		const severityOrder: Record<string, number> = { error: 0, warning: 1, info: 2 };
+		for (let i = 1; i < findings.length; i++) {
+			assert.ok(
+				severityOrder[findings[i - 1].severity] <= severityOrder[findings[i].severity],
+				`finding ${i - 1} (${findings[i - 1].severity}) should come before finding ${i} (${findings[i].severity})`,
+			);
+		}
+		// Verify we have at least one of each
+		assert.ok(findings.some(f => f.severity === 'error'));
+		assert.ok(findings.some(f => f.severity === 'warning'));
+		assert.ok(findings.some(f => f.severity === 'info'));
+	});
+
+	test('rankDepth is deterministic and cycle-safe', () => {
+		// branching + a back-edge
+		const a = makeTask('a', { next: [{ when: '{{ SUCCEEDED }}', do: ['b', 'c'] }] });
+		const b = makeTask('b', { next: [{ when: '{{ SUCCEEDED }}', do: ['d'] }] });
+		const c = makeTask('c', { next: [{ when: '{{ SUCCEEDED }}', do: ['d'] }] });
+		const d = makeTask('d', { next: [{ when: '{{ SUCCEEDED }}', do: ['a'] }] }); // back-edge
+		const tasks = [a, b, c, d];
+		const depth1 = rankDepth(tasks);
+		const depth2 = rankDepth(tasks);
+		assert.strictEqual(depth1, depth2, 'deterministic');
+		assert.ok(typeof depth1 === 'number' && isFinite(depth1), 'finite number');
+	});
+
+	test('formatLintReport groups and counts', () => {
+		const task = makeTask('t1', {
+			action: { ref: 'msgraph.x' },
+			isMocked: true,
+			next: [
+				{ when: '{{ SUCCEEDED }}', do: ['t2'] },
+				{ when: '{{ x }}', do: ['t3'] },
+			],
+		});
+		const t2 = makeTask('t2');
+		const t3 = makeTask('t3');
+		const wf = makeWorkflow([task, t2, t3]);
+		const findings = lintWorkflow(wf);
+		const report = formatLintReport(wf, findings);
+		// Should contain per-severity counts
+		assert.ok(report.includes('error'), 'report mentions error');
+		assert.ok(report.includes('warning'), 'report mentions warning');
+		assert.ok(report.includes('info'), 'report mentions info');
+		// Should contain one line per finding with rule id
+		for (const f of findings) {
+			assert.ok(report.includes(f.rule), `report includes rule ${f.rule}`);
+		}
+	});
+});

--- a/src/workflow/lint.ts
+++ b/src/workflow/lint.ts
@@ -79,18 +79,27 @@ export function lintWorkflow(workflow: RawWorkflow): LintFinding[] {
 	const warnings: LintFinding[] = [];
 	const infos: LintFinding[] = [];
 
-	// Build reachability set via BFS from entry (tasks[0])
-	const taskIds = new Set(tasks.map(t => t.id));
+	// Build reachability set via BFS from the task with no incoming transition.
+	const taskById = new Map(tasks.map(t => [t.id, t]));
+	const incoming = new Set<string>();
+	for (const task of tasks) {
+		for (const tr of task.next ?? []) {
+			for (const targetId of tr.do ?? []) {
+				if (taskById.has(targetId)) incoming.add(targetId);
+			}
+		}
+	}
 	const reachable = new Set<string>();
-	const entryId = tasks[0].id;
+	const entryId = tasks.find(t => !incoming.has(t.id))?.id ?? tasks[0].id;
 	reachable.add(entryId);
 	const queue = [entryId];
-	while (queue.length > 0) {
-		const current = queue.shift()!;
-		const task = tasks.find(t => t.id === current);
+	let head = 0;
+	while (head < queue.length) {
+		const current = queue[head++];
+		const task = taskById.get(current);
 		for (const tr of task?.next ?? []) {
 			for (const targetId of tr.do ?? []) {
-				if (taskIds.has(targetId) && !reachable.has(targetId)) {
+				if (taskById.has(targetId) && !reachable.has(targetId)) {
 					reachable.add(targetId);
 					queue.push(targetId);
 				}
@@ -112,22 +121,24 @@ export function lintWorkflow(workflow: RawWorkflow): LintFinding[] {
 
 		// success-transition-shadowed: a success/default transition appears before a custom one
 		const next = task.next ?? [];
-		for (let i = 0; i < next.length; i++) {
-			if (isSuccessCondition(next[i].when)) {
-				// Check if any later transition is custom (non-success)
-				for (let j = i + 1; j < next.length; j++) {
-					if (!isSuccessCondition(next[j].when)) {
-						errors.push({
-							rule: 'success-transition-shadowed',
-							severity: 'error',
-							taskId: task.id,
-							taskName: task.name,
-							message: `Task "${task.name}" (${task.id}) has a success/default transition at position ${i} that shadows a custom condition at position ${j}. Reorder so custom conditions come first.`,
-						});
-						break; // one finding per task
+		if ((task.transitionMode ?? 'FOLLOW_FIRST') === 'FOLLOW_FIRST') {
+			for (let i = 0; i < next.length; i++) {
+				if (isSuccessCondition(next[i].when)) {
+					// Check if any later transition is custom (non-success)
+					for (let j = i + 1; j < next.length; j++) {
+						if (!isSuccessCondition(next[j].when)) {
+							errors.push({
+								rule: 'success-transition-shadowed',
+								severity: 'error',
+								taskId: task.id,
+								taskName: task.name,
+								message: `Task "${task.name}" (${task.id}) has a success/default transition at position ${i} that shadows a custom condition at position ${j}. Reorder so custom conditions come first.`,
+							});
+							break; // one finding per task
+						}
 					}
+					break; // found first success transition, done checking this task
 				}
-				break; // found first success transition, done checking this task
 			}
 		}
 

--- a/src/workflow/lint.ts
+++ b/src/workflow/lint.ts
@@ -1,0 +1,200 @@
+import { isSuccessCondition, type RawTask, type RawWorkflow } from './types';
+
+export type LintSeverity = 'error' | 'warning' | 'info';
+
+export interface LintFinding {
+	rule: string;
+	severity: LintSeverity;
+	taskId?: string;
+	taskName?: string;
+	message: string;
+}
+
+export const MONOLITH_TASK_THRESHOLD = 20;
+export const MONOLITH_DEPTH_THRESHOLD = 12;
+
+/**
+ * Compute the longest forward-path depth (number of ranks) in the task graph.
+ * Cycle-safe: back-edges (edges to nodes on the current DFS stack) are excluded.
+ * Returns 0 for an empty task list.
+ */
+export function rankDepth(tasks: RawTask[]): number {
+	if (tasks.length === 0) return 0;
+
+	// Build forward-edge adjacency from task.next[].do[]
+	const taskIds = new Set(tasks.map(t => t.id));
+	const adj = new Map<string, string[]>();
+	for (const task of tasks) {
+		const targets: string[] = [];
+		for (const tr of task.next ?? []) {
+			for (const targetId of tr.do ?? []) {
+				if (taskIds.has(targetId)) {
+					targets.push(targetId);
+				}
+			}
+		}
+		adj.set(task.id, targets);
+	}
+
+	// Topological relaxation with cycle detection via DFS stack
+	// dist[id] = longest path length to reach id
+	const dist = new Map<string, number>();
+	const visited = new Set<string>();
+	const onStack = new Set<string>();
+
+	function dfs(id: string): number {
+		if (onStack.has(id)) return 0; // back-edge: skip to break cycle
+		if (visited.has(id)) return dist.get(id) ?? 0;
+		onStack.add(id);
+		let maxChild = -1;
+		for (const neighbor of adj.get(id) ?? []) {
+			const d = dfs(neighbor);
+			if (d > maxChild) maxChild = d;
+		}
+		onStack.delete(id);
+		visited.add(id);
+		const myDist = maxChild < 0 ? 0 : maxChild + 1;
+		dist.set(id, myDist);
+		return myDist;
+	}
+
+	let max = 0;
+	for (const task of tasks) {
+		const d = dfs(task.id);
+		if (d > max) max = d;
+	}
+	return max + 1; // rank count = longest path length + 1
+}
+
+/**
+ * Audit a workflow's structure and return a list of findings.
+ * Ordered: error → warning → info; within a group, per-task findings in task order,
+ * workflow-level monolith finding last.
+ */
+export function lintWorkflow(workflow: RawWorkflow): LintFinding[] {
+	const tasks = workflow.tasks ?? [];
+	if (tasks.length === 0) return [];
+
+	const errors: LintFinding[] = [];
+	const warnings: LintFinding[] = [];
+	const infos: LintFinding[] = [];
+
+	// Build reachability set via BFS from entry (tasks[0])
+	const taskIds = new Set(tasks.map(t => t.id));
+	const reachable = new Set<string>();
+	const entryId = tasks[0].id;
+	reachable.add(entryId);
+	const queue = [entryId];
+	while (queue.length > 0) {
+		const current = queue.shift()!;
+		const task = tasks.find(t => t.id === current);
+		for (const tr of task?.next ?? []) {
+			for (const targetId of tr.do ?? []) {
+				if (taskIds.has(targetId) && !reachable.has(targetId)) {
+					reachable.add(targetId);
+					queue.push(targetId);
+				}
+			}
+		}
+	}
+
+	for (const task of tasks) {
+		// unreachable-task: not reachable from entry (entry itself is never flagged)
+		if (task.id !== entryId && !reachable.has(task.id)) {
+			warnings.push({
+				rule: 'unreachable-task',
+				severity: 'warning',
+				taskId: task.id,
+				taskName: task.name,
+				message: `Task "${task.name}" (${task.id}) is not reachable from the workflow entry.`,
+			});
+		}
+
+		// success-transition-shadowed: a success/default transition appears before a custom one
+		const next = task.next ?? [];
+		for (let i = 0; i < next.length; i++) {
+			if (isSuccessCondition(next[i].when)) {
+				// Check if any later transition is custom (non-success)
+				for (let j = i + 1; j < next.length; j++) {
+					if (!isSuccessCondition(next[j].when)) {
+						errors.push({
+							rule: 'success-transition-shadowed',
+							severity: 'error',
+							taskId: task.id,
+							taskName: task.name,
+							message: `Task "${task.name}" (${task.id}) has a success/default transition at position ${i} that shadows a custom condition at position ${j}. Reorder so custom conditions come first.`,
+						});
+						break; // one finding per task
+					}
+				}
+				break; // found first success transition, done checking this task
+			}
+		}
+
+		// missing-success-transition: has transitions but none is success/default
+		if (next.length > 0 && !next.some(tr => isSuccessCondition(tr.when))) {
+			warnings.push({
+				rule: 'missing-success-transition',
+				severity: 'warning',
+				taskId: task.id,
+				taskName: task.name,
+				message: `Task "${task.name}" (${task.id}) has outgoing transitions but no success/default path. It may get stuck if no condition matches.`,
+			});
+		}
+
+		// action-without-guard: pack-action task with no retry and no timeout
+		if ((task.action?.ref || task.actionId) && task.retry == null && task.timeout == null) {
+			infos.push({
+				rule: 'action-without-guard',
+				severity: 'info',
+				taskId: task.id,
+				taskName: task.name,
+				message: `Task "${task.name}" (${task.id}) is an action task with no retry or timeout configured. Consider adding guards for resilience.`,
+			});
+		}
+
+		// mock-input-enabled
+		if (task.isMocked === true) {
+			warnings.push({
+				rule: 'mock-input-enabled',
+				severity: 'warning',
+				taskId: task.id,
+				taskName: task.name,
+				message: `Task "${task.name}" (${task.id}) has mock input enabled. Disable mocking before using this workflow in production.`,
+			});
+		}
+	}
+
+	// monolith: workflow-level finding (no taskId)
+	const depth = rankDepth(tasks);
+	if (tasks.length >= MONOLITH_TASK_THRESHOLD || depth >= MONOLITH_DEPTH_THRESHOLD) {
+		infos.push({
+			rule: 'monolith',
+			severity: 'info',
+			message: `Workflow has ${tasks.length} task(s) and a dependency-chain depth of ${depth}. Consider extracting sub-workflows to improve maintainability (threshold: ${MONOLITH_TASK_THRESHOLD} tasks or depth ${MONOLITH_DEPTH_THRESHOLD}).`,
+		});
+	}
+
+	return [...errors, ...warnings, ...infos];
+}
+
+/**
+ * Format a lint report as a human-readable string.
+ */
+export function formatLintReport(workflow: RawWorkflow, findings: LintFinding[]): string {
+	if (findings.length === 0) {
+		return `No issues found in workflow "${workflow.name}" (${workflow.id}).`;
+	}
+
+	const errorCount = findings.filter(f => f.severity === 'error').length;
+	const warningCount = findings.filter(f => f.severity === 'warning').length;
+	const infoCount = findings.filter(f => f.severity === 'info').length;
+
+	const parts: string[] = [
+		`Workflow "${workflow.name}" (${workflow.id}) — ${findings.length} issue(s): ${errorCount} error(s), ${warningCount} warning(s), ${infoCount} info(s).`,
+	];
+	for (const f of findings) {
+		parts.push(`[${f.severity.toUpperCase()}] ${f.rule}: ${f.message}`);
+	}
+	return parts.join('\n');
+}

--- a/src/workflow/specs.ts
+++ b/src/workflow/specs.ts
@@ -175,7 +175,17 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = withGeneratedArgsForAll([
 				workflowName: { type: 'string', description: 'The workflow name, shown in the approval prompt.' },
 				orgId: { type: 'string', description: 'The id of the org that owns the workflow.' },
 				orgName: { type: 'string', description: 'The org name, shown in the approval prompt.' },
-				input: { type: 'object', description: "The workflow's run inputs (maps input name to value)." },
+				input: {
+					type: 'object',
+					description:
+						"The workflow's run inputs (maps input name to value). Mutually exclusive with profile.",
+				},
+				profile: {
+					type: 'string',
+					description:
+						'Name of a saved input profile (from buddy_save_workflow_input_profile) to use as run inputs. ' +
+						'Mutually exclusive with input. A fresh approval is still required every time.',
+				},
 				wait: {
 					type: 'boolean',
 					description:

--- a/vitest.suites.mjs
+++ b/vitest.suites.mjs
@@ -19,4 +19,5 @@ export const vitestSuites = [
 	'src/test/tdd.test.ts',
 	'src/sessions/graphql/sdk.test.ts',
 	'src/ui/jinja/jinjaPreviewRender.test.ts',
+	'src/workflow/lint.test.ts',
 ];


### PR DESCRIPTION
Unified working PR for the remaining Epic #129 work.\n\nStarting baseline:\n- C2 read migration from PR #157 is included.\n- Good partial C2 write migration work is kept for tag, trigger, workflow CRUD, and shared helpers.\n- D3 tool consolidation/removal is completed on this branch, with retired aliases removed before later workstreams build on them.\n\nNext workstream: continue .claude/specs/c2-write-capabilities-zod-cleanup.md from commit 071c2aa.\n\nVerification for baseline commit 071c2aa:\n- npm run lint\n- npm run type-check\n- npm run test:unit\n- npm run changelog:check -- --base main

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added saved workflow input profiles for reusing run inputs.
  * Introduced a workflow lint check that highlights common workflow issues.
  * Workflow runs can now use a saved input profile instead of retyping JSON.

* **Bug Fixes**
  * Session restore is more reliable, especially when multiple sessions overlap.
  * Credential storage now avoids collisions between sessions for different users.

* **Changed**
  * Simplified several read tools, including template lookup, and updated input validation for more consistent behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->