### PR TITLE
Add Crate Installer feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Want to pull in **every template** from an organization at once? See the [Bulk F
 - Auto-fetch on open — picks up remote changes when you open a file
 - `Ctrl+Click` template navigation + hover info on `template('UUID')` calls
 - Template bundles — dependency-based grouping in the Explorer sidebar
+- Crate installer — browse the Crate catalog and install one into an org, with a config wizard built from the crate's own options (triggers install disabled by default)
 - Smart template opening — reuses existing linked files instead of creating untitled docs
 - File rename support + automatic stale link cleanup
 - Browser extension integration (sideload — not yet on the Chrome Web Store)

--- a/changelog.d/crate-installer.md
+++ b/changelog.d/crate-installer.md
@@ -2,4 +2,4 @@
 category: Added
 ---
 
-**Crate Installer** — `Install Crate` browses the Crate catalog and installs one into an org through a wizard built from the crate's own configuration options; the `buddy_unpack_crate` AI tool does the same with approval. Triggers install disabled by default.
+**Crate Installer** — browse the Crate catalog and install a Crate into an org with the new `Install Crate` command, through a guided wizard built from the crate's own configuration options. Triggers install disabled by default so nothing fires until you review them.

--- a/changelog.d/crate-installer.md
+++ b/changelog.d/crate-installer.md
@@ -1,0 +1,5 @@
+---
+category: Added
+---
+
+**Crate Installer** — `Install Crate` browses the Crate catalog and installs one into an org through a wizard built from the crate's own configuration options; the `buddy_unpack_crate` AI tool does the same with approval. Triggers install disabled by default.

--- a/docs/features.md
+++ b/docs/features.md
@@ -118,6 +118,21 @@ Templates that reference other templates via `{{ template('UUID') }}` are automa
 - **Auto-rebuild** — Bundles automatically update when templates are fetched or links change
 - **Manual rebuild** — Use `Rewst Buddy: Bundle Templates` from the command palette to refresh
 
+## Crate Installer
+
+Install prebuilt Rewst Crates without leaving VS Code. Run `Rewst Buddy: Install Crate` from the command palette:
+
+1. **Pick an organization** — the crate installs into the org you choose.
+2. **Browse the catalog** — a searchable list of every Crate visible to your session, with category and description; crates already installed in that org are marked with a check.
+3. **Configure dynamically** — each Crate declares its own configuration (free-text values, single- and multi-select options). The wizard is generated from that metadata: option tokens become pickers (defaults preselected), text tokens become input boxes (defaults prefilled), in the same order as Rewst's own unpack dialog.
+4. **Name the workflow** — defaults to the crate name.
+5. **Choose trigger state** — triggers install **disabled by default** so nothing fires until you review it in Rewst; you can opt into installing them enabled.
+6. **Confirm and watch progress** — a summary modal shows the org, workflow name, trigger choice, and any org variables the Crate requires; the install then streams progress in a notification.
+
+Cancelling any step aborts the install without changing anything.
+
+The same capability is available to AI assistants as the `buddy_unpack_crate` tool (behind the MCP write-tools setting and per-call approval): called without configuration values it reports exactly which tokens the crate needs — with their options and defaults — so an assistant can gather them and retry.
+
 ## Ask Rewst AI (Cage-Free Rewsty)
 
 Talk to Rewst's AI assistant directly from VS Code's chat — as its own model, **Cage-Free Rewsty** (the same RoboRewsty that powers the in-app chat, free-range in your editor), in the model picker. **No GitHub account or Copilot plan is required**: Cage-Free Rewsty carries the chat itself (VS Code 1.122+).

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -77,6 +77,10 @@ All commands are available via Command Palette (Cmd/Ctrl + Shift + P) under the 
 
 - `Bundle Templates` — Rebuild template bundle groupings
 
+**Crates**
+
+- `Install Crate` — Browse the Crate catalog and install one into an org, with a configuration wizard generated from the crate's own options. See [Crate Installer](features.md#crate-installer).
+
 **Sync & Maintenance**
 
 - `Sync Template` — Push changes with conflict detection

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -79,7 +79,7 @@ All commands are available via Command Palette (Cmd/Ctrl + Shift + P) under the 
 
 **Crates**
 
-- `Install Crate` — Browse the Crate catalog and install one into an org, with a configuration wizard generated from the crate's own options. See [Crate Installer](features.md#crate-installer).
+- `Install Crate` — Browse the Crate catalog and install one into an org, with a configuration wizard generated from the crate's own options; triggers install disabled by default. See [Crate Installer](features.md#crate-installer).
 
 **Sync & Maintenance**
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -1037,10 +1037,10 @@ disabled, and a modal confirmation summarizing the install before the unpack
 stream runs with visible progress. Cancelling any step SHALL abort the
 install without mutating anything.
 
-_Implementation status:_ the interactive flow is thin VS Code prompt wiring
-over the same planner the capability uses (`resolveTokenArguments`,
-`buildUnpackInput`, and the unpack stream client), which carries the unit
-coverage; the wizard itself has no automated UI test.
+_Implementation status:_ the interactive command builds the same unpack input
+as `buddy_unpack_crate` and shares its behavior guarantees; the full
+end-to-end wizard interaction (organization pick through confirmation) is
+exercised manually rather than by an automated UI test.
 
 #### Scenario: Dynamic token wizard
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -959,3 +959,98 @@ and existing workflows before building anew.
 
 - **WHEN** `buddy_search_crates` is called with an unknown `source` value
 - **THEN** the call is rejected with an error naming the valid sources
+
+### Requirement: Unpack a Crate into an organization
+
+The system SHALL expose `buddy_unpack_crate`, a write capability that installs
+(unpacks) one prebuilt Crate into one organization over the platform's unpack
+stream, gated by the write-tools setting and per-call approval like every
+other write capability. Because crates declare their own configuration
+dynamically as an ordered list of tokens (free-text inputs and single- or
+multi-select options), the capability SHALL resolve every value-bearing token
+from the caller-supplied values (keyed by token name or id) with fallback to
+the crate's own defaults, and when any token remains unresolved it SHALL
+return a structured `input_required` response describing each missing token
+(name, type, options, default, hint) and each default that resolved — without
+prompting or mutating — so the caller can retry with complete values. The
+unpack input SHALL mirror the shape the Rewst web unpack wizard sends: the
+workflow carries the crate's source-workflow name and time-savings figure (no
+org id — targeting is the top-level org id), every crate trigger (a crate can
+carry several) is covered with its own name and criteria forwarded from the
+underlying trigger, and multiselect token values are serialized as a
+Jinja-wrapped JSON list. The crate's triggers SHALL install disabled unless
+the caller explicitly enables them, and the success response SHALL name the
+unpacked workflow and any org variables the crate requires.
+
+#### Scenario: Discover a crate's configuration dynamically
+
+- **GIVEN** a crate whose tokens include one with neither a supplied value
+  nor a default
+- **WHEN** `buddy_unpack_crate` is called without covering that token
+- **THEN** the result is `input_required`, listing the missing token with its
+  type and options and the tokens that resolved via defaults
+- **AND** no approval is requested and nothing is mutated
+
+#### Scenario: Unpack with approval
+
+- **GIVEN** every value-bearing token resolves from supplied values or
+  defaults
+- **WHEN** `buddy_unpack_crate` is called and the user approves the prompt
+- **THEN** the unpack runs with token arguments in wizard order, triggers
+  defaulting to disabled, and the unpacked workflow id is reported along with
+  the crate's required org variables
+
+#### Scenario: Approval denied
+
+- **WHEN** the user denies the approval prompt
+- **THEN** the result is `approval_required` and the unpack stream is never
+  started
+
+#### Scenario: Multiselect token values
+
+- **WHEN** a multiselect token is supplied an array of option values
+- **THEN** the values are serialized into the single Jinja-wrapped JSON list
+  token argument the platform expects
+
+#### Scenario: Multiple triggers
+
+- **GIVEN** a crate that carries several triggers
+- **WHEN** the unpack input is built
+- **THEN** every crate trigger is included, each with its own trigger name and
+  criteria and its underlying trigger's managed-orgs default
+
+#### Scenario: Unknown crate
+
+- **WHEN** `buddy_unpack_crate` names a crate id that is not visible to the
+  session
+- **THEN** the call is rejected with an error naming the crate id
+
+### Requirement: Install a Crate interactively
+
+The system SHALL provide an `Install Crate` command that walks the user from
+crate discovery to a completed install: an organization pick, a searchable
+catalog pick that marks already-installed crates, a configuration wizard
+generated dynamically from the crate's token metadata (option pickers for
+select tokens including multi-select, prefilled input boxes for free-text
+tokens), a workflow-name prompt, a trigger enablement choice defaulting to
+disabled, and a modal confirmation summarizing the install before the unpack
+stream runs with visible progress. Cancelling any step SHALL abort the
+install without mutating anything.
+
+_Implementation status:_ the interactive flow is thin VS Code prompt wiring
+over the same planner the capability uses (`resolveTokenArguments`,
+`buildUnpackInput`, and the unpack stream client), which carries the unit
+coverage; the wizard itself has no automated UI test.
+
+#### Scenario: Dynamic token wizard
+
+- **GIVEN** a crate with a free-text token and a multiselect token
+- **WHEN** the user runs `Install Crate` and selects the crate
+- **THEN** the free-text token prompts with its default prefilled and the
+  multiselect token offers its options with defaults preselected, in the
+  crate's wizard order
+
+#### Scenario: Cancel aborts cleanly
+
+- **WHEN** the user dismisses any wizard step or the final confirmation
+- **THEN** the command returns without starting the unpack stream

--- a/package.json
+++ b/package.json
@@ -357,6 +357,10 @@
 				"title": "Rewst Buddy: Open Template"
 			},
 			{
+				"command": "rewst-buddy.prefix.InstallCrate",
+				"title": "Rewst Buddy: Install Crate"
+			},
+			{
 				"command": "rewst-buddy.prefix.UnlinkAllTemplates",
 				"title": "Rewst Buddy: Unlink All Templates"
 			},
