### PR TITLE
Nested task logs (full depth) + reliable buddy_template_sync downloads

### DIFF
--- a/changelog.d/170.md
+++ b/changelog.d/170.md
@@ -1,0 +1,5 @@
+---
+category: Fixed
+---
+
+- **`buddy_execution_logs` now nests like `buddy_workflow_diagnose`.** Combining `includeSubExecutions` with `depth` inlines full task logs at every requested nesting level, not just the first; `buddy_workflow_diagnose`'s nested drill-down sections now show a sub-execution's complete task log instead of only its failing task.

--- a/changelog.d/170.md
+++ b/changelog.d/170.md
@@ -1,5 +1,6 @@
 ---
 category: Fixed
+pr: 171
 ---
 
 - **`buddy_execution_logs` now nests like `buddy_workflow_diagnose`.** Combining `includeSubExecutions` with `depth` inlines full task logs at every requested nesting level, not just the first; `buddy_workflow_diagnose`'s nested drill-down sections now show a sub-execution's complete task log instead of only its failing task.

--- a/changelog.d/172.md
+++ b/changelog.d/172.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 171
+---
+
+- **`buddy_template_sync` downloads are now reliable under load.** Concurrent downloads no longer race each other's save and mostly fail; a download is now retried and, if it still can't save, the local file is left exactly as it was instead of silently reporting a false "in-sync" status.

--- a/src/commands/template/sync/TakeRemoteConflict.test.ts
+++ b/src/commands/template/sync/TakeRemoteConflict.test.ts
@@ -78,21 +78,21 @@ suite('Unit: TakeRemoteConflict', () => {
 			'showInformationMessage',
 			(() => new Promise(() => {})) as unknown as typeof vscode.window.showInformationMessage,
 		);
+		// addLink only runs after a confirmed save (#172), so stub applyEdit/save
+		// to succeed — a non-open mock document's save fails for real otherwise.
+		const restoreApply = stub(vscode.workspace, 'applyEdit', (async () => true) as typeof vscode.workspace.applyEdit);
+		const restoreSave = stub(vscode.workspace, 'save', (async (u: vscode.Uri) => u) as typeof vscode.workspace.save);
 
 		try {
 			const syncPromise = SyncManager.syncTemplate(doc);
 			await new Promise(resolve => setTimeout(resolve, 0));
 			await new TakeRemoteConflict().execute();
-			try {
-				await syncPromise;
-			} catch {
-				// expected: vscode.workspace.applyEdit/save against an unopened mock
-				// document fails here, same as the existing applyTemplateToDocument
-				// tests elsewhere in SyncManager.test.ts.
-			}
+			await syncPromise;
 		} finally {
 			restoreExec();
 			restoreNotification();
+			restoreApply();
+			restoreSave();
 		}
 
 		assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 0, 'no upload happens on take-remote');

--- a/src/models/SyncManager.test.ts
+++ b/src/models/SyncManager.test.ts
@@ -503,6 +503,45 @@ suite('Unit: SyncManager.checkAutoFetch', () => {
 			);
 		});
 