@@ -571,6 +575,10 @@
 				},
 				{
 					"command": "rewst-buddy.prefix.OpenTemplateInteractive",
+					"when": "rewst-buddy.anyActiveSessions"
+				},
+				{
+					"command": "rewst-buddy.prefix.InstallCrate",
 					"when": "rewst-buddy.anyActiveSessions"
 				},
 				{

--- a/src/capabilities/crateUnpackCapability.test.ts
+++ b/src/capabilities/crateUnpackCapability.test.ts
@@ -1,0 +1,311 @@
+import type { Session } from '@sessions';
+import { createMockSession, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { listTools } from '../mcp/McpActions';
+import type { McpSettings } from '../mcp/settings';
+import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { CapabilityContext } from './Capability';
+import { _resetMcpMutationApproverForTesting, setMcpMutationApprover } from './graphqlMutateCapability';
+import {
+	_setUnpackTransportForTesting,
+	crateUnpackCapability,
+	type UnpackOutcome,
+	type UnpackTransportOptions,
+} from './crateUnpackCapability';
+import { getCapability } from './registry';
+
+const { suite, test, setup, teardown } = Mocha;
+
+const CRATE_ROW = {
+	id: 'crate-1',
+	name: 'User Onboarding',
+	description: 'Full onboarding',
+	requiredOrgVariables: ['ORG_VAR'],
+	isUnpackedForSelectedOrg: false,
+	workflow: { name: 'Onboarding Flow', humanSecondsSaved: 900 },
+	tokens: [
+		{ id: 'tok-1', name: 'Team Name', type: 'inputVar', index: 0, options: [] },
+		{
+			id: 'tok-2',
+			name: 'Channel',
+			type: 'selectVar',
+			index: 1,
+			options: [{ id: 'o-1', label: 'General', value: 'general', isDefault: true }],
+		},
+	],
+	crateTriggers: [
+		{
+			id: 'ct-1',
+			trigger: {
+				id: 'tr-1',
+				name: 'On Form Submit',
+				criteria: { condition: {} },
+				autoActivateManagedOrgs: false,
+			},
+		},
+	],
+};
+
+function useRawGraphqlWrapper(session: Session, wrapper: ReturnType<typeof createMockSession>['wrapper']): void {
+	const wrap = wrapper.getWrapper();
+	(session as { rawGraphql: Session['rawGraphql'] }).rawGraphql = async (query, variables) => {
+		return wrap(async () => ({ data: undefined, errors: undefined }), 'rawGraphql', 'query RewstBuddyCrateDetail', {
+			query,
+			variables,
+		});
+	};
+}
+
+function sandboxCtx(orgId = 'org-sandbox', name = 'Sandbox') {
+	const { session, wrapper } = createMockSession({ profile: { org: { id: orgId, name } } });
+	useRawGraphqlWrapper(session, wrapper);
+	const ctx: CapabilityContext = { session, orgId, sessions: [session] };
+	return { ctx, wrapper };
+}
+
+suite('Unit: crateUnpackCapability', () => {
+	let transportCalls: UnpackTransportOptions[];
+
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		transportCalls = [];
+		_setUnpackTransportForTesting(async (opts): Promise<UnpackOutcome> => {
+			transportCalls.push(opts);
+			return { id: 'wf-9', orgId: opts.input.orgId, type: 'workflow' };
+		});
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+		_setUnpackTransportForTesting(undefined);
+	});
+
+	test('registered write capability requiring org, crateId, and orgId', () => {
+		const cap = getCapability('buddy_unpack_crate');
+		assert.ok(cap, 'buddy_unpack_crate is registered');
+		assert.strictEqual(cap, crateUnpackCapability);
+		assert.strictEqual(cap.access, 'write');
+		assert.notStrictEqual(cap.requiresOrg, false);
+		const schema = cap.spec.inputSchema as { required: string[]; properties: Record<string, unknown> };
+		assert.deepStrictEqual([...schema.required].sort(), ['crateId', 'orgId']);
+		assert.ok('workflowName' in schema.properties);
+		assert.ok('tokenValues' in schema.properties);
+		assert.ok('enableTriggers' in schema.properties);
+	});
+
+	test('unpacks with approval: fetches detail, builds input, reports the unpacked workflow', async () => {
+		const { ctx, wrapper } = sandboxCtx();
+		wrapper.when('rawGraphql', { data: { data: { crate: CRATE_ROW } } });
+		let seenScope: MutationScope | undefined;
+		let seenSummary = '';
+		setMcpMutationApprover(async (scope, summary) => {
+			seenScope = scope;
+			seenSummary = summary;
+			return true;
+		});
+
+		const output = await crateUnpackCapability.run(
+			{ orgId: 'org-sandbox', crateId: 'crate-1', tokenValues: { 'Team Name': 'Acme' } },
+			ctx,
+		);
+
+		// Detail query carried the crate + org.
+		const calls = wrapper.getCallsFor('rawGraphql');
+		assert.strictEqual(calls.length, 1);
+		const vars = (calls[0].variables as { variables: Record<string, unknown> }).variables;
+		assert.strictEqual(vars.crateId, 'crate-1');
+		assert.strictEqual(vars.orgId, 'org-sandbox');
+
+		// Approval names the crate and the target org.
+		assert.ok(seenScope);
+		assert.strictEqual(seenScope.orgId, 'org-sandbox');
+		assert.strictEqual(seenScope.scopeName, 'User Onboarding');
+		assert.ok(seenSummary.includes('User Onboarding'));
+		assert.ok(seenSummary.includes('org-sandbox'));
+
+		// Transport received the fully built input, shaped like the web unpack wizard's.
+		assert.strictEqual(transportCalls.length, 1);
+		assert.deepStrictEqual(transportCalls[0].input, {
+			crateId: 'crate-1',
+			orgId: 'org-sandbox',
+			tokenArguments: [
+				{ crateTokenId: 'tok-1', value: 'Acme' },
+				{ crateTokenId: 'tok-2', value: 'general' },
+			],
+			triggers: [
+				{
+					crateTriggerId: 'ct-1',
+					triggerName: 'On Form Submit',
+					enabled: false,
+					isActivatedForOwner: true,
+					autoActivateManagedOrgs: false,
+					activateForOrgIds: [],
+					activateForTagIds: [],
+					criteria: { condition: {} },
+				},
+			],
+			workflow: { name: 'Onboarding Flow', humanSecondsSaved: 900 },
+		});
+
+		const parsed = JSON.parse(output);
+		assert.strictEqual(parsed.status, 'unpacked');
+		assert.strictEqual(parsed.unpackedId, 'wf-9');
+		assert.strictEqual(parsed.crateName, 'User Onboarding');
+		assert.strictEqual(parsed.workflowName, 'Onboarding Flow');
+		assert.deepStrictEqual(parsed.requiredOrgVariables, ['ORG_VAR']);
+	});
+
+	test('does not unpack when approval is denied', async () => {
+		const { ctx, wrapper } = sandboxCtx();
+		wrapper.when('rawGraphql', { data: { data: { crate: CRATE_ROW } } });
+		setMcpMutationApprover(async () => false);
+
+		const output = await crateUnpackCapability.run(
+			{ orgId: 'org-sandbox', crateId: 'crate-1', tokenValues: { 'Team Name': 'Acme' } },
+			ctx,
+		);
+
+		assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		assert.strictEqual(transportCalls.length, 0, 'transport never invoked');
+	});
+
+	test('missing token values return a structured input_required list before requesting approval', async () => {
+		const { ctx, wrapper } = sandboxCtx();
+		wrapper.when('rawGraphql', { data: { data: { crate: CRATE_ROW } } });
+		let approverCalled = false;
+		setMcpMutationApprover(async () => {
+			approverCalled = true;
+			return true;
+		});
+
+		const output = await crateUnpackCapability.run({ orgId: 'org-sandbox', crateId: 'crate-1' }, ctx);
+		const parsed = JSON.parse(output);
+		assert.strictEqual(parsed.status, 'input_required');
+		// The one token with neither a provided value nor a default is described
+		// dynamically: name, type, and its options so the caller can prompt or pick.
+		assert.strictEqual(parsed.missingTokens.length, 1);
+		assert.strictEqual(parsed.missingTokens[0].name, 'Team Name');
+		assert.strictEqual(parsed.missingTokens[0].type, 'inputVar');
+		// Tokens that resolved via defaults are reported too, so the caller can
+		// override them in the same retry if the defaults are wrong.
+		const resolved = parsed.resolvedTokens as { name: string; value: string }[];
+		assert.deepStrictEqual(resolved, [{ name: 'Channel', value: 'general' }]);
+		assert.strictEqual(approverCalled, false, 'approval never requested');
+		assert.strictEqual(transportCalls.length, 0, 'transport never invoked');
+	});
+
+	test('select tokens surface their option labels and values in input_required', async () => {
+		const { ctx, wrapper } = sandboxCtx();
+		const row = {
+			...CRATE_ROW,
+			tokens: [
+				{
+					id: 'tok-sel',
+					name: 'Region',
+					type: 'selectVar',
+					index: 0,
+					// No default option — must be surfaced with its choices.
+					options: [
+						{ id: 'o-1', label: 'US East', value: 'us-east', isDefault: false },
+						{ id: 'o-2', label: 'EU West', value: 'eu-west', isDefault: false },
+					],
+				},
+			],
+		};
+		wrapper.when('rawGraphql', { data: { data: { crate: row } } });
+
+		const output = await crateUnpackCapability.run({ orgId: 'org-sandbox', crateId: 'crate-1' }, ctx);
+		const parsed = JSON.parse(output);
+		assert.strictEqual(parsed.status, 'input_required');
+		assert.strictEqual(parsed.missingTokens.length, 1);
+		const missing = parsed.missingTokens[0];
+		assert.strictEqual(missing.name, 'Region');
+		assert.deepStrictEqual(
+			missing.options.map((o: { value: string }) => o.value),
+			['us-east', 'eu-west'],
+			'select options listed for dynamic prompting',
+		);
+		assert.strictEqual(transportCalls.length, 0);
+	});
+
+	test('multiselect tokens accept an array of values', async () => {
+		const { ctx, wrapper } = sandboxCtx();
+		const row = {
+			...CRATE_ROW,
+			tokens: [
+				{
+					id: 'tok-multi',
+					name: 'Channels',
+					type: 'selectVar',
+					index: 0,
+					isMultiselect: true,
+					options: [
+						{ id: 'o-1', label: 'General', value: 'general', isDefault: false },
+						{ id: 'o-2', label: 'Alerts', value: 'alerts', isDefault: false },
+					],
+				},
+			],
+		};
+		wrapper.when('rawGraphql', { data: { data: { crate: row } } });
+		setMcpMutationApprover(async () => true);
+
+		const output = await crateUnpackCapability.run(
+			{ orgId: 'org-sandbox', crateId: 'crate-1', tokenValues: { Channels: ['general', 'alerts'] } },
+			ctx,
+		);
+
+		assert.strictEqual(JSON.parse(output).status, 'unpacked');
+		assert.strictEqual(transportCalls.length, 1);
+		// Multiselect values ride as the Jinja-wrapped JSON list the platform expects.
+		assert.deepStrictEqual(transportCalls[0].input.tokenArguments, [
+			{ crateTokenId: 'tok-multi', value: '{{ ["general","alerts"] }}' },
+		]);
+	});
+
+	test('exposed to chat and MCP only when write tools are enabled', () => {
+		// Cage-Free Rewsty's chat tools mirror listTools() (buddyChatToolSpecs), so
+		// this pins both surfaces: hidden while write tools are off, listed when on.
+		const settings = (enableWriteTools: boolean): McpSettings => ({
+			enable: true,
+			enableWriteTools,
+			enableDangerousGraphqlMutation: false,
+			alwaysAllowedOrgs: [],
+			workingOrgScope: 'strict',
+		});
+		const withoutWrite = listTools(settings(false)).map(tool => tool.name);
+		assert.ok(!withoutWrite.includes('buddy_unpack_crate'), 'hidden while write tools are disabled');
+		const withWrite = listTools(settings(true)).map(tool => tool.name);
+		assert.ok(withWrite.includes('buddy_unpack_crate'), 'listed once write tools are enabled');
+	});
+
+	test('unknown crate rejects', async () => {
+		const { ctx, wrapper } = sandboxCtx();
+		wrapper.when('rawGraphql', { data: { data: { crate: null } } });
+
+		await assert.rejects(
+			() => crateUnpackCapability.run({ orgId: 'org-sandbox', crateId: 'crate-x' }, ctx),
+			(err: Error) => {
+				assert.ok(err.message.includes('crate-x'), 'error names the crate id');
+				return true;
+			},
+		);
+		assert.strictEqual(transportCalls.length, 0);
+	});
+
+	test('GraphQL errors propagate', async () => {
+		const { ctx, wrapper } = sandboxCtx();
+		wrapper.when('rawGraphql', { data: { data: undefined, errors: [{ message: 'crate error' }] } });
+
+		await assert.rejects(
+			() => crateUnpackCapability.run({ orgId: 'org-sandbox', crateId: 'crate-1' }, ctx),
+			(err: Error) => {
+				assert.ok(err.message.includes('GraphQL error'));
+				return true;
+			},
+		);
+	});
+});

--- a/src/capabilities/crateUnpackCapability.test.ts
+++ b/src/capabilities/crateUnpackCapability.test.ts
@@ -282,6 +282,27 @@ suite('Unit: crateUnpackCapability', () => {
 		assert.ok(withWrite.includes('buddy_unpack_crate'), 'listed once write tools are enabled');
 	});
 