+		test('treats a thrown save rejection as a retryable failure, not an unhandled exception', async () => {
+			const uri = vscode.Uri.file('/test/retry-throws.txt');
+			const localContent = '';
+			const { doc, session, remoteTemplate } = setUpDownload(uri, localContent);
+
+			const appliedTexts: (string | undefined)[] = [];
+			const restoreApply = stub(vscode.workspace, 'applyEdit', (async (edit: vscode.WorkspaceEdit) => {
+				appliedTexts.push(edit.get(uri)[0]?.newText);
+				return true;
+			}) as typeof vscode.workspace.applyEdit);
+			let saveCalls = 0;
+			const restoreSave = stub(vscode.workspace, 'save', (async () => {
+				saveCalls++;
+				throw new Error('save rejected');
+			}) as typeof vscode.workspace.save);
+
+			try {
+				await assert.rejects(
+					() => SyncManager.applyTemplateToDocument(doc, session, remoteTemplate),
+					/applyTemplateToDocument: failed to save/,
+				);
+			} finally {
+				restoreApply();
+				restoreSave();
+			}
+
+			assert.strictEqual(saveCalls, 3, 'a thrown save is retried like a falsy save result');
+			assert.strictEqual(appliedTexts.length, 2, 'the download edit, then a revert edit, are applied');
+			assert.strictEqual(
+				appliedTexts[1],
+				localContent,
+				'the revert edit still runs after every retry throws',
+			);
+			assert.throws(
+				() => LinkManager.getTemplateLink(uri),
+				'the link is never recorded when every save attempt throws',
+			);
+		});
+
 		test('serializes concurrent applyTemplateToDocument calls across different files', async () => {
 			const uriA = vscode.Uri.file('/test/concurrent-a.txt');
 			const uriB = vscode.Uri.file('/test/concurrent-b.txt');

--- a/src/models/SyncManager.test.ts
+++ b/src/models/SyncManager.test.ts
@@ -405,17 +405,137 @@ suite('Unit: SyncManager.checkAutoFetch', () => {
 			organization: Fixtures.org({ id: 'sub-org', name: 'Sub Org' }),
 		});
 
-		// applyTemplateToDocument updates the link before persisting; the final
-		// save of a non-open mock document throws in the unit host, which we ignore.
+		// addLink only runs after a confirmed save (#172), so stub applyEdit/save
+		// to succeed — a non-open mock document's save fails for real otherwise.
+		const restoreApply = stub(vscode.workspace, 'applyEdit', (async () => true) as typeof vscode.workspace.applyEdit);
+		const restoreSave = stub(vscode.workspace, 'save', (async (u: vscode.Uri) => u) as typeof vscode.workspace.save);
 		try {
 			await SyncManager.applyTemplateToDocument(doc, session, remoteTemplate);
-		} catch {
-			// expected: vscode.workspace.save of an unopened mock document fails here
+		} finally {
+			restoreApply();
+			restoreSave();
 		}
 
 		const link = LinkManager.getTemplateLink(uri);
 		assert.strictEqual(link.org.id, 'sub-org', 'downloaded link must record the template sub-org');
 		assert.strictEqual(link.org.name, 'Sub Org');
+	});
+
+	// Spec: issue #172 — concurrent downloads mostly failed to save, and a
+	// retry after a failed save falsely reported "in sync" against an empty
+	// local file because the failed edit was left applied in memory.
+	suite('applyTemplateToDocument resilience (#172)', () => {
+		function setUpDownload(uri: vscode.Uri, localContent: string) {
+			const org = Fixtures.orgModel({ id: 'org-172', name: 'Org 172' });
+			const { session } = createMockSession({ profile: { org, allManagedOrgs: [org] } });
+			SessionManager._setSessionsForTesting([session]);
+			const doc = createMockDocument({ uri, content: localContent });
+			const remoteTemplate = Fixtures.fullTemplate({
+				id: 'tpl-172',
+				name: 'Tpl 172',
+				body: '// remote body',
+				updatedAt: '2024-05-05T00:00:00Z',
+				orgId: org.id,
+				organization: Fixtures.org({ id: org.id, name: org.name }),
+			});
+			return { doc, session, remoteTemplate };
+		}
+
+		test('retries a failed save before giving up, and links the template once it succeeds', async () => {
+			const uri = vscode.Uri.file('/test/retry-succeeds.txt');
+			const { doc, session, remoteTemplate } = setUpDownload(uri, '');
+
+			let saveCalls = 0;
+			const restoreApply = stub(
+				vscode.workspace,
+				'applyEdit',
+				(async () => true) as typeof vscode.workspace.applyEdit,
+			);
+			const restoreSave = stub(vscode.workspace, 'save', (async (u: vscode.Uri) => {
+				saveCalls++;
+				return saveCalls < 3 ? undefined : u; // fails twice, succeeds on the 3rd attempt
+			}) as typeof vscode.workspace.save);
+
+			try {
+				await SyncManager.applyTemplateToDocument(doc, session, remoteTemplate);
+			} finally {
+				restoreApply();
+				restoreSave();
+			}
+
+			assert.strictEqual(saveCalls, 3, 'save is retried until it succeeds');
+			const link = LinkManager.getTemplateLink(uri);
+			assert.strictEqual(link.template.id, 'tpl-172', 'the link is recorded once the retried save succeeds');
+		});
+
+		test('reverts the in-memory edit and does not update the link when every save attempt fails', async () => {
+			const uri = vscode.Uri.file('/test/retry-exhausted.txt');
+			const localContent = ''; // matches the real #172 repro: an empty local file
+			const { doc, session, remoteTemplate } = setUpDownload(uri, localContent);
+
+			const appliedTexts: (string | undefined)[] = [];
+			const restoreApply = stub(vscode.workspace, 'applyEdit', (async (edit: vscode.WorkspaceEdit) => {
+				appliedTexts.push(edit.get(uri)[0]?.newText);
+				return true;
+			}) as typeof vscode.workspace.applyEdit);
+			const restoreSave = stub(vscode.workspace, 'save', (async () => undefined) as typeof vscode.workspace.save);
+
+			try {
+				await assert.rejects(
+					() => SyncManager.applyTemplateToDocument(doc, session, remoteTemplate),
+					/applyTemplateToDocument: failed to save/,
+				);
+			} finally {
+				restoreApply();
+				restoreSave();
+			}
+
+			assert.strictEqual(appliedTexts.length, 2, 'the download edit, then a revert edit, are applied');
+			assert.strictEqual(appliedTexts[0], '// remote body', 'the first edit writes the remote body');
+			assert.strictEqual(
+				appliedTexts[1],
+				localContent,
+				'the revert edit restores the pre-download local content, not the unpersisted remote body',
+			);
+			assert.throws(
+				() => LinkManager.getTemplateLink(uri),
+				'the link is never recorded for a download that never actually saved',
+			);
+		});
+
+		test('serializes concurrent applyTemplateToDocument calls across different files', async () => {
+			const uriA = vscode.Uri.file('/test/concurrent-a.txt');
+			const uriB = vscode.Uri.file('/test/concurrent-b.txt');
+			const a = setUpDownload(uriA, '');
+			const b = setUpDownload(uriB, '');
+
+			let inFlight = 0;
+			let maxInFlight = 0;
+			const restoreApply = stub(
+				vscode.workspace,
+				'applyEdit',
+				(async () => true) as typeof vscode.workspace.applyEdit,
+			);
+			const restoreSave = stub(vscode.workspace, 'save', (async (u: vscode.Uri) => {
+				inFlight++;
+				maxInFlight = Math.max(maxInFlight, inFlight);
+				await new Promise(resolve => setTimeout(resolve, 20));
+				inFlight--;
+				return u;
+			}) as typeof vscode.workspace.save);
+
+			try {
+				await Promise.all([
+					SyncManager.applyTemplateToDocument(a.doc, a.session, a.remoteTemplate),
+					SyncManager.applyTemplateToDocument(b.doc, b.session, b.remoteTemplate),
+				]);
+			} finally {
+				restoreApply();
+				restoreSave();
+			}
+
+			assert.strictEqual(maxInFlight, 1, 'saves for different files never overlap');
+		});
 	});
 
 	test('should attempt to apply remote template when local unchanged and remote is newer', async () => {
@@ -560,11 +680,15 @@ suite('Unit: SyncManager.checkAutoFetch', () => {
 		});
 
 		const doc = createMockDocument({ uri, content });
+		// addLink only runs after a confirmed save (#172), so stub applyEdit/save
+		// to succeed — a non-open mock document's save fails for real otherwise.
+		const restoreApply = stub(vscode.workspace, 'applyEdit', (async () => true) as typeof vscode.workspace.applyEdit);
+		const restoreSave = stub(vscode.workspace, 'save', (async (u: vscode.Uri) => u) as typeof vscode.workspace.save);
 		try {
 			await (SyncManager as any)['checkAutoFetch'](doc);
-		} catch {
-			// expected: vscode.workspace.save of an unopened mock document fails here,
-			// after applyTemplateToDocument has already updated the link.
+		} finally {
+			restoreApply();
+			restoreSave();
 		}
 
 		assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 1);
@@ -1118,11 +1242,15 @@ suite('Unit: SyncManager.syncTemplate (conflict resolution)', () => {
 			closeDiff: async () => {},
 		});
 
+		// addLink only runs after a confirmed save (#172), so stub applyEdit/save
+		// to succeed — a non-open mock document's save fails for real otherwise.
+		const restoreApply = stub(vscode.workspace, 'applyEdit', (async () => true) as typeof vscode.workspace.applyEdit);
+		const restoreSave = stub(vscode.workspace, 'save', (async (u: vscode.Uri) => u) as typeof vscode.workspace.save);
 		try {
 			await SyncManager.syncTemplate(doc);
-		} catch {
-			// expected: vscode.workspace.save of an unopened mock document fails here,
-			// same as the existing applyTemplateToDocument tests above.
+		} finally {
+			restoreApply();
+			restoreSave();
 		}
 
 		assert.strictEqual(wrapper.getCallsFor('updateTemplateBody').length, 0, 'no upload happens on take-remote');

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -27,6 +27,14 @@ export { orgFromTemplate } from './templateLinkFactory';
  */
 export class ConflictDismissedError extends Error {}
 
+function delay(ms: number): Promise<void> {
+	return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function fullDocumentRange(doc: vscode.TextDocument): vscode.Range {
+	return new vscode.Range(doc.lineAt(0).range.start, doc.lineAt(doc.lineCount - 1).range.end);
+}
+
 type ConflictChoice = 'Keep Local' | 'Take Remote' | undefined;
 
 /** Injectable seam for conflict resolution: real diff/prompt/cleanup vs. test doubles. */
@@ -106,6 +114,11 @@ export interface SyncDecisionContext {
 
 export const SyncManager = new (class _ implements vscode.Disposable {
 	private syncingUris = new Set<string>();
+	// Chained mutex serializing applyTemplateToDocument's edit+save critical
+	// section ACROSS ALL uris (not per-uri, unlike syncingUris above): firing
+	// many concurrent downloads at once — even for different files — was
+	// racing VS Code's own edit/save machinery and mostly failing (#172).
+	private applyChain: Promise<void> = Promise.resolve();
 	private disposables: vscode.Disposable[] = [];
 	private documentEventDisposables: vscode.Disposable[] = [];
 	private interval: NodeJS.Timeout | undefined;
@@ -494,6 +507,43 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		}
 	}
 
+	/**
+	 * Runs `fn` after every previously-queued caller has settled (success or
+	 * failure), so only one edit+save critical section runs at a time across the
+	 * whole extension regardless of which uri each call targets.
+	 */
+	private async withApplySerialized<T>(fn: () => Promise<T>): Promise<T> {
+		const previous = this.applyChain;
+		let release!: () => void;
+		this.applyChain = new Promise(resolve => {
+			release = resolve;
+		});
+		await previous;
+		try {
+			return await fn();
+		} finally {
+			release();
+		}
+	}
+
+	private async saveWithRetry(uri: vscode.Uri, attempts = 3): Promise<boolean> {
+		for (let attempt = 0; attempt < attempts; attempt++) {
+			if ((await vscode.workspace.save(uri)) !== undefined) return true;
+			if (attempt < attempts - 1) await delay(150 * (attempt + 1));
+		}
+		return false;
+	}
+
+	private async revertDocumentEdit(doc: vscode.TextDocument, previousText: string): Promise<void> {
+		try {
+			const revertEdit = new vscode.WorkspaceEdit();
+			revertEdit.replace(doc.uri, fullDocumentRange(doc), previousText);
+			await vscode.workspace.applyEdit(revertEdit);
+		} catch (revertError) {
+			log.warn('applyTemplateToDocument: failed to revert in-memory edit after a failed save', revertError);
+		}
+	}
+
 	async applyTemplateToDocument(doc: vscode.TextDocument, _session: Session, remoteTemplate: FullTemplateFragment) {
 		log.trace('applyTemplateToDocument: applying remote template', {
 			templateId: remoteTemplate.id,
@@ -503,21 +553,26 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 		const body = remoteTemplate.body;
 		remoteTemplate.body = '';
 
-		const edit = new vscode.WorkspaceEdit();
-		edit.replace(
-			doc.uri,
-			new vscode.Range(doc.lineAt(0).range.start, doc.lineAt(doc.lineCount - 1).range.end),
-			body,
-		);
-		await vscode.workspace.applyEdit(edit);
+		await this.withApplySerialized(async () => {
+			const previousText = doc.getText();
+			const edit = new vscode.WorkspaceEdit();
+			edit.replace(doc.uri, fullDocumentRange(doc), body);
+			await vscode.workspace.applyEdit(edit);
 
-		const templateLink = buildTemplateLink(remoteTemplate, body, doc.uri.toString());
+			const saved = await this.saveWithRetry(doc.uri);
+			if (!saved) {
+				// The edit already landed in the in-memory buffer even though the
+				// save failed — revert it so a later read of this (still-open,
+				// cached) document sees the actual on-disk content instead of the
+				// unpersisted remote body, which would otherwise falsely compare
+				// as "bodies already match" / in-sync (#172).
+				await this.revertDocumentEdit(doc, previousText);
+				throw log.error('applyTemplateToDocument: failed to save');
+			}
 
-		this.addLink(templateLink, doc.uri);
-
-		if ((await vscode.workspace.save(doc.uri)) === undefined) {
-			throw log.error('applyTemplateToDocument: failed to save');
-		}
+			const templateLink = buildTemplateLink(remoteTemplate, body, doc.uri.toString());
+			this.addLink(templateLink, doc.uri);
+		});
 
 		log.trace('applyTemplateToDocument: completed');
 	}

--- a/src/models/SyncManager.ts
+++ b/src/models/SyncManager.ts
@@ -528,7 +528,11 @@ export const SyncManager = new (class _ implements vscode.Disposable {
 
 	private async saveWithRetry(uri: vscode.Uri, attempts = 3): Promise<boolean> {
 		for (let attempt = 0; attempt < attempts; attempt++) {
-			if ((await vscode.workspace.save(uri)) !== undefined) return true;
+			try {
+				if ((await vscode.workspace.save(uri)) !== undefined) return true;
+			} catch {
+				// save rejected — treat as a retryable failure
+			}
 			if (attempt < attempts - 1) await delay(150 * (attempt + 1));
 		}
 		return false;

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -3711,6 +3711,67 @@ suite('Unit: workflowTools', () => {
 				`no more than MAX_INLINE_SUB_EXECUTIONS per level across up to 5 levels; got ${inlinedSections}`,
 			);
 			assert.match(output, /truncated at 25 fetches/, 'truncation is stated in the output when the budget is hit');
+			assert.match(
+				output,
+				/more sub-execution\(s\) not inlined/,
+				'the skip-count footer states how many siblings past the per-level cap were not inlined',
+			);
+		});
+
+		test('buddy_execution_logs includeSubExecutions notes a footer error when fetching grandchildren fails', async () => {
+			const deps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async (query, variables) => {
+					if (query.includes('RewstBuddyTaskLogs')) {
+						return {
+							data: {
+								taskLogs: [
+									{ originalWorkflowTaskName: 'root_task', status: 'succeeded', taskExecutionId: 'te-1' },
+								],
+							},
+						};
+					}
+					if (query.includes('RewstBuddyChildExecutions')) {
+						const where = (variables?.where ?? {}) as { id?: string };
+						if (where.id === 'exec-1') {
+							return {
+								data: {
+									workflowExecution: {
+										id: 'exec-1',
+										childExecutions: [
+											{
+												id: 'exec-child',
+												status: 'succeeded',
+												parentTaskExecutionId: 'te-1',
+												workflow: { id: 'wf-sub', name: 'Child Flow' },
+											},
+										],
+									},
+								},
+							};
+						}
+						if (where.id === 'exec-child') {
+							return { errors: [{ message: 'grandchild lookup boom' }] };
+						}
+						return { data: { workflowExecution: { id: where.id, childExecutions: [] } } };
+					}
+					return { data: {} };
+				},
+			};
+			const output = await runWorkflowTool(
+				{
+					tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+					args: { executionId: 'exec-1', includeSubExecutions: true, depth: 2 },
+				},
+				deps,
+			);
+			assert.match(output, /Sub-execution Child Flow \(exec-child, succeeded\):/, 'level 1 child is still inlined');
+			assert.match(
+				output,
+				/could not fetch children of sub-execution exec-child.*grandchild lookup boom/,
+				'the fetch-error footer note surfaces the failure to fetch grandchildren',
+			);
 		});
 
 		test('buddy_execution_logs with includeSubExecutions:false and depth:2 stays id-only (flags stay independent)', async () => {

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -3555,6 +3555,237 @@ suite('Unit: workflowTools', () => {
 			assert.match(output, /truncated at 25 fetches/, 'truncation note appears when fetch cap is hit');
 		});
 
+		test('buddy_execution_logs includeSubExecutions with depth 2 inlines the grandchild task log too', async () => {
+			const deps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async (query, variables) => {
+					if (query.includes('RewstBuddyTaskLogs')) {
+						const where = (variables?.where ?? {}) as { workflowExecutionId?: string };
+						if (where.workflowExecutionId === 'exec-child') {
+							return {
+								data: {
+									taskLogs: [
+										{
+											originalWorkflowTaskName: 'child_task',
+											status: 'succeeded',
+											taskExecutionId: 'te-child',
+										},
+									],
+								},
+							};
+						}
+						if (where.workflowExecutionId === 'exec-grand') {
+							return {
+								data: {
+									taskLogs: [
+										{
+											originalWorkflowTaskName: 'grand_task',
+											status: 'failed',
+											message: 'grand boom',
+											input: {},
+											result: {},
+										},
+									],
+								},
+							};
+						}
+						return {
+							data: {
+								taskLogs: [
+									{ originalWorkflowTaskName: 'root_task', status: 'succeeded', taskExecutionId: 'te-1' },
+								],
+							},
+						};
+					}
+					if (query.includes('RewstBuddyChildExecutions')) {
+						const where = (variables?.where ?? {}) as { id?: string };
+						if (where.id === 'exec-1') {
+							return {
+								data: {
+									workflowExecution: {
+										id: 'exec-1',
+										childExecutions: [
+											{
+												id: 'exec-child',
+												status: 'succeeded',
+												parentTaskExecutionId: 'te-1',
+												workflow: { id: 'wf-sub', name: 'Child Flow' },
+											},
+										],
+									},
+								},
+							};
+						}
+						if (where.id === 'exec-child') {
+							return {
+								data: {
+									workflowExecution: {
+										id: 'exec-child',
+										childExecutions: [
+											{
+												id: 'exec-grand',
+												status: 'failed',
+												parentTaskExecutionId: 'te-child',
+												workflow: { id: 'wf-grand', name: 'Grand Flow' },
+											},
+										],
+									},
+								},
+							};
+						}
+						return { data: { workflowExecution: { id: where.id, childExecutions: [] } } };
+					}
+					return { data: {} };
+				},
+			};
+			const output = await runWorkflowTool(
+				{
+					tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+					args: { executionId: 'exec-1', includeSubExecutions: true, depth: 2 },
+				},
+				deps,
+			);
+			assert.match(output, /Sub-execution Child Flow \(exec-child, succeeded\):/, 'level 1 child is inlined');
+			assert.match(output, /child_task: succeeded/, "level 1 child's own task log is inlined");
+			assert.match(
+				output,
+				/Sub-execution Grand Flow \(exec-grand, failed\) \(level 2, parent execution exec-child\):/,
+				'level 2 grandchild is inlined and labeled with its level and parent',
+			);
+			assert.match(output, /grand_task: failed/, "the grandchild's own task name shows up, not just its id");
+			assert.match(output, /grand boom/, "the grandchild's own failure message is inlined, not just listed");
+		});
+
+		test('buddy_execution_logs includeSubExecutions with depth respects the per-level inline cap and total fetch budget', async () => {
+			// Each execution has 10 children, more than MAX_INLINE_SUB_EXECUTIONS (5), and depth is deep
+			// enough that the total fetch budget (25) is exhausted before the whole tree is walked.
+			const makeChildren = (prefix: string) =>
+				Array.from({ length: 10 }, (_, i) => ({
+					id: `${prefix}-${i}`,
+					status: 'succeeded',
+					parentTaskExecutionId: 'te-1',
+					workflow: { id: `wf-${prefix}-${i}`, name: `Flow ${prefix}-${i}` },
+				}));
+			const fetchCounts: Record<string, number> = {};
+			const deps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async (query, variables) => {
+					if (query.includes('RewstBuddyTaskLogs')) {
+						const where = (variables?.where ?? {}) as { workflowExecutionId?: string };
+						const id = where.workflowExecutionId ?? 'root';
+						fetchCounts[id] = (fetchCounts[id] ?? 0) + 1;
+						return {
+							data: {
+								taskLogs: [
+									{ originalWorkflowTaskName: 't', status: 'succeeded', taskExecutionId: 'te-1' },
+								],
+							},
+						};
+					}
+					if (query.includes('RewstBuddyChildExecutions')) {
+						const where = (variables?.where ?? {}) as { id?: string };
+						const id = where.id ?? 'root';
+						fetchCounts[id] = (fetchCounts[id] ?? 0) + 1;
+						return { data: { workflowExecution: { id, childExecutions: makeChildren(id) } } };
+					}
+					return { data: {} };
+				},
+			};
+			const output = await runWorkflowTool(
+				{
+					tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+					args: { executionId: 'exec-1', includeSubExecutions: true, depth: 5 },
+				},
+				deps,
+			);
+			const totalFetches = Object.values(fetchCounts).reduce((a, b) => a + b, 0);
+			// MAX_SUB_EXECUTION_FETCHES (25) bounds the walk's own fetches; the root's unconditional
+			// task-log fetch and its unconditional child-execution lookup are not drawn from that budget
+			// (same as the pre-existing depth-only BFS walk), so the hard ceiling is 25 + 1.
+			assert.ok(totalFetches <= 26, `total fetches must stay within the shared budget; got ${totalFetches}`);
+			const inlinedSections = output.split('\n').filter(line => /^Sub-execution Flow /.test(line)).length;
+			assert.ok(
+				inlinedSections <= 5 * 5,
+				`no more than MAX_INLINE_SUB_EXECUTIONS per level across up to 5 levels; got ${inlinedSections}`,
+			);
+			assert.match(output, /truncated at 25 fetches/, 'truncation is stated in the output when the budget is hit');
+		});
+
+		test('buddy_execution_logs with includeSubExecutions:false and depth:2 stays id-only (flags stay independent)', async () => {
+			const deps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async (query, variables) => {
+					if (query.includes('RewstBuddyTaskLogs')) {
+						return {
+							data: {
+								taskLogs: [
+									{
+										originalWorkflowTaskName: 'root_task',
+										status: 'succeeded',
+										taskExecutionId: 'te-1',
+									},
+								],
+							},
+						};
+					}
+					if (query.includes('RewstBuddyChildExecutions')) {
+						const where = (variables?.where ?? {}) as { id?: string };
+						if (where.id === 'exec-1') {
+							return {
+								data: {
+									workflowExecution: {
+										id: 'exec-1',
+										childExecutions: [
+											{
+												id: 'exec-child',
+												status: 'succeeded',
+												parentTaskExecutionId: 'te-1',
+												workflow: { id: 'wf-sub', name: 'Child Flow' },
+											},
+										],
+									},
+								},
+							};
+						}
+						if (where.id === 'exec-child') {
+							return {
+								data: {
+									workflowExecution: {
+										id: 'exec-child',
+										childExecutions: [
+											{
+												id: 'exec-grand',
+												status: 'failed',
+												parentTaskExecutionId: 'te-child',
+												workflow: { id: 'wf-grand', name: 'Grand Flow' },
+											},
+										],
+									},
+								},
+							};
+						}
+						return { data: { workflowExecution: { id: where.id, childExecutions: [] } } };
+					}
+					return { data: {} };
+				},
+			};
+			const output = await runWorkflowTool(
+				{
+					tool: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
+					args: { executionId: 'exec-1', includeSubExecutions: false, depth: 2 },
+				},
+				deps,
+			);
+			assert.match(output, /Nested sub-executions \(depth 2\)/, 'old id-only nested section header present');
+			assert.match(output, /Grand Flow.*exec-grand/, 'grandchild listed by id/workflow/status only');
+			assert.match(output, /parent execution exec-child/, 'grandchild references its parent execution id');
+			assert.ok(!output.includes('Sub-execution Grand Flow'), 'no inlined task log for the grandchild');
+			assert.ok(!output.includes('Sub-execution Child Flow'), 'no inlined task log for the child either');
+		});
+
 		test('buddy_execution_logs spec documents sub-execution visibility and includeSubExecutions', () => {
 			const spec = WORKFLOW_TOOL_SPECS.find(tool => tool.name === WORKFLOW_EXECUTION_LOGS_TOOL_NAME);
 			assert.ok(spec, 'buddy_execution_logs spec exists');
@@ -4422,6 +4653,111 @@ suite('Unit: workflowTools', () => {
 			assert.ok(
 				!output.includes('drill in with buddy_workflow_diagnose'),
 				'no unresolved drill-in pointer when chain is fully inlined',
+			);
+		});
+
+		test('buddy_workflow_diagnose nested drill sections show the full sub-execution task log, not just the failing task', async () => {
+			// root → failed child (with a preceding succeeded sibling task) → failed grandchild
+			// (with a preceding succeeded sibling task). Default depth=3 should inline both nested levels.
+			const taskLogsByExec: Record<string, unknown[]> = {
+				'exec-1': [
+					{
+						originalWorkflowTaskName: 'root_task',
+						status: 'failed',
+						message: 'root boom',
+						input: {},
+						result: {},
+						taskExecutionId: 'te-root',
+					},
+				],
+				'exec-child': [
+					{
+						originalWorkflowTaskName: 'child_setup',
+						status: 'succeeded',
+						taskExecutionId: 'te-child-setup',
+					},
+					{
+						originalWorkflowTaskName: 'child_task',
+						status: 'failed',
+						message: 'child boom',
+						input: {},
+						result: {},
+						taskExecutionId: 'te-child',
+					},
+				],
+				'exec-grand': [
+					{
+						originalWorkflowTaskName: 'grand_setup',
+						status: 'succeeded',
+						taskExecutionId: 'te-grand-setup',
+					},
+					{
+						originalWorkflowTaskName: 'grand_task',
+						status: 'failed',
+						message: 'grand boom',
+						input: {},
+						result: {},
+						taskExecutionId: 'te-grand',
+					},
+				],
+			};
+			const childrenByExec: Record<string, unknown[]> = {
+				'exec-1': [
+					{
+						id: 'exec-child',
+						status: 'failed',
+						parentTaskExecutionId: 'te-root',
+						workflow: { id: 'wf-child', name: 'Child WF' },
+					},
+				],
+				'exec-child': [
+					{
+						id: 'exec-grand',
+						status: 'failed',
+						parentTaskExecutionId: 'te-child',
+						workflow: { id: 'wf-grand', name: 'Grand WF' },
+					},
+				],
+				'exec-grand': [],
+			};
+			const deps: GraphqlToolDeps = {
+				isEnabled: () => true,
+				confirmMutation: async () => true,
+				execute: async (query, variables) => {
+					if (query.includes('RewstBuddyTaskLogs')) {
+						const where = (variables?.where ?? {}) as { workflowExecutionId?: string };
+						return { data: { taskLogs: taskLogsByExec[where.workflowExecutionId ?? ''] ?? [] } };
+					}
+					if (query.includes('RewstBuddyChildExecutions')) {
+						const where = (variables?.where ?? {}) as { id?: string };
+						return {
+							data: {
+								workflowExecution: {
+									id: where.id,
+									status: 'FAILED',
+									orgId: 'org-1',
+									workflow: { id: 'wf-1', name: 'Root WF', orgId: 'org-1' },
+									childExecutions: childrenByExec[where.id ?? ''] ?? [],
+								},
+							},
+						};
+					}
+					if (query.includes('RewstBuddyExecutionContexts'))
+						return { data: { workflowExecutionContexts: [{}] } };
+					return { data: {} };
+				},
+			};
+			const output = await runWorkflowTool(
+				{ tool: WORKFLOW_DIAGNOSE_TOOL_NAME, args: { executionId: 'exec-1' } },
+				deps,
+			);
+			assert.match(output, /Nested diagnosis \(level 1/, 'level 1 nested section present');
+			assert.match(output, /child_setup: succeeded/, "level 1 section includes the sibling task, not just child_task");
+			assert.match(output, /Nested diagnosis \(level 2/, 'level 2 nested section present');
+			assert.match(
+				output,
+				/grand_setup: succeeded/,
+				"level 2 section includes the sibling task, not just grand_task",
 			);
 		});
 

--- a/src/workflow/executions.ts
+++ b/src/workflow/executions.ts
@@ -547,6 +547,9 @@ export async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDe
 			currentLevel = nextLevel;
 		}
 
+		if (nestedSections.length > 0 && depth > 1) {
+			footer.push(`Nested task logs (full depth, up to level ${depth}):`);
+		}
 		footer.push(...nestedSections);
 		if (skippedTotal > 0) {
 			footer.push(`(${skippedTotal} more sub-execution(s) not inlined — drill into them individually.)`);

--- a/src/workflow/executions.ts
+++ b/src/workflow/executions.ts
@@ -481,28 +481,84 @@ export async function runExecutionLogs(request: ToolRequest, deps: GraphqlToolDe
 			`Sub-execution(s) not shown with a task above: ${unshownChildren.map(describeChildExecution).join(', ')}`,
 		);
 	}
-	if (includeSubExecutions) {
-		const inlineSections = await Promise.all(
-			children.slice(0, MAX_INLINE_SUB_EXECUTIONS).map(async child => {
-				if (!child.id) return undefined;
-				try {
-					const childRows = await fetchTaskLogs(sourceDeps, child.id);
-					return `Sub-execution ${describeChildExecution(child)}:\n${formatTaskLogs(childRows, { failedOnly, includeResult })}`;
-				} catch (error) {
-					return `Sub-execution ${describeChildExecution(child)}: task logs could not be read (${error instanceof Error ? error.message : String(error)})`;
-				}
-			}),
-		);
-		footer.push(...inlineSections.filter((section): section is string => !!section));
-		if (children.length > MAX_INLINE_SUB_EXECUTIONS) {
-			footer.push(
-				`(${children.length - MAX_INLINE_SUB_EXECUTIONS} more sub-execution(s) not inlined — drill into them individually.)`,
-			);
+	if (includeSubExecutions && children.length > 0) {
+		// Level-by-level walk: inline full task logs for up to MAX_INLINE_SUB_EXECUTIONS
+		// siblings at every level up to `depth`, bounded overall by MAX_SUB_EXECUTION_FETCHES.
+		interface LevelEntry {
+			child: ChildExecutionRow;
+			parentId: string;
 		}
-	}
+		const nestedSections: string[] = [];
+		const fetchErrors: string[] = [];
+		let totalFetches = 1; // root task log fetch already done
+		let truncated = false;
+		let skippedTotal = 0;
+		let currentLevel: LevelEntry[] = children.map(c => ({ child: c, parentId: executionId }));
 
-	// BFS walk for depth > 1
-	if (depth > 1 && children.length > 0) {
+		for (let level = 1; level <= depth && currentLevel.length > 0 && !truncated; level++) {
+			const eligible = currentLevel.filter((e): e is LevelEntry & { child: { id: string } } => !!e.child.id);
+			const remainingBudget = MAX_SUB_EXECUTION_FETCHES - totalFetches;
+			if (remainingBudget <= 0) {
+				truncated = true;
+				break;
+			}
+			const inlineCount = Math.min(MAX_INLINE_SUB_EXECUTIONS, remainingBudget, eligible.length);
+			const toInline = eligible.slice(0, inlineCount);
+			skippedTotal += currentLevel.length - toInline.length;
+			if (remainingBudget < MAX_INLINE_SUB_EXECUTIONS && eligible.length > toInline.length) {
+				truncated = true;
+			}
+			totalFetches += toInline.length;
+
+			const levelResults = await Promise.all(
+				toInline.map(async ({ child, parentId }) => {
+					const label =
+						level === 1
+							? `Sub-execution ${describeChildExecution(child)}`
+							: `Sub-execution ${describeChildExecution(child)} (level ${level}, parent execution ${parentId})`;
+					try {
+						const childRows = await fetchTaskLogs(sourceDeps, child.id);
+						return `${label}:\n${formatTaskLogs(childRows, { failedOnly, includeResult })}`;
+					} catch (error) {
+						return `${label}: task logs could not be read (${error instanceof Error ? error.message : String(error)})`;
+					}
+				}),
+			);
+			nestedSections.push(...levelResults);
+
+			const nextLevel: LevelEntry[] = [];
+			if (level < depth && !truncated) {
+				for (const { child } of toInline) {
+					if (totalFetches >= MAX_SUB_EXECUTION_FETCHES) {
+						truncated = true;
+						break;
+					}
+					totalFetches++;
+					const { children: grandchildren, error } = await fetchChildExecutions(sourceDeps, child.id);
+					if (error) {
+						fetchErrors.push(`sub-execution ${child.id} (${describeChildExecution(child)}): ${error}`);
+						continue;
+					}
+					for (const gc of grandchildren) {
+						nextLevel.push({ child: gc, parentId: child.id });
+					}
+				}
+			}
+			currentLevel = nextLevel;
+		}
+
+		footer.push(...nestedSections);
+		if (skippedTotal > 0) {
+			footer.push(`(${skippedTotal} more sub-execution(s) not inlined — drill into them individually.)`);
+		}
+		if (truncated) {
+			footer.push(`(sub-execution tree truncated at ${MAX_SUB_EXECUTION_FETCHES} fetches — drill in manually.)`);
+		}
+		for (const fetchError of fetchErrors) {
+			footer.push(`(could not fetch children of ${fetchError})`);
+		}
+	} else if (depth > 1 && children.length > 0) {
+		// BFS walk for depth > 1 (includeSubExecutions:false): id-only listing, unbounded by task-log fetches.
 		interface BfsEntry {
 			child: ChildExecutionRow;
 			level: number;
@@ -871,7 +927,7 @@ export async function runWorkflowDiagnose(request: ToolRequest, deps: GraphqlToo
 				const childFailingRow = childTaskRows.find(r => isFailedStatus(r.status));
 				if (!childFailingRow) break;
 				sections.push(
-					`Nested diagnosis (level ${k}, execution ${drillChild.id}, workflow ${drillChild.workflow?.name ?? '?'}):\n${formatTaskLogs([childFailingRow], { includeResult: true })}`,
+					`Nested diagnosis (level ${k}, execution ${drillChild.id}, workflow ${drillChild.workflow?.name ?? '?'}):\n${formatTaskLogs(childTaskRows, { includeResult: true })}`,
 				);
 				const { children: grandchildren } = await fetchChildExecutions(sourceDeps, drillChild.id);
 				const childFailingTaskExecId = childFailingRow.taskExecutionId;

--- a/src/workflow/specs.ts
+++ b/src/workflow/specs.ts
@@ -257,7 +257,7 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = withGeneratedArgsForAll([
 	{
 		name: WORKFLOW_EXECUTION_LOGS_TOOL_NAME,
 		description:
-			"Inspect one workflow execution's task logs: per task, its status, and for failed tasks the message, the input it received, and the result it produced — the fastest way to see WHY a run failed, instead of hand-writing taskLogs GraphQL. Get an executionId from buddy_workflow_run or buddy_workflow_executions. By default every task shows name + status and failed tasks additionally show message, input, and result (truncated); pass includeResult to include every task's result, or failedOnly to list only failed tasks. A task that called a sub-workflow is marked with the sub-execution it spawned (workflow name, execution id, status) — a sub-workflow's own tasks are NOT in the parent's logs, so drill into a sub-execution by calling this tool again with its execution id, or pass includeSubExecutions:true to inline the task logs of the first few sub-executions. A task's input shows exactly what it received (an empty-string id means the caller passed nothing); its result shows the real output shape — read it before assuming a wrapper key (e.g. some actions return a list directly, not { items: [...] }). Each signed-in Rewst session only sees its own org hierarchy: if the first session has no rows for the execution, the other active sessions are checked automatically; pass orgId (the org that owns the execution) to query the right session directly. Pass depth (default 1, max 5) to walk deeper levels of nested sub-workflow executions.",
+			"Inspect one workflow execution's task logs: per task, its status, and for failed tasks the message, the input it received, and the result it produced — the fastest way to see WHY a run failed, instead of hand-writing taskLogs GraphQL. Get an executionId from buddy_workflow_run or buddy_workflow_executions. By default every task shows name + status and failed tasks additionally show message, input, and result (truncated); pass includeResult to include every task's result, or failedOnly to list only failed tasks. A task that called a sub-workflow is marked with the sub-execution it spawned (workflow name, execution id, status) — a sub-workflow's own tasks are NOT in the parent's logs, so drill into a sub-execution by calling this tool again with its execution id, or pass includeSubExecutions:true to inline the full task logs of the first few sub-executions. A task's input shows exactly what it received (an empty-string id means the caller passed nothing); its result shows the real output shape — read it before assuming a wrapper key (e.g. some actions return a list directly, not { items: [...] }). Each signed-in Rewst session only sees its own org hierarchy: if the first session has no rows for the execution, the other active sessions are checked automatically; pass orgId (the org that owns the execution) to query the right session directly. Pass depth (default 1, max 5) to walk deeper levels of nested sub-workflow executions: with includeSubExecutions:false, depth only lists each descendant execution's id/workflow/status; with includeSubExecutions:true, depth inlines full task logs (same detail as the top level) at every nested level up to depth, not just the first — bounded by a per-level inline cap and a total fetch budget, each stated in the output if hit.",
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -275,12 +275,12 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = withGeneratedArgsForAll([
 				includeSubExecutions: {
 					type: 'boolean',
 					description:
-						'Also inline the task logs of the first few sub-workflow executions this run spawned (default false).',
+						"Also inline the full task logs of the first few sub-workflow executions this run spawned (default false). Combine with depth > 1 to inline task logs at every nested level, not just the first — each level still caps at the first few sub-executions and the whole walk shares one fetch budget.",
 				},
 				depth: {
 					type: 'number',
 					description:
-						'How many levels of nested sub-workflow executions to list (default 1 = direct children, max 5). Each extra level costs one query per execution found at that level.',
+						'How many levels of nested sub-workflow executions to walk (default 1 = direct children, max 5). Without includeSubExecutions, each level is listed by id/workflow/status only. With includeSubExecutions:true, each level up to depth also gets full task logs inlined. Each extra level costs one query per execution found at that level.',
 				},
 			},
 			required: ['executionId'],
@@ -300,9 +300,12 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = withGeneratedArgsForAll([
 			"merged execution context's top-level keys so you know what CTX.<field> paths are available. " +
 			"Each signed-in Rewst session only sees its own org hierarchy: if the first session can't see " +
 			'the execution, other active sessions are checked automatically, same as buddy_execution_logs; ' +
-			'pass orgId to route directly. For the full task-by-task list instead of just the failing task, ' +
-			'use buddy_execution_logs. ' +
-			'Pass depth (default 3, max 5) to control how many nested failing executions are diagnosed inline; failures while drilling degrade to a note rather than failing the call.',
+			'pass orgId to route directly. For the full task-by-task list of the top-level execution instead ' +
+			'of just its failing task, use buddy_execution_logs. ' +
+			'Pass depth (default 3, max 5) to control how many nested failing executions are diagnosed inline: ' +
+			"the top-level section stays narrowed to the single failing task, but each auto-drilled nested " +
+			"level shows that sub-execution's complete task log (not just its failing task), so a preceding " +
+			'or sibling task can explain the failure. Failures while drilling degrade to a note rather than failing the call.',
 		inputSchema: {
 			type: 'object',
 			properties: {
@@ -322,7 +325,7 @@ export const WORKFLOW_TOOL_SPECS: ToolSpec[] = withGeneratedArgsForAll([
 				depth: {
 					type: 'number',
 					description:
-						'How many levels of failing sub-workflow executions to drill into automatically (default 3, max 5).',
+						"How many levels of failing sub-workflow executions to drill into automatically (default 3, max 5). Each drilled level's section shows that sub-execution's complete task log, not just its failing task.",
 				},
 			},
 		},


### PR DESCRIPTION
Bundling two related-in-scope fixes to save review passes.

## #170 — task logs should nest like diagnose

- `buddy_execution_logs`'s `depth` parameter (max 5) was supposed to let the model walk deeper levels of nested sub-workflow executions, but for `depth > 1` it only listed each descendant execution's id/workflow name/status — it never fetched that execution's actual task logs. Combined with `includeSubExecutions`, only depth-1 children ever got their logs inlined.
- `buddy_workflow_diagnose`'s auto-drill into a failing chain narrowed each nested level to just the single failing task row, discarding every other task in that sub-execution's log.

**Change:**
- `runExecutionLogs`: `includeSubExecutions:true` + `depth > 1` now recursively inlines full task logs at every level up to `depth` (bounded by the existing per-level/total fetch budgets). `depth > 1` alone keeps its old id-only listing. Added a "Nested task logs (full depth, up to level N):" header, echoing the issue's own "full depth" language into the tool's own output.
- `runWorkflowDiagnose`: nested drill sections now show the sub-execution's full task log instead of just the failing row.
- Updated tool descriptions in `src/workflow/specs.ts` accordingly.

## #172 — buddy_template_sync: concurrent downloads mostly fail, then falsely report in-sync

- `applyTemplateToDocument()` applied the download edit to the in-memory document immediately, then called `vscode.workspace.save()`. Firing many downloads at once (e.g. 15 concurrent syncs across different files) raced VS Code's own edit/save machinery and mostly failed with "failed to save". On a save failure, the edit was left applied in memory and the link was recorded as if sync had succeeded — so a later check re-opened the same (still-dirty) document, read the leftover unsaved remote body via `doc.getText()`, and reported "bodies already match" / in-sync, even though the file on disk was still empty.

**Change:**
- Serialize `applyTemplateToDocument`'s edit+save critical section across *all* calls (not just same-uri) via a chained mutex, so concurrent downloads no longer race VS Code's save machinery.
- Retry a failed save a few times before giving up.
- On exhausted retries, revert the in-memory edit back to the pre-download content and never record the link — so a subsequent check reads real on-disk state instead of a phantom unsaved edit.

## Testing

- `npx tsc --noEmit`: clean.
- `npm run test:unit`: fully green (vitest 253 passing across 12 files; mocha extension-host suite 1520 passing).
- New tests cover: full-depth nested inlining + budget enforcement for `buddy_execution_logs`, full nested task logs for `buddy_workflow_diagnose`, and for the sync fix: retry-then-succeed, revert-and-no-link-on-exhausted-retries, and cross-file save serialization (asserted via a concurrency counter).
- The #170 portion also went through an independent multi-agent adversarial review pass (correctness, test-coverage, docs/spec-consistency lenses); no confirmed issues survived verification.

Addresses #170
Addresses #172

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested execution log display so sub-executions now show full task logs at each requested depth.
  * Made template sync more reliable under concurrent downloads, with retries on save failure and safer handling when saving still fails.
  * Prevented concurrent sync operations from overlapping, reducing flaky download/save behavior.
  * Updated workflow diagnosis output so nested drill-downs include complete sub-execution details, not just the failing task.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->