+	test('a transport failure after approval rejects with the transport error', async () => {
+		const { ctx, wrapper } = sandboxCtx();
+		wrapper.when('rawGraphql', { data: { data: { crate: CRATE_ROW } } });
+		setMcpMutationApprover(async () => true);
+		_setUnpackTransportForTesting(async () => {
+			throw new Error('websocket closed before the unpack finished');
+		});
+
+		await assert.rejects(
+			() =>
+				crateUnpackCapability.run(
+					{ orgId: 'org-sandbox', crateId: 'crate-1', tokenValues: { 'Team Name': 'Acme' } },
+					ctx,
+				),
+			(err: Error) => {
+				assert.ok(err.message.includes('websocket closed'), 'transport error surfaces to the caller');
+				return true;
+			},
+		);
+	});
+
 	test('unknown crate rejects', async () => {
 		const { ctx, wrapper } = sandboxCtx();
 		wrapper.when('rawGraphql', { data: { data: { crate: null } } });

--- a/src/capabilities/crateUnpackCapability.ts
+++ b/src/capabilities/crateUnpackCapability.ts
@@ -1,0 +1,163 @@
+import { z } from 'zod';
+import {
+	buildUnpackInput,
+	CRATE_DETAIL_QUERY,
+	parseCrateDetail,
+	resolveTokenArguments,
+	tokenDefault,
+	type CrateDetail,
+	type CrateTokenDetail,
+	type TokenValues,
+	type UnpackSuccess,
+} from '../crates/crateUnpack';
+import { runUnpackCrate, type UnpackTransportOptions } from '../crates/unpackClient';
+import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
+import type { MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { Capability, CapabilityContext } from './Capability';
+import { writeCapability } from './capabilityFactories';
+import {
+	json,
+	ORG_ID_FIELD,
+	parseCapabilityInput,
+	rawGraphqlOrThrow,
+	requiredStringField,
+	toInputSchema,
+} from './inputHelpers';
+import { orgDisplayName, withMutationApproval } from './mutationApproval';
+
+/**
+ * buddy_unpack_crate — install ("unpack") a prebuilt Rewst Crate into an org.
+ *
+ * Crates configure themselves dynamically through tokens (free-text inputs and
+ * single/multi selects with option lists), so this capability is a two-step
+ * conversation: called without enough token values it returns a structured
+ * `input_required` payload describing exactly what the crate needs (never
+ * prompting or mutating), and called with every value resolvable it runs the
+ * unpackCrate subscription behind the standard per-call write approval.
+ */
+
+export type UnpackOutcome = UnpackSuccess;
+export type { UnpackTransportOptions };
+
+type UnpackTransport = (options: UnpackTransportOptions) => Promise<UnpackOutcome>;
+
+let unpackTransport: UnpackTransport = runUnpackCrate;
+
+/** Replaces the websocket transport in unit tests; pass undefined to restore. */
+export function _setUnpackTransportForTesting(transport: UnpackTransport | undefined): void {
+	unpackTransport = transport ?? runUnpackCrate;
+}
+
+const tokenValuesSchema: z.ZodType<TokenValues | undefined> = z
+	.record(z.string(), z.union([z.string(), z.array(z.string())]))
+	.optional()
+	.describe(
+		"Values for the crate's configuration tokens, keyed by token name (or token id). Multiselect tokens accept an array of option values. Call once without this to discover what the crate needs — the input_required response lists every token with its type, options, and default.",
+	);
+
+const unpackCrateInputSchema = z.object({
+	orgId: ORG_ID_FIELD,
+	crateId: requiredStringField('crateId').describe('Id of the crate to unpack (from buddy_search_crates).'),
+	workflowName: z
+		.preprocess(raw => (typeof raw === 'string' ? raw.trim() : raw), z.string().min(1).optional())
+		.catch(undefined)
+		.describe('Name for the unpacked workflow; defaults to the crate name.') as z.ZodType<string | undefined>,
+	tokenValues: tokenValuesSchema,
+	enableTriggers: z
+		.boolean()
+		.optional()
+		.describe(
+			"Whether the crate's triggers install enabled. Defaults to false — the safe default installs triggers disabled so nothing fires until a human reviews them in Rewst.",
+		),
+});
+
+/** One missing token, described richly enough to prompt or pick dynamically. */
+function describeToken(token: CrateTokenDetail): Record<string, unknown> {
+	const described: Record<string, unknown> = {
+		id: token.id,
+		name: token.name,
+		type: token.type,
+	};
+	if (token.isMultiselect === true) described.isMultiselect = true;
+	if (token.previewText !== undefined) described.hint = token.previewText;
+	if (token.emptyLabel !== undefined) described.emptyLabel = token.emptyLabel;
+	const defaultValue = tokenDefault(token);
+	if (defaultValue !== undefined) described.default = defaultValue;
+	if (token.options.length > 0) {
+		described.options = token.options.map(option => ({
+			label: option.label,
+			value: option.value,
+			isDefault: option.isDefault === true || undefined,
+		}));
+	}
+	return described;
+}
+
+async function fetchCrateDetail(ctx: CapabilityContext, crateId: string, orgId: string): Promise<CrateDetail> {
+	const data = await rawGraphqlOrThrow(ctx.session, CRATE_DETAIL_QUERY, { crateId, orgId });
+	const crate = parseCrateDetail(data);
+	if (!crate) {
+		throw new Error(`Crate ${crateId} was not found or is not visible to this session.`);
+	}
+	return crate;
+}
+
+async function runUnpackCrateCapability(input: Record<string, unknown>, ctx: CapabilityContext): Promise<string> {
+	const parsed = parseCapabilityInput(unpackCrateInputSchema, input);
+	const { orgId, crateId, workflowName, enableTriggers } = parsed;
+	const tokenValues = parsed.tokenValues ?? {};
+
+	const crate = await fetchCrateDetail(ctx, crateId, orgId);
+
+	// Dynamic configuration handshake: when anything the crate needs is still
+	// unresolved, describe every gap (and what resolved via defaults, so those
+	// can be overridden in the same retry) instead of prompting or mutating.
+	const resolution = resolveTokenArguments(crate.tokens, tokenValues);
+	if (resolution.missing.length > 0) {
+		return json({
+			status: 'input_required',
+			crateId: crate.id,
+			crateName: crate.name,
+			message:
+				'The crate needs values for the tokens below. Retry with tokenValues covering at least the missing tokens (keyed by token name or id); resolvedTokens show defaults that will be used unless overridden.',
+			missingTokens: resolution.missing.map(describeToken),
+			resolvedTokens: resolution.defaulted.map(({ token, value }) => ({
+				name: token.name ?? token.id,
+				value,
+			})),
+			requiredOrgVariables: crate.requiredOrgVariables,
+		});
+	}
+
+	const unpackInput = buildUnpackInput(crate, { orgId, workflowName, tokenValues, enableTriggers });
+
+	const orgName = orgDisplayName(ctx);
+	const scope: MutationScope = { scopeId: crate.id, scopeName: crate.name, orgId, orgName };
+	const summary = `Unpack crate "${crate.name}" (${crate.id}) into org "${orgName}" (${orgId}) as workflow "${unpackInput.workflow.name}"`;
+
+	return withMutationApproval(scope, summary, async () => {
+		const outcome = await unpackTransport({ session: ctx.session, input: unpackInput });
+		return json({
+			status: 'unpacked',
+			crateId: crate.id,
+			crateName: crate.name,
+			orgId,
+			workflowName: unpackInput.workflow.name,
+			unpackedId: outcome.id,
+			unpackedType: outcome.type,
+			triggersEnabled: enableTriggers === true,
+			// Org variables the crate expects to exist; surface them so the caller
+			// can verify or create them (buddy_list_org_variables / create).
+			requiredOrgVariables: crate.requiredOrgVariables,
+		});
+	});
+}
+
+const unpackCrateSpec: ToolSpecDefinition = {
+	name: 'buddy_unpack_crate',
+	description:
+		'Unpack (install) a prebuilt Rewst Crate into one organization, creating its workflow and triggers. Crates declare their own configuration tokens; call this without tokenValues first and it returns input_required listing every token the crate needs (with types, options, and defaults) — then retry with tokenValues filled in. Triggers install disabled unless enableTriggers is true. Requires write tools to be enabled and per-call approval in VS Code. Use buddy_search_crates to find crate ids.',
+	inputSchema: toInputSchema(unpackCrateInputSchema),
+};
+
+export const crateUnpackCapability: Capability = writeCapability(unpackCrateSpec, runUnpackCrateCapability);

--- a/src/capabilities/registry.ts
+++ b/src/capabilities/registry.ts
@@ -5,6 +5,7 @@ import {
 	graphqlSchemaCapability,
 } from './chatToolCapabilities';
 import { CRATE_CAPABILITIES } from './crateCapabilities';
+import { crateUnpackCapability } from './crateUnpackCapability';
 import { graphqlMutateCapability } from './graphqlMutateCapability';
 import { JINJA_DOCS_CAPABILITIES } from './jinjaDocsCapabilities';
 import { ORG_USER_CAPABILITIES } from './orgUserCapabilities';
@@ -50,6 +51,7 @@ export const CAPABILITY_REGISTRY: Capability[] = [
 	...WORKING_SCOPE_CAPABILITIES,
 	...JINJA_DOCS_CAPABILITIES,
 	...CRATE_CAPABILITIES,
+	crateUnpackCapability,
 	workflowImpactCapability,
 	graphqlMutateCapability,
 	resultReadCapability,

--- a/src/commands/crates/InstallCrate.test.ts
+++ b/src/commands/crates/InstallCrate.test.ts
@@ -1,0 +1,191 @@
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import vscode from 'vscode';
+import type { CrateDetail, CrateTokenDetail } from '../../crates/crateUnpack';
+import { collectTokenValues, crateQuickPickItems, promptInputToken, promptSelectToken } from './InstallCrate';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function token(overrides: Partial<CrateTokenDetail> = {}): CrateTokenDetail {
+	return {
+		id: 'tok-1',
+		name: 'Token One',
+		type: 'inputVar',
+		index: 0,
+		options: [],
+		...overrides,
+	};
+}
+
+function crate(overrides: Partial<CrateDetail> = {}): CrateDetail {
+	return {
+		id: 'crate-1',
+		name: 'User Onboarding',
+		requiredOrgVariables: [],
+		tokens: [],
+		crateTriggers: [],
+		...overrides,
+	};
+}
+
+suite('Unit: InstallCrate wizard helpers', () => {
+	const originalShowQuickPick = vscode.window.showQuickPick;
+	const originalShowInputBox = vscode.window.showInputBox;
+
+	setup(() => {
+		initTestEnvironment();
+	});
+
+	teardown(() => {
+		vscode.window.showQuickPick = originalShowQuickPick;
+		vscode.window.showInputBox = originalShowInputBox;
+	});
+
+	suite('crateQuickPickItems()', () => {
+		test('maps rows, drops id-less rows, and marks installed crates', () => {
+			const items = crateQuickPickItems([
+				{ id: 'c-1', name: 'Alpha', category: 'Ops', description: 'First', isUnpackedForSelectedOrg: false },
+				{ id: 'c-2', name: 'Beta', category: null, description: null, isUnpackedForSelectedOrg: true },
+				{ id: null, name: 'Ghost' },
+			]);
+			assert.strictEqual(items.length, 2, 'row without an id is dropped');
+
+			assert.strictEqual(items[0].crateId, 'c-1');
+			assert.strictEqual(items[0].label, 'Alpha');
+			assert.strictEqual(items[0].description, 'Ops');
+			assert.strictEqual(items[0].detail, 'First');
+
+			assert.strictEqual(items[1].crateId, 'c-2');
+			assert.strictEqual(items[1].label, '$(check) Beta', 'installed crates carry the check icon');
+			assert.strictEqual(items[1].description, 'already installed');
+		});
+	});
+
+	suite('promptSelectToken()', () => {
+		test('single-select offers option labels with the default tagged and returns the picked value', async () => {
+			let seenItems: readonly { label: string; description?: string; value: string }[] = [];
+			let seenOptions: { placeHolder?: string; canPickMany?: boolean } = {};
+			vscode.window.showQuickPick = (async (items: never, options: never) => {
+				seenItems = await items;
+				seenOptions = options ?? {};
+				return seenItems[1];
+			}) as unknown as typeof vscode.window.showQuickPick;
+
+			const value = await promptSelectToken(
+				token({
+					name: 'Region',
+					type: 'selectVar',
+					options: [
+						{ id: 'o-1', label: 'US East', value: 'us-east', isDefault: true },
+						{ id: 'o-2', label: 'EU West', value: 'eu-west', isDefault: false },
+						{ id: 'o-3', label: 'Broken', value: undefined, isDefault: false },
+					],
+				}),
+			);
+
+			assert.strictEqual(value, 'eu-west');
+			assert.strictEqual(seenOptions.placeHolder, 'Region');
+			assert.notStrictEqual(seenOptions.canPickMany, true);
+			assert.deepStrictEqual(
+				seenItems.map(item => item.label),
+				['US East', 'EU West'],
+				'value-less options are dropped',
+			);
+			assert.strictEqual(seenItems[0].description, 'default', 'default option is tagged');
+		});
+
+		test('multiselect preselects defaults and returns every picked value', async () => {
+			let seenItems: readonly { picked?: boolean; value: string }[] = [];
+			vscode.window.showQuickPick = (async (items: never, options: { canPickMany?: boolean }) => {
+				seenItems = await items;
+				assert.strictEqual(options.canPickMany, true, 'multiselect uses canPickMany');
+				return seenItems.filter(item => item.picked);
+			}) as unknown as typeof vscode.window.showQuickPick;
+
+			const value = await promptSelectToken(
+				token({
+					name: 'Channels',
+					type: 'selectVar',
+					isMultiselect: true,
+					options: [
+						{ id: 'o-1', label: 'General', value: 'general', isDefault: true },
+						{ id: 'o-2', label: 'Alerts', value: 'alerts', isDefault: true },
+						{ id: 'o-3', label: 'Random', value: 'random', isDefault: false },
+					],
+				}),
+			);
+
+			assert.deepStrictEqual(value, ['general', 'alerts'], 'default options come back preselected');
+			assert.deepStrictEqual(
+				seenItems.map(item => item.picked),
+				[true, true, false],
+			);
+		});
+	});
+
+	suite('promptInputToken()', () => {
+		test('prefills the token default and hint', async () => {
+			let seenOptions: { prompt?: string; value?: string; placeHolder?: string } = {};
+			vscode.window.showInputBox = (async (options: never) => {
+				seenOptions = options ?? {};
+				return 'typed value';
+			}) as unknown as typeof vscode.window.showInputBox;
+
+			const value = await promptInputToken(
+				token({ name: 'Team Name', value: 'Acme Default', previewText: 'e.g. Contoso' }),
+			);
+
+			assert.strictEqual(value, 'typed value');
+			assert.strictEqual(seenOptions.prompt, 'Team Name');
+			assert.strictEqual(seenOptions.value, 'Acme Default', 'default prefilled');
+			assert.strictEqual(seenOptions.placeHolder, 'e.g. Contoso');
+		});
+	});
+
+	suite('collectTokenValues()', () => {
+		test('walks value tokens in wizard order with step labels, keying values by token id', async () => {
+			const prompts: string[] = [];
+			vscode.window.showInputBox = (async (options: { prompt?: string }) => {
+				prompts.push(options.prompt ?? '');
+				return `answer-${prompts.length}`;
+			}) as unknown as typeof vscode.window.showInputBox;
+			vscode.window.showQuickPick = (async (items: never, options: { placeHolder?: string }) => {
+				prompts.push(options.placeHolder ?? '');
+				const resolved = (await items) as { value: string }[];
+				return resolved[0];
+			}) as unknown as typeof vscode.window.showQuickPick;
+
+			const values = await collectTokenValues(
+				crate({
+					tokens: [
+						token({ id: 'tok-note', name: 'Note', type: 'text', index: 0 }),
+						token({ id: 'tok-team', name: 'Team', type: 'inputVar', index: 1 }),
+						token({
+							id: 'tok-region',
+							name: 'Region',
+							type: 'selectVar',
+							index: 2,
+							options: [{ id: 'o-1', label: 'US', value: 'us', isDefault: true }],
+						}),
+					],
+				}),
+			);
+
+			// Display-only token is skipped; both value tokens prompt in order with
+			// step labels counting only the value tokens.
+			assert.deepStrictEqual(prompts, ['Team (1/2)', 'Region (2/2)']);
+			assert.deepStrictEqual(values, { 'tok-team': 'answer-1', 'tok-region': 'us' });
+		});
+
+		test('cancelling any step aborts with undefined', async () => {
+			vscode.window.showInputBox = (async () => undefined) as unknown as typeof vscode.window.showInputBox;
+
+			const values = await collectTokenValues(
+				crate({ tokens: [token({ id: 'tok-team', name: 'Team', type: 'inputVar' })] }),
+			);
+
+			assert.strictEqual(values, undefined);
+		});
+	});
+});

--- a/src/commands/crates/InstallCrate.ts
+++ b/src/commands/crates/InstallCrate.ts
@@ -27,7 +27,7 @@ import GenericCommand from '../GenericCommand';
  * default so nothing fires until reviewed in Rewst.
  */
 
-interface CrateListRow {
+export interface CrateListRow {
 	id?: string | null;
 	name?: string | null;
 	category?: string | null;
@@ -35,22 +35,18 @@ interface CrateListRow {
 	isUnpackedForSelectedOrg?: boolean | null;
 }
 
-interface CrateQuickPickItem extends vscode.QuickPickItem {
+export interface CrateQuickPickItem extends vscode.QuickPickItem {
 	crateId: string;
 }
 
 const CRATE_LIST_LIMIT = 500;
 
-async function pickCrate(session: Session, orgId: string): Promise<string | undefined> {
-	const crates = await vscode.window.withProgress(
-		{ location: vscode.ProgressLocation.Notification, title: 'Loading Crate catalog…' },
-		async () => {
-			const data = await rawGraphqlOrThrow(session, CRATE_LIST_QUERY, { orgId, limit: CRATE_LIST_LIMIT });
-			return (data as { crates?: CrateListRow[] | null } | undefined)?.crates ?? [];
-		},
-	);
-
-	const items: CrateQuickPickItem[] = crates
+/**
+ * Maps catalog rows to QuickPick items: rows without an id are dropped, and
+ * already-installed crates carry a check icon and an "already installed" tag.
+ */
+export function crateQuickPickItems(crates: readonly CrateListRow[]): CrateQuickPickItem[] {
+	return crates
 		.filter((crate): crate is CrateListRow & { id: string } => typeof crate.id === 'string' && crate.id.length > 0)
 		.map(crate => ({
 			crateId: crate.id,
@@ -66,7 +62,18 @@ async function pickCrate(session: Session, orgId: string): Promise<string | unde
 				.join(' — '),
 			detail: crate.description ?? undefined,
 		}));
+}
 
+async function pickCrate(session: Session, orgId: string): Promise<string | undefined> {
+	const crates = await vscode.window.withProgress(
+		{ location: vscode.ProgressLocation.Notification, title: 'Loading Crate catalog…' },
+		async () => {
+			const data = await rawGraphqlOrThrow(session, CRATE_LIST_QUERY, { orgId, limit: CRATE_LIST_LIMIT });
+			return (data as { crates?: CrateListRow[] | null } | undefined)?.crates ?? [];
+		},
+	);
+
+	const items = crateQuickPickItems(crates);
 	if (items.length === 0) {
 		log.notifyInfo('No Crates are visible to this session.');
 		return undefined;
@@ -81,7 +88,7 @@ async function pickCrate(session: Session, orgId: string): Promise<string | unde
 }
 
 /** Collects a value for one select token; undefined means the user backed out. */
-async function promptSelectToken(token: CrateTokenDetail): Promise<string | string[] | undefined> {
+export async function promptSelectToken(token: CrateTokenDetail): Promise<string | string[] | undefined> {
 	const defaultValue = tokenDefault(token);
 	const items = token.options
 		.filter(option => option.value !== undefined)
@@ -107,7 +114,7 @@ async function promptSelectToken(token: CrateTokenDetail): Promise<string | stri
 }
 
 /** Collects a value for one free-text token; undefined means backed out. */
-async function promptInputToken(token: CrateTokenDetail): Promise<string | undefined> {
+export async function promptInputToken(token: CrateTokenDetail): Promise<string | undefined> {
 	return vscode.window.showInputBox({
 		prompt: token.name,
 		value: tokenDefault(token) ?? '',
@@ -120,7 +127,7 @@ async function promptInputToken(token: CrateTokenDetail): Promise<string | undef
  * Walks the crate's value-bearing tokens in wizard order, prompting for each
  * (defaults prefilled). Returns undefined when the user cancels any step.
  */
-async function collectTokenValues(crate: CrateDetail): Promise<TokenValues | undefined> {
+export async function collectTokenValues(crate: CrateDetail): Promise<TokenValues | undefined> {
 	const values: TokenValues = {};
 	const valueTokens = crate.tokens.filter(token => isValueToken(token) && token.id !== undefined);
 	for (const [position, token] of valueTokens.entries()) {
@@ -175,9 +182,18 @@ export class InstallCrate extends GenericCommand {
 			enableTriggers = triggerChoice.enabled;
 		}
 
+		// Build the input before confirming so the preview shows exactly what will
+		// run — including the resolved workflow name when the input box was cleared.
+		const input = buildUnpackInput(crate, {
+			orgId: org.id,
+			workflowName: workflowName || undefined,
+			tokenValues,
+			enableTriggers,
+		});
+
 		const detailLines = [
 			`Organization: ${org.name}`,
-			`Workflow name: ${workflowName || crate.name}`,
+			`Workflow name: ${input.workflow.name}`,
 			crate.crateTriggers.length > 0
 				? `Triggers: ${crate.crateTriggers.length}, installed ${enableTriggers ? 'enabled' : 'disabled'}`
 				: undefined,
@@ -192,22 +208,31 @@ export class InstallCrate extends GenericCommand {
 		);
 		if (confirmed !== 'Install') return;
 
-		const input = buildUnpackInput(crate, {
-			orgId: org.id,
-			workflowName: workflowName || undefined,
-			tokenValues,
-			enableTriggers,
-		});
-
+		let cancelled = false;
 		try {
 			const outcome = await vscode.window.withProgress(
-				{ location: vscode.ProgressLocation.Notification, title: `Installing Crate "${crate.name}"…` },
-				async progress =>
-					runUnpackCrate({
-						session,
-						input,
-						onProgress: label => progress.report({ message: label }),
-					}),
+				{
+					location: vscode.ProgressLocation.Notification,
+					title: `Installing Crate "${crate.name}"…`,
+					cancellable: true,
+				},
+				async (progress, token) => {
+					const controller = new AbortController();
+					const cancelListener = token.onCancellationRequested(() => {
+						cancelled = true;
+						controller.abort();
+					});
+					try {
+						return await runUnpackCrate({
+							session,
+							input,
+							signal: controller.signal,
+							onProgress: label => progress.report({ message: label }),
+						});
+					} finally {
+						cancelListener.dispose();
+					}
+				},
 			);
 			const suffix =
 				crate.requiredOrgVariables.length > 0
@@ -219,6 +244,12 @@ export class InstallCrate extends GenericCommand {
 					`.${suffix}`,
 			);
 		} catch (error) {
+			if (cancelled) {
+				log.notifyInfo(
+					`Cancelled installing Crate "${crate.name}". The unpack may have already started server-side — check the org in Rewst.`,
+				);
+				return;
+			}
 			const message = error instanceof Error ? error.message : String(error);
 			log.notifyError(`Installing Crate "${crate.name}" failed: ${message}`);
 		}

--- a/src/commands/crates/InstallCrate.ts
+++ b/src/commands/crates/InstallCrate.ts
@@ -1,0 +1,226 @@
+import { Session } from '@sessions';
+import { pickOrganization } from '@ui';
+import { log } from '@utils';
+import vscode from 'vscode';
+import { rawGraphqlOrThrow } from '../../capabilities/inputHelpers';
+import {
+	buildUnpackInput,
+	CRATE_DETAIL_QUERY,
+	CRATE_LIST_QUERY,
+	isValueToken,
+	parseCrateDetail,
+	tokenDefault,
+	type CrateDetail,
+	type CrateTokenDetail,
+	type TokenValues,
+} from '../../crates/crateUnpack';
+import { runUnpackCrate } from '../../crates/unpackClient';
+import GenericCommand from '../GenericCommand';
+
+/**
+ * Install (unpack) a prebuilt Rewst Crate into an organization. The whole
+ * configuration step is dynamic: the crate's own token metadata drives a
+ * QuickPick/InputBox wizard — free-text tokens become input boxes (prefilled
+ * with the crate's defaults), select tokens become option pickers, and
+ * multiselect tokens allow picking several options — so any crate's option
+ * set is handled without per-crate knowledge. Triggers install disabled by
+ * default so nothing fires until reviewed in Rewst.
+ */
+
+interface CrateListRow {
+	id?: string | null;
+	name?: string | null;
+	category?: string | null;
+	description?: string | null;
+	isUnpackedForSelectedOrg?: boolean | null;
+}
+
+interface CrateQuickPickItem extends vscode.QuickPickItem {
+	crateId: string;
+}
+
+const CRATE_LIST_LIMIT = 500;
+
+async function pickCrate(session: Session, orgId: string): Promise<string | undefined> {
+	const crates = await vscode.window.withProgress(
+		{ location: vscode.ProgressLocation.Notification, title: 'Loading Crate catalog…' },
+		async () => {
+			const data = await rawGraphqlOrThrow(session, CRATE_LIST_QUERY, { orgId, limit: CRATE_LIST_LIMIT });
+			return (data as { crates?: CrateListRow[] | null } | undefined)?.crates ?? [];
+		},
+	);
+
+	const items: CrateQuickPickItem[] = crates
+		.filter((crate): crate is CrateListRow & { id: string } => typeof crate.id === 'string' && crate.id.length > 0)
+		.map(crate => ({
+			crateId: crate.id,
+			label:
+				crate.isUnpackedForSelectedOrg === true
+					? `$(check) ${crate.name ?? crate.id}`
+					: (crate.name ?? crate.id),
+			description: [
+				crate.category ?? undefined,
+				crate.isUnpackedForSelectedOrg === true ? 'already installed' : undefined,
+			]
+				.filter(Boolean)
+				.join(' — '),
+			detail: crate.description ?? undefined,
+		}));
+
+	if (items.length === 0) {
+		log.notifyInfo('No Crates are visible to this session.');
+		return undefined;
+	}
+
+	const picked = await vscode.window.showQuickPick(items, {
+		placeHolder: 'Select a Crate to install',
+		matchOnDescription: true,
+		matchOnDetail: true,
+	});
+	return picked?.crateId;
+}
+
+/** Collects a value for one select token; undefined means the user backed out. */
+async function promptSelectToken(token: CrateTokenDetail): Promise<string | string[] | undefined> {
+	const defaultValue = tokenDefault(token);
+	const items = token.options
+		.filter(option => option.value !== undefined)
+		.map(option => ({
+			label: option.label ?? option.value ?? '',
+			description: option.isDefault === true ? 'default' : undefined,
+			picked: token.isMultiselect === true && (option.isDefault === true || option.value === defaultValue),
+			value: option.value as string,
+		}));
+
+	if (token.isMultiselect === true) {
+		const picked = await vscode.window.showQuickPick(items, {
+			placeHolder: token.name ?? 'Select values',
+			canPickMany: true,
+		});
+		return picked?.map(item => item.value);
+	}
+
+	const picked = await vscode.window.showQuickPick(items, {
+		placeHolder: token.name ?? 'Select a value',
+	});
+	return picked?.value;
+}
+
+/** Collects a value for one free-text token; undefined means backed out. */
+async function promptInputToken(token: CrateTokenDetail): Promise<string | undefined> {
+	return vscode.window.showInputBox({
+		prompt: token.name,
+		value: tokenDefault(token) ?? '',
+		placeHolder: token.previewText ?? token.emptyLabel,
+		ignoreFocusOut: true,
+	});
+}
+
+/**
+ * Walks the crate's value-bearing tokens in wizard order, prompting for each
+ * (defaults prefilled). Returns undefined when the user cancels any step.
+ */
+async function collectTokenValues(crate: CrateDetail): Promise<TokenValues | undefined> {
+	const values: TokenValues = {};
+	const valueTokens = crate.tokens.filter(token => isValueToken(token) && token.id !== undefined);
+	for (const [position, token] of valueTokens.entries()) {
+		const stepLabel = `(${position + 1}/${valueTokens.length})`;
+		const named = { ...token, name: `${token.name ?? token.id} ${stepLabel}` };
+		const value = token.options.length > 0 ? await promptSelectToken(named) : await promptInputToken(named);
+		if (value === undefined) return undefined;
+		values[token.id as string] = value;
+	}
+	return values;
+}
+
+export class InstallCrate extends GenericCommand {
+	commandName = 'InstallCrate';
+
+	async execute(): Promise<void> {
+		const pick = await pickOrganization();
+		if (!pick) return;
+		const { session, org } = pick;
+
+		const crateId = await pickCrate(session, org.id);
+		if (crateId === undefined) return;
+
+		const data = await rawGraphqlOrThrow(session, CRATE_DETAIL_QUERY, { crateId, orgId: org.id });
+		const crate = parseCrateDetail(data);
+		if (!crate) {
+			log.notifyError(`Crate ${crateId} was not found or is not visible to this session.`);
+			return;
+		}
+
+		const tokenValues = await collectTokenValues(crate);
+		if (tokenValues === undefined) return;
+
+		const workflowName = await vscode.window.showInputBox({
+			prompt: 'Name for the unpacked workflow',
+			// Same default the web unpack wizard offers: the crate's source workflow name.
+			value: crate.workflowName ?? crate.name,
+			ignoreFocusOut: true,
+		});
+		if (workflowName === undefined) return;
+
+		let enableTriggers = false;
+		if (crate.crateTriggers.length > 0) {
+			const triggerChoice = await vscode.window.showQuickPick(
+				[
+					{ label: 'Install triggers disabled (recommended)', enabled: false },
+					{ label: 'Install triggers enabled', enabled: true },
+				],
+				{ placeHolder: `This Crate installs ${crate.crateTriggers.length} trigger(s)` },
+			);
+			if (triggerChoice === undefined) return;
+			enableTriggers = triggerChoice.enabled;
+		}
+
+		const detailLines = [
+			`Organization: ${org.name}`,
+			`Workflow name: ${workflowName || crate.name}`,
+			crate.crateTriggers.length > 0
+				? `Triggers: ${crate.crateTriggers.length}, installed ${enableTriggers ? 'enabled' : 'disabled'}`
+				: undefined,
+			crate.requiredOrgVariables.length > 0
+				? `Requires org variables: ${crate.requiredOrgVariables.join(', ')}`
+				: undefined,
+		].filter(Boolean);
+		const confirmed = await vscode.window.showWarningMessage(
+			`Install Crate "${crate.name}"?`,
+			{ modal: true, detail: detailLines.join('\n') },
+			'Install',
+		);
+		if (confirmed !== 'Install') return;
+
+		const input = buildUnpackInput(crate, {
+			orgId: org.id,
+			workflowName: workflowName || undefined,
+			tokenValues,
+			enableTriggers,
+		});
+
+		try {
+			const outcome = await vscode.window.withProgress(
+				{ location: vscode.ProgressLocation.Notification, title: `Installing Crate "${crate.name}"…` },
+				async progress =>
+					runUnpackCrate({
+						session,
+						input,
+						onProgress: label => progress.report({ message: label }),
+					}),
+			);
+			const suffix =
+				crate.requiredOrgVariables.length > 0
+					? ` Reminder — this Crate expects org variable(s): ${crate.requiredOrgVariables.join(', ')}.`
+					: '';
+			log.notifyInfo(
+				`Installed Crate "${crate.name}" into ${org.name} as workflow "${input.workflow.name}"` +
+					(outcome.id ? ` (${outcome.id})` : '') +
+					`.${suffix}`,
+			);
+		} catch (error) {
+			const message = error instanceof Error ? error.message : String(error);
+			log.notifyError(`Installing Crate "${crate.name}" failed: ${message}`);
+		}
+	}
+}

--- a/src/commands/crates/index.ts
+++ b/src/commands/crates/index.ts
@@ -1,0 +1,1 @@
+export { InstallCrate } from './InstallCrate';

--- a/src/commands/exportedCommands.ts
+++ b/src/commands/exportedCommands.ts
@@ -1,3 +1,4 @@
+export * from './crates/index';
 export * from './folders/index';
 export * from './mcp/index';
 export { RotateMcpToken } from './mcp/RotateMcpToken';

--- a/src/crates/crateUnpack.test.ts
+++ b/src/crates/crateUnpack.test.ts
@@ -172,6 +172,28 @@ suite('Unit: crateUnpack planner', () => {
 			assert.deepStrictEqual(missing, []);
 		});
 
+		test('multiselect defaults resolve to the same Jinja-list format as supplied arrays', () => {
+			const tokens = [
+				token({
+					id: 'tok-multi',
+					name: 'Channels',
+					type: 'selectVar',
+					isMultiselect: true,
+					options: [
+						{ id: 'o-1', label: 'General', value: 'general', isDefault: true },
+						{ id: 'o-2', label: 'Alerts', value: 'alerts', isDefault: true },
+						{ id: 'o-3', label: 'Random', value: 'random', isDefault: false },
+					],
+				}),
+			];
+			const { tokenArguments, missing, defaulted } = resolveTokenArguments(tokens, {});
+			assert.deepStrictEqual(tokenArguments, [
+				{ crateTokenId: 'tok-multi', value: '{{ ["general","alerts"] }}' },
+			]);
+			assert.deepStrictEqual(missing, []);
+			assert.strictEqual(defaulted.length, 1, 'reported as default-resolved');
+		});
+
 		test('resolveTokenArguments lists value tokens with no value and no default as missing', () => {
 			const tokens = [token({ id: 'tok-1', name: 'Team Name', type: 'inputVar' })];
 			const { tokenArguments, missing } = resolveTokenArguments(tokens, {});

--- a/src/crates/crateUnpack.test.ts
+++ b/src/crates/crateUnpack.test.ts
@@ -1,0 +1,421 @@
+import * as assert from 'assert';
+import { suite, test } from '../test/tdd';
+import {
+	buildUnpackInput,
+	classifyUnpackEvent,
+	collectUnpackOutcome,
+	isValueToken,
+	parseCrateDetail,
+	resolveTokenArguments,
+	tokenDefault,
+	type CrateDetail,
+	type CrateTokenDetail,
+} from './crateUnpack';
+
+/** Builds a token row with sensible defaults, mirroring the GraphQL shape. */
+function token(overrides: Partial<CrateTokenDetail> = {}): CrateTokenDetail {
+	return {
+		id: 'tok-1',
+		name: 'Token One',
+		type: 'inputVar',
+		index: 0,
+		options: [],
+		...overrides,
+	};
+}
+
+function crate(overrides: Partial<CrateDetail> = {}): CrateDetail {
+	return {
+		id: 'crate-1',
+		name: 'User Onboarding',
+		requiredOrgVariables: [],
+		tokens: [],
+		crateTriggers: [],
+		...overrides,
+	};
+}
+
+async function* scripted(...payloads: unknown[]): AsyncIterable<unknown> {
+	for (const payload of payloads) {
+		yield payload;
+	}
+}
+
+suite('Unit: crateUnpack planner', () => {
+	suite('parseCrateDetail()', () => {
+		test('normalizes a crate row and sorts tokens by index', () => {
+			const detail = parseCrateDetail({
+				crate: {
+					id: 'crate-1',
+					name: 'User Onboarding',
+					description: 'Full onboarding',
+					requiredOrgVariables: ['ORG_VAR'],
+					isUnpackedForSelectedOrg: false,
+					workflow: { name: 'Onboarding Flow', humanSecondsSaved: 900 },
+					tokens: [
+						{ id: 'tok-b', name: 'Second', type: 'inputVar', index: 2, options: [] },
+						{ id: 'tok-a', name: 'First', type: 'selectVar', index: 1, options: [] },
+					],
+					crateTriggers: [
+						{
+							id: 'ct-1',
+							trigger: {
+								id: 'tr-1',
+								name: 'On Form Submit',
+								criteria: { condition: {} },
+								autoActivateManagedOrgs: true,
+							},
+						},
+					],
+				},
+			});
+			assert.ok(detail, 'crate row parses');
+			assert.strictEqual(detail.id, 'crate-1');
+			assert.strictEqual(detail.name, 'User Onboarding');
+			assert.deepStrictEqual(detail.requiredOrgVariables, ['ORG_VAR']);
+			// The unpacked-workflow defaults come from the crate's source workflow,
+			// mirroring the web unpack wizard.
+			assert.strictEqual(detail.workflowName, 'Onboarding Flow');
+			assert.strictEqual(detail.humanSecondsSaved, 900);
+			assert.deepStrictEqual(
+				detail.tokens.map(t => t.id),
+				['tok-a', 'tok-b'],
+				'tokens sorted by index',
+			);
+			assert.strictEqual(detail.crateTriggers.length, 1);
+			assert.strictEqual(detail.crateTriggers[0].id, 'ct-1');
+			assert.strictEqual(detail.crateTriggers[0].triggerName, 'On Form Submit');
+			assert.deepStrictEqual(detail.crateTriggers[0].criteria, { condition: {} });
+			assert.strictEqual(detail.crateTriggers[0].autoActivateManagedOrgs, true);
+		});
+
+		test('missing crate row parses to undefined', () => {
+			assert.strictEqual(parseCrateDetail({ crate: null }), undefined);
+			assert.strictEqual(parseCrateDetail(undefined), undefined);
+			assert.strictEqual(parseCrateDetail({}), undefined);
+		});
+	});
+
+	suite('token planning', () => {
+		test('input and select tokens carry values; display tokens do not', () => {
+			assert.strictEqual(isValueToken(token({ type: 'inputVar' })), true);
+			assert.strictEqual(isValueToken(token({ type: 'inputTriggerParam' })), true);
+			assert.strictEqual(isValueToken(token({ type: 'selectVar' })), true);
+			assert.strictEqual(isValueToken(token({ type: 'selectPackVar' })), true);
+			assert.strictEqual(isValueToken(token({ type: 'selectTriggerParam' })), true);
+			assert.strictEqual(isValueToken(token({ type: 'text' })), false);
+			assert.strictEqual(isValueToken(token({ type: 'linebreak' })), false);
+			assert.strictEqual(isValueToken(token({ type: 'requiresVar' })), false);
+			assert.strictEqual(isValueToken(token({ type: undefined })), false);
+		});
+
+		test('tokenDefault prefers explicit value, then default option, then undefined', () => {
+			assert.strictEqual(tokenDefault(token({ value: 'preset' })), 'preset');
+			assert.strictEqual(
+				tokenDefault(
+					token({
+						options: [
+							{ id: 'o-1', label: 'A', value: 'a', isDefault: false },
+							{ id: 'o-2', label: 'B', value: 'b', isDefault: true },
+						],
+					}),
+				),
+				'b',
+			);
+			assert.strictEqual(tokenDefault(token({})), undefined);
+		});
+
+		test('resolveTokenArguments matches by name and id, fills defaults, reports missing', () => {
+			const tokens = [
+				token({ id: 'tok-1', name: 'Team Name', type: 'inputVar', index: 0 }),
+				token({
+					id: 'tok-2',
+					name: 'Channel',
+					type: 'selectVar',
+					index: 1,
+					options: [{ id: 'o', label: 'General', value: 'general', isDefault: true }],
+				}),
+				token({ id: 'tok-3', name: 'Notes', type: 'text', index: 2 }),
+				token({ id: 'tok-4', name: 'Region', type: 'inputVar', index: 3 }),
+			];
+			const { tokenArguments, missing } = resolveTokenArguments(tokens, {
+				'Team Name': 'Acme',
+				'tok-4': 'us-east',
+			});
+			assert.deepStrictEqual(tokenArguments, [
+				{ crateTokenId: 'tok-1', value: 'Acme' },
+				{ crateTokenId: 'tok-2', value: 'general' },
+				{ crateTokenId: 'tok-4', value: 'us-east' },
+			]);
+			assert.deepStrictEqual(missing, [], 'nothing missing');
+		});
+
+		test('array values join for multiselect tokens', () => {
+			const tokens = [
+				token({
+					id: 'tok-multi',
+					name: 'Channels',
+					type: 'selectVar',
+					isMultiselect: true,
+					options: [
+						{ id: 'o-1', label: 'General', value: 'general', isDefault: false },
+						{ id: 'o-2', label: 'Alerts', value: 'alerts', isDefault: false },
+					],
+				}),
+			];
+			const { tokenArguments, missing } = resolveTokenArguments(tokens, { Channels: ['general', 'alerts'] });
+			// The platform expects multiselect values as a Jinja-wrapped JSON list —
+			// the exact serialization the web unpack wizard sends.
+			assert.deepStrictEqual(tokenArguments, [
+				{ crateTokenId: 'tok-multi', value: '{{ ["general","alerts"] }}' },
+			]);
+			assert.deepStrictEqual(missing, []);
+		});
+
+		test('resolveTokenArguments lists value tokens with no value and no default as missing', () => {
+			const tokens = [token({ id: 'tok-1', name: 'Team Name', type: 'inputVar' })];
+			const { tokenArguments, missing } = resolveTokenArguments(tokens, {});
+			assert.deepStrictEqual(tokenArguments, []);
+			assert.strictEqual(missing.length, 1);
+			assert.strictEqual(missing[0].name, 'Team Name');
+		});
+	});
+
+	suite('buildUnpackInput()', () => {
+		test('builds the full UnpackCrateInput the way the web unpack wizard does', () => {
+			const detail = crate({
+				workflowName: 'Onboarding Flow',
+				humanSecondsSaved: 900,
+				tokens: [token({ id: 'tok-1', name: 'Team Name', type: 'inputVar' })],
+				crateTriggers: [
+					{
+						id: 'ct-1',
+						triggerName: 'On Form Submit',
+						criteria: { condition: {} },
+						autoActivateManagedOrgs: true,
+					},
+				],
+			});
+			const input = buildUnpackInput(detail, {
+				orgId: 'org-1',
+				tokenValues: { 'Team Name': 'Acme' },
+			});
+			assert.deepStrictEqual(input, {
+				crateId: 'crate-1',
+				orgId: 'org-1',
+				tokenArguments: [{ crateTokenId: 'tok-1', value: 'Acme' }],
+				triggers: [
+					{
+						crateTriggerId: 'ct-1',
+						triggerName: 'On Form Submit',
+						enabled: false,
+						isActivatedForOwner: true,
+						// Carried from the trigger itself, as the web wizard defaults it.
+						autoActivateManagedOrgs: true,
+						activateForOrgIds: [],
+						activateForTagIds: [],
+						criteria: { condition: {} },
+					},
+				],
+				// No orgId inside workflow — the org is the top-level orgId, and
+				// humanSecondsSaved comes from the crate's source workflow.
+				workflow: { name: 'Onboarding Flow', humanSecondsSaved: 900 },
+			});
+		});
+
+		test('covers every trigger when a crate has several', () => {
+			const detail = crate({
+				crateTriggers: [
+					{ id: 'ct-1', triggerName: 'On Form Submit', criteria: { condition: {} } },
+					{
+						id: 'ct-2',
+						triggerName: 'On Timer',
+						criteria: { schedule: 'daily' },
+						autoActivateManagedOrgs: true,
+					},
+				],
+			});
+			const input = buildUnpackInput(detail, { orgId: 'org-1', enableTriggers: true });
+			assert.strictEqual(input.triggers.length, 2);
+			assert.deepStrictEqual(
+				input.triggers.map(t => t.crateTriggerId),
+				['ct-1', 'ct-2'],
+			);
+			assert.deepStrictEqual(
+				input.triggers.map(t => t.triggerName),
+				['On Form Submit', 'On Timer'],
+				'each trigger keeps its own name',
+			);
+			assert.deepStrictEqual(
+				input.triggers.map(t => t.criteria),
+				[{ condition: {} }, { schedule: 'daily' }],
+				'each trigger keeps its own criteria',
+			);
+			assert.deepStrictEqual(
+				input.triggers.map(t => t.autoActivateManagedOrgs),
+				[false, true],
+				'autoActivateManagedOrgs is per-trigger',
+			);
+			assert.ok(
+				input.triggers.every(t => t.enabled),
+				'enableTriggers applies to all triggers',
+			);
+		});
+
+		test('honors workflowName and enableTriggers, defaulting workflow fields when the crate has none', () => {
+			const detail = crate({ crateTriggers: [{ id: 'ct-1', triggerName: 'On Timer' }] });
+			const input = buildUnpackInput(detail, {
+				orgId: 'org-1',
+				workflowName: 'Custom Name',
+				enableTriggers: true,
+			});
+			assert.strictEqual(input.workflow.name, 'Custom Name');
+			assert.strictEqual(input.workflow.humanSecondsSaved, 0);
+			assert.strictEqual(input.triggers[0].enabled, true);
+			// A trigger with no criteria still sends an empty criteria object.
+			assert.deepStrictEqual(input.triggers[0].criteria, {});
+		});
+
+		test('throws listing missing token names', () => {
+			const detail = crate({ tokens: [token({ id: 'tok-1', name: 'Team Name', type: 'inputVar' })] });
+			assert.throws(
+				() => buildUnpackInput(detail, { orgId: 'org-1' }),
+				(err: Error) => {
+					assert.ok(err.message.includes('Team Name'), 'error names the missing token');
+					return true;
+				},
+			);
+		});
+	});
+
+	suite('classifyUnpackEvent()', () => {
+		test('success event', () => {
+			const event = classifyUnpackEvent({
+				__typename: 'UnpackCrateStreamSuccessResponse',
+				didSucceed: true,
+				isFinished: true,
+				id: 'wf-1',
+				orgId: 'org-1',
+				type: 'workflow',
+			});
+			assert.deepStrictEqual(event, { kind: 'success', id: 'wf-1', orgId: 'org-1', type: 'workflow' });
+		});
+
+		test('failure events carry the server error', () => {
+			const event = classifyUnpackEvent({
+				__typename: 'CloningImportPhaseStreamFailureResponse',
+				didSucceed: false,
+				isFinished: true,
+				error: 'boom',
+			});
+			assert.strictEqual(event?.kind, 'failure');
+			assert.ok(event.kind === 'failure' && event.error.includes('boom'));
+		});
+
+		test('success-shaped event that did not succeed is a failure', () => {
+			const event = classifyUnpackEvent({
+				__typename: 'UnpackCrateStreamSuccessResponse',
+				didSucceed: false,
+				isFinished: true,
+				id: 'wf-1',
+			});
+			assert.strictEqual(event?.kind, 'failure');
+		});
+
+		test('progress and null payloads', () => {
+			const progress = classifyUnpackEvent({
+				__typename: 'CloningImportPhaseStreamMessage',
+				isFinished: false,
+				phase: 'import',
+			});
+			assert.strictEqual(progress?.kind, 'progress');
+			assert.ok(progress.kind === 'progress' && progress.label.includes('import'));
+			assert.strictEqual(classifyUnpackEvent(null), undefined);
+			assert.strictEqual(classifyUnpackEvent(undefined), undefined);
+		});
+	});
+
+	suite('collectUnpackOutcome()', () => {
+		test('consumes progress then resolves on success', async () => {
+			const labels: string[] = [];
+			const outcome = await collectUnpackOutcome(
+				scripted(
+					{ __typename: 'ExportDownloadPhaseStreamMessage', isFinished: false, phase: 'export' },
+					{ __typename: 'CloningImportPhaseStreamMessage', isFinished: false, phase: 'import' },
+					{
+						__typename: 'UnpackCrateStreamSuccessResponse',
+						didSucceed: true,
+						isFinished: true,
+						id: 'wf-9',
+						orgId: 'org-1',
+						type: 'workflow',
+					},
+				),
+				{ onProgress: label => labels.push(label) },
+			);
+			assert.strictEqual(outcome.id, 'wf-9');
+			assert.strictEqual(labels.length, 2, 'both progress events reported');
+		});
+
+		test('rejects on a failure event with the server error', async () => {
+			await assert.rejects(
+				() =>
+					collectUnpackOutcome(
+						scripted({
+							__typename: 'CloningImportPhaseStreamFailureResponse',
+							didSucceed: false,
+							isFinished: true,
+							error: 'import exploded',
+						}),
+						{},
+					),
+				(err: Error) => {
+					assert.ok(err.message.includes('import exploded'));
+					return true;
+				},
+			);
+		});
+
+		test('rejects when the stream ends without a terminal event', async () => {
+			await assert.rejects(
+				() =>
+					collectUnpackOutcome(
+						scripted({ __typename: 'CloningImportPhaseStreamMessage', isFinished: false, phase: 'import' }),
+						{},
+					),
+				(err: Error) => {
+					assert.ok(err.message.length > 0);
+					return true;
+				},
+			);
+		});
+
+		test('inactivity timeout aborts the transport and rejects', async () => {
+			let aborted = false;
+			const stalled: AsyncIterable<unknown> = {
+				[Symbol.asyncIterator]() {
+					return {
+						next: () => new Promise<IteratorResult<unknown>>(() => {}),
+					};
+				},
+			};
+			await assert.rejects(
+				() =>
+					collectUnpackOutcome(stalled, {
+						inactivityTimeoutMs: 20,
+						abort: () => {
+							aborted = true;
+						},
+					}),
+				(err: Error) => {
+					assert.ok(
+						/no (unpack )?progress|timed out|no response/i.test(err.message),
+						`timeout message: ${err.message}`,
+					);
+					return true;
+				},
+			);
+			assert.ok(aborted, 'abort was invoked on timeout');
+		});
+	});
+});

--- a/src/crates/crateUnpack.ts
+++ b/src/crates/crateUnpack.ts
@@ -1,0 +1,500 @@
+/**
+ * Pure crate-unpack planning: GraphQL documents, crate-detail normalization,
+ * dynamic token resolution, UnpackCrateInput construction, and the stream-event
+ * loop that consumes the unpackCrate subscription. No `vscode` import anywhere —
+ * the transport wiring (websocket, cookies) lives in unpackClient.ts and the UI
+ * prompting lives in the InstallCrate command, both built on this module.
+ *
+ * Crates describe their own configuration dynamically: a crate carries an
+ * ordered list of tokens (free-text inputs, single/multi selects with options,
+ * and display-only rows) that the Rewst unpack wizard renders. Everything here
+ * is driven off that token metadata so any crate's option set is handled
+ * without per-crate knowledge.
+ */
+
+/** Value(s) supplied for tokens, keyed by token name or token id. */
+export type TokenValues = Record<string, string | string[]>;
+
+export interface CrateTokenOptionDetail {
+	id?: string;
+	label?: string;
+	value?: string;
+	isDefault?: boolean;
+}
+
+export interface CrateTokenDetail {
+	id?: string;
+	name?: string;
+	type?: string;
+	index: number;
+	value?: string;
+	isMultiselect?: boolean;
+	previewText?: string;
+	emptyLabel?: string;
+	options: CrateTokenOptionDetail[];
+}
+
+export interface CrateTriggerDetail {
+	id: string;
+	triggerName?: string;
+	/** The underlying trigger's criteria, forwarded verbatim on unpack. */
+	criteria?: unknown;
+	/** The underlying trigger's own default for the managed-orgs flag. */
+	autoActivateManagedOrgs?: boolean;
+}
+
+export interface CrateDetail {
+	id: string;
+	name: string;
+	description?: string;
+	requiredOrgVariables: string[];
+	isUnpackedForSelectedOrg?: boolean;
+	/** Default name for the unpacked workflow (the crate's source workflow). */
+	workflowName?: string;
+	/** The source workflow's time-savings figure, echoed on unpack. */
+	humanSecondsSaved?: number;
+	tokens: CrateTokenDetail[];
+	crateTriggers: CrateTriggerDetail[];
+}
+
+/** Lists the crate catalog visible to a session, scoped to one org. */
+export const CRATE_LIST_QUERY = `
+query RewstBuddyCrateList($orgId: ID, $limit: Int) {
+  crates(selectedOrgId: $orgId, limit: $limit) {
+    id
+    name
+    category
+    description
+    isUnpackedForSelectedOrg
+  }
+}
+`.trim();
+
+/** One crate with everything unpacking needs: tokens, options, and triggers. */
+export const CRATE_DETAIL_QUERY = `
+query RewstBuddyCrateDetail($crateId: ID, $orgId: ID) {
+  crate(selectedOrgId: $orgId, where: { id: $crateId }) {
+    id
+    name
+    description
+    requiredOrgVariables
+    isUnpackedForSelectedOrg
+    workflow {
+      name
+      humanSecondsSaved
+    }
+    tokens {
+      id
+      name
+      type
+      index
+      value
+      isMultiselect
+      previewText
+      emptyLabel
+      options {
+        id
+        label
+        value
+        isDefault
+      }
+    }
+    crateTriggers {
+      id
+      trigger {
+        id
+        name
+        criteria
+        autoActivateManagedOrgs
+      }
+    }
+  }
+}
+`.trim();
+
+/**
+ * The unpack stream. Progress members only need enough for a status label;
+ * failures carry the server error and the success member carries the unpacked
+ * object id.
+ */
+export const UNPACK_CRATE_SUBSCRIPTION = `
+subscription RewstBuddyUnpackCrate($unpackingArguments: UnpackCrateInput!) {
+  unpackCrate(unpackingArguments: $unpackingArguments) {
+    __typename
+    ... on UnpackCrateStreamSuccessResponse {
+      didSucceed
+      isFinished
+      id
+      orgId
+      type
+    }
+    ... on CloningImportPhaseStreamFailureResponse {
+      didSucceed
+      isFinished
+      error
+      code
+      phase
+    }
+    ... on ExportDownloadPhaseStreamFailureResponse {
+      didSucceed
+      isFinished
+      error
+      code
+      phase
+    }
+    ... on CloningImportPhaseStreamMessage {
+      isFinished
+      phase
+    }
+    ... on ExportDownloadPhaseStreamMessage {
+      isFinished
+      phase
+    }
+  }
+}
+`.trim();
+
+interface RawTokenOption {
+	id?: unknown;
+	label?: unknown;
+	value?: unknown;
+	isDefault?: unknown;
+}
+
+interface RawToken {
+	id?: unknown;
+	name?: unknown;
+	type?: unknown;
+	index?: unknown;
+	value?: unknown;
+	isMultiselect?: unknown;
+	previewText?: unknown;
+	emptyLabel?: unknown;
+	options?: RawTokenOption[] | null;
+}
+
+interface RawCrateTrigger {
+	id?: unknown;
+	trigger?: { name?: unknown; criteria?: unknown; autoActivateManagedOrgs?: unknown } | null;
+}
+
+interface RawCrate {
+	id?: unknown;
+	name?: unknown;
+	description?: unknown;
+	requiredOrgVariables?: unknown[] | null;
+	isUnpackedForSelectedOrg?: unknown;
+	workflow?: { name?: unknown; humanSecondsSaved?: unknown } | null;
+	tokens?: RawToken[] | null;
+	crateTriggers?: RawCrateTrigger[] | null;
+}
+
+function optString(value: unknown): string | undefined {
+	return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+/**
+ * Normalizes the crate-detail response into a CrateDetail, sorting tokens by
+ * their wizard index so prompting order matches Rewst's own unpack dialog.
+ * Returns undefined when the crate row is absent (unknown id or no access).
+ */
+export function parseCrateDetail(data: unknown): CrateDetail | undefined {
+	const crate = (data as { crate?: RawCrate | null } | null | undefined)?.crate;
+	if (!crate || typeof crate.id !== 'string' || crate.id.length === 0) return undefined;
+
+	const tokens: CrateTokenDetail[] = (crate.tokens ?? [])
+		.map(raw => ({
+			id: optString(raw.id),
+			name: optString(raw.name),
+			type: optString(raw.type),
+			index: typeof raw.index === 'number' ? raw.index : 0,
+			value: optString(raw.value),
+			isMultiselect: raw.isMultiselect === true,
+			previewText: optString(raw.previewText),
+			emptyLabel: optString(raw.emptyLabel),
+			options: (raw.options ?? []).map(option => ({
+				id: optString(option.id),
+				label: optString(option.label),
+				value: optString(option.value),
+				isDefault: option.isDefault === true,
+			})),
+		}))
+		.sort((a, b) => a.index - b.index);
+
+	const crateTriggers: CrateTriggerDetail[] = (crate.crateTriggers ?? [])
+		.filter((raw): raw is RawCrateTrigger & { id: string } => typeof raw.id === 'string' && raw.id.length > 0)
+		.map(raw => ({
+			id: raw.id,
+			triggerName: optString(raw.trigger?.name),
+			criteria: raw.trigger?.criteria ?? undefined,
+			autoActivateManagedOrgs: raw.trigger?.autoActivateManagedOrgs === true,
+		}));
+
+	return {
+		id: crate.id,
+		name: optString(crate.name) ?? '(unnamed crate)',
+		description: optString(crate.description),
+		requiredOrgVariables: (crate.requiredOrgVariables ?? []).filter(
+			(v): v is string => typeof v === 'string' && v.length > 0,
+		),
+		isUnpackedForSelectedOrg: crate.isUnpackedForSelectedOrg === true,
+		workflowName: optString(crate.workflow?.name),
+		humanSecondsSaved:
+			typeof crate.workflow?.humanSecondsSaved === 'number' ? crate.workflow.humanSecondsSaved : undefined,
+		tokens,
+		crateTriggers,
+	};
+}
+
+/**
+ * Whether a token carries a user-supplied value. `input*` tokens are free-text
+ * and `select*` tokens choose from options; the rest (`text`, `linebreak`,
+ * `requires*`) are display-only rows in the unpack wizard.
+ */
+export function isValueToken(token: CrateTokenDetail): boolean {
+	return token.type !== undefined && (token.type.startsWith('input') || token.type.startsWith('select'));
+}
+
+/** A token's default: its preset value, else its default option's value. */
+export function tokenDefault(token: CrateTokenDetail): string | undefined {
+	if (token.value !== undefined) return token.value;
+	return token.options.find(option => option.isDefault)?.value;
+}
+
+/**
+ * How a supplied value is flattened into the single string the API expects.
+ * Multiselect values ride as a Jinja-wrapped JSON list (`{{ ["a","b"] }}`) —
+ * the exact serialization the web unpack wizard sends.
+ */
+function flattenValue(value: string | string[]): string {
+	return Array.isArray(value) ? `{{ ${JSON.stringify(value)} }}` : value;
+}
+
+export interface ResolvedTokenArguments {
+	/** One entry per value-bearing token that resolved, in wizard order. */
+	tokenArguments: { crateTokenId: string; value: string }[];
+	/** Value tokens with neither a supplied value nor a default. */
+	missing: CrateTokenDetail[];
+	/** Tokens that resolved from defaults rather than supplied values. */
+	defaulted: { token: CrateTokenDetail; value: string }[];
+}
+
+/**
+ * Resolves every value-bearing token against the supplied values (keyed by
+ * token name or id), falling back to the token's default. Display-only tokens
+ * are skipped; anything unresolvable is reported in `missing` so callers can
+ * prompt for exactly what the crate needs.
+ */
+export function resolveTokenArguments(tokens: CrateTokenDetail[], provided: TokenValues): ResolvedTokenArguments {
+	const tokenArguments: { crateTokenId: string; value: string }[] = [];
+	const missing: CrateTokenDetail[] = [];
+	const defaulted: { token: CrateTokenDetail; value: string }[] = [];
+
+	for (const token of tokens) {
+		if (!isValueToken(token) || token.id === undefined) continue;
+
+		const suppliedRaw =
+			(token.name !== undefined ? provided[token.name] : undefined) ?? provided[token.id] ?? undefined;
+		const supplied = suppliedRaw === undefined ? undefined : flattenValue(suppliedRaw);
+		const value = supplied ?? tokenDefault(token);
+		if (value === undefined) {
+			missing.push(token);
+			continue;
+		}
+		if (supplied === undefined) {
+			defaulted.push({ token, value });
+		}
+		tokenArguments.push({ crateTokenId: token.id, value });
+	}
+
+	return { tokenArguments, missing, defaulted };
+}
+
+export interface UnpackCrateInput {
+	crateId: string;
+	orgId: string;
+	tokenArguments: { crateTokenId: string; value: string }[];
+	triggers: {
+		crateTriggerId: string;
+		triggerName: string;
+		enabled: boolean;
+		isActivatedForOwner: boolean;
+		autoActivateManagedOrgs: boolean;
+		activateForOrgIds: string[];
+		activateForTagIds: string[];
+		criteria: unknown;
+	}[];
+	/** No orgId here — the target org is the top-level orgId (mirrors the web wizard). */
+	workflow: { name: string; humanSecondsSaved: number };
+}
+
+export interface BuildUnpackOptions {
+	orgId: string;
+	/** Name for the unpacked workflow; defaults to the crate name. */
+	workflowName?: string;
+	tokenValues?: TokenValues;
+	/**
+	 * Whether the crate's triggers install enabled. Defaults to false — the
+	 * safe default is installing with triggers off and enabling in Rewst after
+	 * review, so an unpack can never start firing automations by surprise.
+	 */
+	enableTriggers?: boolean;
+}
+
+/**
+ * Builds the UnpackCrateInput for one crate. Throws when any value-bearing
+ * token cannot be resolved — callers that want to prompt should call
+ * resolveTokenArguments first and only build once nothing is missing.
+ */
+export function buildUnpackInput(crate: CrateDetail, opts: BuildUnpackOptions): UnpackCrateInput {
+	const { tokenArguments, missing } = resolveTokenArguments(crate.tokens, opts.tokenValues ?? {});
+	if (missing.length > 0) {
+		const names = missing.map(token => token.name ?? token.id ?? '(unnamed token)').join('", "');
+		throw new Error(`Crate "${crate.name}" needs values for token(s) "${names}".`);
+	}
+
+	return {
+		crateId: crate.id,
+		orgId: opts.orgId,
+		tokenArguments,
+		// One entry per crate trigger (a crate can carry several); each keeps its
+		// own name and criteria, mirroring the web wizard's per-trigger defaults.
+		triggers: crate.crateTriggers.map(trigger => ({
+			crateTriggerId: trigger.id,
+			triggerName: trigger.triggerName ?? crate.name,
+			enabled: opts.enableTriggers === true,
+			isActivatedForOwner: true,
+			autoActivateManagedOrgs: trigger.autoActivateManagedOrgs === true,
+			activateForOrgIds: [],
+			activateForTagIds: [],
+			criteria: trigger.criteria ?? {},
+		})),
+		workflow: {
+			name: opts.workflowName ?? crate.workflowName ?? crate.name,
+			humanSecondsSaved: crate.humanSecondsSaved ?? 0,
+		},
+	};
+}
+
+export interface UnpackSuccess {
+	id?: string;
+	orgId?: string;
+	type?: string;
+}
+
+export type UnpackEvent =
+	| { kind: 'progress'; label: string }
+	| ({ kind: 'success' } & UnpackSuccess)
+	| { kind: 'failure'; error: string };
+
+interface RawStreamEvent {
+	__typename?: unknown;
+	didSucceed?: unknown;
+	isFinished?: unknown;
+	id?: unknown;
+	orgId?: unknown;
+	type?: unknown;
+	error?: unknown;
+	code?: unknown;
+	phase?: unknown;
+}
+
+/**
+ * Classifies one unpackCrate stream payload. A success-typed event that did
+ * not succeed is a failure — didSucceed is authoritative over the typename.
+ */
+export function classifyUnpackEvent(payload: unknown): UnpackEvent | undefined {
+	if (payload === null || payload === undefined || typeof payload !== 'object') return undefined;
+	const event = payload as RawStreamEvent;
+
+	if (typeof event.error === 'string' && event.error.length > 0) {
+		return { kind: 'failure', error: event.error };
+	}
+	if (event.__typename === 'UnpackCrateStreamSuccessResponse') {
+		if (event.didSucceed !== true) {
+			return { kind: 'failure', error: 'Unpack reported it did not succeed.' };
+		}
+		return {
+			kind: 'success',
+			id: optString(event.id),
+			orgId: optString(event.orgId),
+			type: optString(event.type),
+		};
+	}
+	if (event.didSucceed === false) {
+		return { kind: 'failure', error: 'Unpack failed without a server error message.' };
+	}
+	const label = optString(event.phase) ?? optString(event.__typename) ?? 'working';
+	return { kind: 'progress', label };
+}
+
+const TIMED_OUT = Symbol('timed-out');
+
+async function nextWithTimeout<T>(promise: Promise<T>, ms: number): Promise<T | typeof TIMED_OUT> {
+	let timer: NodeJS.Timeout | undefined;
+	try {
+		return await Promise.race([
+			promise,
+			new Promise<typeof TIMED_OUT>(resolve => {
+				timer = setTimeout(() => resolve(TIMED_OUT), ms);
+			}),
+		]);
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+/** Unpacks can be slow (they clone a workflow tree), but each phase streams. */
+const DEFAULT_UNPACK_INACTIVITY_TIMEOUT_MS = 300_000;
+
+export interface CollectUnpackOptions {
+	/** Resets on every received payload; guards a silently stalled stream. */
+	inactivityTimeoutMs?: number;
+	/** Tears down the underlying transport when the loop gives up waiting. */
+	abort?: () => void;
+	onProgress?: (label: string) => void;
+}
+
+/**
+ * Consumes unpackCrate stream payloads until a terminal event: resolves on
+ * success, throws on failure, a stream that ends without a terminal event, or
+ * inactivity. Mirrors the runConversation loop shape so it is unit-testable
+ * with scripted iterables.
+ */
+export async function collectUnpackOutcome(
+	payloads: AsyncIterable<unknown>,
+	options: CollectUnpackOptions,
+): Promise<UnpackSuccess> {
+	const timeoutMs = options.inactivityTimeoutMs ?? DEFAULT_UNPACK_INACTIVITY_TIMEOUT_MS;
+	const iterator = payloads[Symbol.asyncIterator]();
+	try {
+		for (;;) {
+			const step = iterator.next();
+			const next = await nextWithTimeout(step, timeoutMs);
+			if (next === TIMED_OUT) {
+				// The dangling next() settles (or rejects) once abort tears down
+				// the transport; swallow it to avoid unhandled rejections.
+				step.catch(() => {});
+				options.abort?.();
+				throw new Error(`No unpack progress for ${Math.round(timeoutMs / 1000)}s; gave up.`);
+			}
+			if (next.done) {
+				throw new Error('The unpack stream ended without reporting success or failure.');
+			}
+
+			const event = classifyUnpackEvent(next.value);
+			if (event === undefined) continue;
+			if (event.kind === 'success') {
+				return { id: event.id, orgId: event.orgId, type: event.type };
+			}
+			if (event.kind === 'failure') {
+				throw new Error(`Crate unpack failed: ${event.error}`);
+			}
+			options.onProgress?.(event.label);
+		}
+	} finally {
+		// Fire-and-forget: a source stalled mid-await would never settle return(),
+		// and the transport teardown (abort/dispose) is what actually frees it.
+		Promise.resolve(iterator.return?.(undefined)).catch(() => {});
+	}
+}

--- a/src/crates/crateUnpack.ts
+++ b/src/crates/crateUnpack.ts
@@ -262,6 +262,23 @@ export function tokenDefault(token: CrateTokenDetail): string | undefined {
 }
 
 /**
+ * A token's raw default before serialization. A multiselect token defaults to
+ * every option marked default (the set the web wizard preselects), so its
+ * default must ride through the same list serialization as supplied arrays.
+ */
+function tokenDefaultRaw(token: CrateTokenDetail): string | string[] | undefined {
+	if (token.value !== undefined) return token.value;
+	if (token.isMultiselect === true) {
+		const defaults = token.options
+			.filter(option => option.isDefault)
+			.map(option => option.value)
+			.filter((value): value is string => value !== undefined);
+		return defaults.length > 0 ? defaults : undefined;
+	}
+	return token.options.find(option => option.isDefault)?.value;
+}
+
+/**
  * How a supplied value is flattened into the single string the API expects.
  * Multiselect values ride as a Jinja-wrapped JSON list (`{{ ["a","b"] }}`) —
  * the exact serialization the web unpack wizard sends.
@@ -295,8 +312,11 @@ export function resolveTokenArguments(tokens: CrateTokenDetail[], provided: Toke
 
 		const suppliedRaw =
 			(token.name !== undefined ? provided[token.name] : undefined) ?? provided[token.id] ?? undefined;
+		// Defaults ride through the same serializer as supplied values, so a
+		// multiselect default emits the identical Jinja-list format.
+		const raw = suppliedRaw ?? tokenDefaultRaw(token);
 		const supplied = suppliedRaw === undefined ? undefined : flattenValue(suppliedRaw);
-		const value = supplied ?? tokenDefault(token);
+		const value = raw === undefined ? undefined : flattenValue(raw);
 		if (value === undefined) {
 			missing.push(token);
 			continue;

--- a/src/crates/unpackClient.ts
+++ b/src/crates/unpackClient.ts
@@ -42,6 +42,8 @@ export interface UnpackTransportOptions {
 	input: UnpackCrateInput;
 	onProgress?: (label: string) => void;
 	inactivityTimeoutMs?: number;
+	/** Aborting tears down the websocket, ending the stream early. */
+	signal?: AbortSignal;
 }
 
 /**
@@ -75,6 +77,12 @@ export async function runUnpackCrate(options: UnpackTransportOptions): Promise<U
 		Promise.resolve(client.dispose()).catch(() => {});
 	};
 
+	if (options.signal?.aborted) {
+		dispose();
+		throw new Error('Crate unpack was cancelled before it started.');
+	}
+	options.signal?.addEventListener('abort', dispose, { once: true });
+
 	log.debug('unpackCrate: starting subscription', {
 		crateId: options.input.crateId,
 		orgId: options.input.orgId,
@@ -92,6 +100,7 @@ export async function runUnpackCrate(options: UnpackTransportOptions): Promise<U
 			onProgress: options.onProgress,
 		});
 	} finally {
+		options.signal?.removeEventListener('abort', dispose);
 		dispose();
 	}
 }

--- a/src/crates/unpackClient.ts
+++ b/src/crates/unpackClient.ts
@@ -1,0 +1,97 @@
+import { getSubscriptionsUrl, type RegionConfig, type Session } from '@sessions';
+import { log } from '@utils';
+import { createClient } from 'graphql-ws';
+import WebSocket from 'ws';
+import {
+	collectUnpackOutcome,
+	UNPACK_CRATE_SUBSCRIPTION,
+	type UnpackCrateInput,
+	type UnpackSuccess,
+} from './crateUnpack';
+
+/**
+ * Transport wiring for the unpackCrate subscription. Unpacking a crate is a
+ * GraphQL *subscription*, not a mutation — the server streams export/import
+ * progress and finishes with a success or failure event — so this rides the
+ * same graphql-ws + cookie websocket stack as the Rewst AI conversation client.
+ * All decision logic lives in crateUnpack.ts; this file only moves bytes.
+ */
+
+// Secrets hold whatever cookie string validated at session creation — either a
+// full "name=value" cookie or a bare token (same convention as ConversationClient).
+function toCookieHeader(stored: string, region: RegionConfig): string {
+	return stored.includes('=') ? stored : `${region.cookieName}=${stored}`;
+}
+
+interface SubscriptionResult {
+	data?: { unpackCrate?: unknown } | null;
+	errors?: readonly { message: string }[];
+}
+
+async function* payloadsOf(results: AsyncIterable<SubscriptionResult>): AsyncIterable<unknown> {
+	for await (const result of results) {
+		if (result.errors?.length) {
+			throw new Error(`GraphQL error: ${result.errors.map(e => e.message).join('; ')}`);
+		}
+		yield result.data?.unpackCrate;
+	}
+}
+
+export interface UnpackTransportOptions {
+	session: Session;
+	input: UnpackCrateInput;
+	onProgress?: (label: string) => void;
+	inactivityTimeoutMs?: number;
+}
+
+/**
+ * Runs one unpackCrate subscription to completion: resolves with the unpacked
+ * object (its id is the new workflow) or throws with the server's failure.
+ */
+export async function runUnpackCrate(options: UnpackTransportOptions): Promise<UnpackSuccess> {
+	const { session } = options;
+	const cookie = toCookieHeader(await session.getCookies(), session.profile.region);
+	const url = getSubscriptionsUrl(session.profile.region);
+
+	class CookieWebSocket extends WebSocket {
+		constructor(address: string | URL, protocols?: string | string[]) {
+			super(address, protocols, { headers: { cookie } });
+		}
+	}
+
+	const client = createClient({
+		url,
+		webSocketImpl: CookieWebSocket,
+		retryAttempts: 0,
+		lazy: true,
+		on: {
+			connected: () => log.debug('unpackCrate: ws connected', { url }),
+			closed: () => log.debug('unpackCrate: ws closed'),
+			error: err => log.debug('unpackCrate: ws error', err),
+		},
+	});
+
+	const dispose = () => {
+		Promise.resolve(client.dispose()).catch(() => {});
+	};
+
+	log.debug('unpackCrate: starting subscription', {
+		crateId: options.input.crateId,
+		orgId: options.input.orgId,
+		workflowName: options.input.workflow.name,
+	});
+
+	try {
+		const results = client.iterate<SubscriptionResult['data']>({
+			query: UNPACK_CRATE_SUBSCRIPTION,
+			variables: { unpackingArguments: options.input },
+		});
+		return await collectUnpackOutcome(payloadsOf(results), {
+			inactivityTimeoutMs: options.inactivityTimeoutMs,
+			abort: dispose,
+			onProgress: options.onProgress,
+		});
+	} finally {
+		dispose();
+	}
+}

--- a/src/test/integration/crateUnpack.test.ts
+++ b/src/test/integration/crateUnpack.test.ts
@@ -3,7 +3,13 @@ import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment }
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
 import { rawGraphqlOrThrow } from '../../capabilities/inputHelpers';
-import { buildUnpackInput, CRATE_DETAIL_QUERY, CRATE_LIST_QUERY, parseCrateDetail } from '../../crates/crateUnpack';
+import {
+	buildUnpackInput,
+	CRATE_DETAIL_QUERY,
+	CRATE_LIST_QUERY,
+	parseCrateDetail,
+	resolveTokenArguments,
+} from '../../crates/crateUnpack';
 
 const { suite, test, suiteSetup, suiteTeardown } = Mocha;
 
@@ -47,14 +53,24 @@ suite('Integration: crate unpack planning probes', function () {
 		assert.ok(crates[0].id, 'crates carry ids');
 	});
 
-	test('detail query on a known public crate parses and builds a wizard-shaped input', async () => {
+	test('detail query on a known public crate parses and builds a wizard-shaped input', async function () {
+		// The reference crate is Rewst-maintained and can be edited or withdrawn;
+		// a missing or reshaped catalog entry is an external change, not a
+		// regression — skip rather than fail CI in that case.
 		const data = await rawGraphqlOrThrow(session, CRATE_DETAIL_QUERY, { crateId: KNOWN_CRATE_ID, orgId });
 		const crate = parseCrateDetail(data);
-		assert.ok(crate, 'known crate parses');
+		if (!crate) {
+			console.log(`[itest] known crate ${KNOWN_CRATE_ID} is no longer visible — skipping`);
+			this.skip();
+			return;
+		}
+		if (crate.tokens.length === 0 || crate.crateTriggers.length === 0) {
+			console.log(`[itest] known crate ${KNOWN_CRATE_ID} no longer carries tokens/triggers — skipping`);
+			this.skip();
+			return;
+		}
 		assert.strictEqual(crate.id, KNOWN_CRATE_ID);
 		assert.ok(crate.name.length > 0, 'crate has a name');
-		assert.ok(crate.tokens.length > 0, 'crate carries tokens');
-		assert.ok(crate.crateTriggers.length > 0, 'crate carries at least one trigger');
 		for (const trigger of crate.crateTriggers) {
 			assert.ok(trigger.triggerName, 'each trigger resolves its underlying trigger name');
 		}
@@ -63,7 +79,14 @@ suite('Integration: crate unpack planning probes', function () {
 
 		// This crate's tokens are all display-only in production, so the input
 		// builds with no supplied values — matching the web wizard, which asks
-		// for nothing but workflow name and trigger settings.
+		// for nothing but workflow name and trigger settings. If Rewst later adds
+		// value tokens without defaults, that's an external catalog change: skip.
+		const { missing } = resolveTokenArguments(crate.tokens, {});
+		if (missing.length > 0) {
+			console.log(`[itest] known crate ${KNOWN_CRATE_ID} now requires token values — skipping input build`);
+			this.skip();
+			return;
+		}
 		const input = buildUnpackInput(crate, { orgId });
 		assert.strictEqual(input.crateId, KNOWN_CRATE_ID);
 		assert.strictEqual(input.orgId, orgId);

--- a/src/test/integration/crateUnpack.test.ts
+++ b/src/test/integration/crateUnpack.test.ts
@@ -1,0 +1,80 @@
+import type { Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { rawGraphqlOrThrow } from '../../capabilities/inputHelpers';
+import { buildUnpackInput, CRATE_DETAIL_QUERY, CRATE_LIST_QUERY, parseCrateDetail } from '../../crates/crateUnpack';
+
+const { suite, test, suiteSetup, suiteTeardown } = Mocha;
+
+/**
+ * Live read-only probes for the crate-unpack planner: the catalog and detail
+ * queries must parse real production crates end-to-end, and the resulting
+ * UnpackCrateInput must assemble the same shape the web unpack wizard sends
+ * (verified against a captured HAR of the "Add Client to Rewst" wizard).
+ * Nothing here unpacks anything — the subscription is never started.
+ */
+
+// Public Rewst-maintained crate ("Add Client to Rewst") used in the HAR capture.
+const KNOWN_CRATE_ID = '1df926ab-e10f-451f-ac24-5ffbfb94c4ae';
+
+suite('Integration: crate unpack planning probes', function () {
+	this.timeout(120_000);
+
+	let session: Session;
+	let orgId: string;
+
+	suiteSetup(async function () {
+		if (!hasTestToken()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		session = await getTestSession();
+		orgId = session.profile.org.id;
+		if (!orgId) throw new Error('Refusing to run: the test session has no primary org id.');
+		console.log(`\n[itest] target org: ${session.profile.org.name} (${orgId})`);
+	});
+
+	suiteTeardown(() => {
+		clearCachedSession();
+	});
+
+	test('catalog list query returns crates for the org', async () => {
+		const data = await rawGraphqlOrThrow(session, CRATE_LIST_QUERY, { orgId, limit: 5 });
+		const crates = (data as { crates?: { id?: string; name?: string }[] } | undefined)?.crates ?? [];
+		assert.ok(crates.length > 0, 'at least one catalog crate visible');
+		assert.ok(crates[0].id, 'crates carry ids');
+	});
+
+	test('detail query on a known public crate parses and builds a wizard-shaped input', async () => {
+		const data = await rawGraphqlOrThrow(session, CRATE_DETAIL_QUERY, { crateId: KNOWN_CRATE_ID, orgId });
+		const crate = parseCrateDetail(data);
+		assert.ok(crate, 'known crate parses');
+		assert.strictEqual(crate.id, KNOWN_CRATE_ID);
+		assert.ok(crate.name.length > 0, 'crate has a name');
+		assert.ok(crate.tokens.length > 0, 'crate carries tokens');
+		assert.ok(crate.crateTriggers.length > 0, 'crate carries at least one trigger');
+		for (const trigger of crate.crateTriggers) {
+			assert.ok(trigger.triggerName, 'each trigger resolves its underlying trigger name');
+		}
+		assert.ok(crate.workflowName, 'source workflow name resolves for the default');
+		assert.strictEqual(typeof crate.humanSecondsSaved, 'number', 'source workflow humanSecondsSaved resolves');
+
+		// This crate's tokens are all display-only in production, so the input
+		// builds with no supplied values — matching the web wizard, which asks
+		// for nothing but workflow name and trigger settings.
+		const input = buildUnpackInput(crate, { orgId });
+		assert.strictEqual(input.crateId, KNOWN_CRATE_ID);
+		assert.strictEqual(input.orgId, orgId);
+		assert.strictEqual(typeof input.workflow.humanSecondsSaved, 'number');
+		assert.ok(!('orgId' in input.workflow), 'workflow carries no orgId (top-level orgId owns targeting)');
+		assert.strictEqual(input.triggers.length, crate.crateTriggers.length, 'every crate trigger is covered');
+		for (const trigger of input.triggers) {
+			assert.strictEqual(trigger.enabled, false, 'triggers default to disabled');
+			assert.deepStrictEqual(trigger.activateForOrgIds, []);
+			assert.deepStrictEqual(trigger.activateForTagIds, []);
+			assert.notStrictEqual(trigger.criteria, undefined, 'criteria is always sent');
+		}
+	});
+});

--- a/vitest.suites.mjs
+++ b/vitest.suites.mjs
@@ -19,4 +19,5 @@ export const vitestSuites = [
 	'src/test/tdd.test.ts',
 	'src/sessions/graphql/sdk.test.ts',
 	'src/ui/jinja/jinjaPreviewRender.test.ts',
+	'src/crates/crateUnpack.test.ts',
 ];


### PR DESCRIPTION
## What & why

Add interactive crate installation. The `Install Crate` command walks users through
org selection, catalog browsing, dynamic token configuration (driven by crate
metadata), workflow naming, and trigger enablement before unpacking. The
`buddy_unpack_crate` capability provides the same workflow to AI assistants —
both Cage-Free Rewsty chat and external MCP clients — gated by the write-tools
setting, working scope, and per-call approval.

Crate tokens (free-text, single/multi-select, display-only) are handled
generically — any crate's config is supported without per-crate knowledge.
Called without token values, the capability returns a structured
`input_required` payload (each missing token with its type, options, and
defaults) so an assistant can gather values conversationally and retry.
Triggers install disabled by default for safety.

The unpack input mirrors the Rewst web unpack wizard exactly (verified against
a HAR capture of a real unpack): `workflow: { name, humanSecondsSaved }` with
no org id, per-trigger `criteria`/`autoActivateManagedOrgs` forwarded from the
underlying trigger, and multiselect values serialized as a Jinja-wrapped JSON
list (`{{ ["a","b"] }}`). Unpacking is a GraphQL *subscription*, so this rides
the same graphql-ws + cookie websocket stack as the conversation client.

Core planning logic (token resolution, input building, stream event handling)
lives in pure `crateUnpack.ts` with no `vscode` imports, making it testable
and reusable across both the interactive and capability surfaces.

## Related issue(s)

<!-- none -->

## Testing

- Unit (vitest): planner suite — detail parsing, token resolution incl.
  multiselect serialization, wizard-shaped input building, multiple triggers,
  stream event classification, timeout/abort handling
- Unit (extension host): capability suite — schema/gating, approval
  approve/deny, `input_required` handshake, chat/MCP exposure via `listTools`,
  error paths; full suite green
- Integration: read-only probe (`Integration: crate unpack planning probes`)
  runs the catalog + detail queries against production and asserts the built
  input is wizard-shaped — never starts an unpack (requires `REWST_TEST_TOKEN`)
- Manual: pending — a live end-to-end unpack against a sandbox org is the
  remaining verification

## Checklist

- [x] Added a changelog note under `changelog.d/` (`npm run changelog:new`)
- [x] Tests added/updated for the change (unit, and integration if it hits the API)
- [x] Docs updated if user-facing (`docs/`, `README.md`)
- [x] Self-reviewed the diff

@coderabbitai review

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new Crate Installer experience for browsing crates and installing one into an organization through a guided setup flow.
  * Added support for configuring crate-specific options, choosing workflow details, and optionally enabling triggers during install.
  * Added progress updates, confirmation, and cancellation behavior for installs.

* **Documentation**
  * Updated feature docs, command reference, README, and changelog to describe the new install flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->