### PR TITLE
Fix batch: issues #168, #173-#177

### DIFF
--- a/changelog.d/168.md
+++ b/changelog.d/168.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 168
+---
+
+- **Chat no longer forwards raw terminal scrollback as if it were instructions.** Terminal tool output is now capped much tighter and clearly marked as likely-unrelated context, instead of being sent to the assistant verbatim and sometimes mistaken for the actual request.

--- a/changelog.d/173.md
+++ b/changelog.d/173.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 173
+---
+
+- **Jinja Live Preview now renders immediately, even before picking an execution context.** It previously blocked on a context pick before showing anything; it now renders right away using empty/override-only variables, per Jinja's normal undefined-variable handling.

--- a/changelog.d/174.md
+++ b/changelog.d/174.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 174
+---
+
+- **Creating a task with a specific pack config selection now sticks on the first try.** Rewst's API silently defaults `configSelectionMode`/`configFallbackMode` on a newly created task, honoring them only on a follow-up update; `buddy_workflow_edit` now detects that and auto-corrects it, instead of requiring a manual second edit.

--- a/changelog.d/175.md
+++ b/changelog.d/175.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 175
+---
+
+- **The chat assistant retries much harder before giving up when the backend keeps requesting a server-side tool by mistake.** It previously surfaced a "stopped" message after a single correction attempt; it now escalates through many attempts, so the stop message should now rarely, if ever, appear.

--- a/changelog.d/176.md
+++ b/changelog.d/176.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 176
+---
+
+- **Renaming a template now updates the status bar and tree view immediately.** `buddy_rename_template` previously left the locally cached template name stale until the next sync or reload; it now refreshes the local link cache right away.

--- a/changelog.d/177.md
+++ b/changelog.d/177.md
@@ -3,4 +3,4 @@ category: Fixed
 pr: 177
 ---
 
-- **Delete operations now always prompt for approval, even after another change to the same resource was approved.** Approving a rename or update could previously pre-approve deleting that same template, tag, org variable, or workflow with no further prompt.
+- **Delete operations, and raw GraphQL mutations, now always prompt for approval, even after another change to the same resource was approved.** Approving a rename or update could previously pre-approve a later delete, or a raw mutation reusing the same scope, with no further prompt.

--- a/changelog.d/177.md
+++ b/changelog.d/177.md
@@ -1,0 +1,6 @@
+---
+category: Fixed
+pr: 177
+---
+
+- **Delete operations now always prompt for approval, even after another change to the same resource was approved.** Approving a rename or update could previously pre-approve deleting that same template, tag, org variable, or workflow with no further prompt.

--- a/docs/features.md
+++ b/docs/features.md
@@ -93,7 +93,7 @@ The `Preview Jinja Render` command opens a native 3-pane layout beside your link
 **How it works:**
 
 1. Open a linked template file and run `Preview Jinja Render` from the command palette, the editor title bar (`$(eye)` icon), the right-click context menu, or the `Ctrl+Shift+Enter` / `Cmd+Shift+Enter` keybinding.
-2. Two panes open to the right of the template, stacked top/bottom: a **vars/overrides** file on top and a read-only **rendered output** document below it. Both are named after the template (e.g. `My Template (a1b2c3d4).vars.jsonc`), not a raw id. Click **Pick Jinja Preview Context** (editor title bar `$(target)` icon, or the same menus/keybinding pattern) to select a workflow and one of its recent executions — the execution's context snapshots are fetched and merged once.
+2. Two panes open to the right of the template, stacked top/bottom: a **vars/overrides** file on top and a read-only **rendered output** document below it. Both are named after the template (e.g. `My Template (a1b2c3d4).vars.jsonc`), not a raw id. The rendered pane starts updating immediately, even with no execution context picked — undefined variables render per Jinja's normal semantics. Click **Pick Jinja Preview Context** (editor title bar `$(target)` icon, or the same menus/keybinding pattern) to select a workflow and one of its recent executions and merge its context in — the execution's context snapshots are fetched and merged once.
 3. Edit the template (or select a sub-expression), or edit the vars/overrides file, and the rendered-output pane re-renders within 300 ms of your last keystroke, calling the same server-side render engine as `buddy_render_jinja`.
 
 **Key behaviours:**

--- a/openspec/specs/ai-chat/spec.md
+++ b/openspec/specs/ai-chat/spec.md
@@ -203,11 +203,11 @@ rendered as the final path. It SHALL interrupt the native attempt, send a neutra
 correction that names the local `vscode-tool` transport, carry through any
 resolved native tool arguments, and suppress abandoned native output. A repeated
 native-tool attempt within the same backend turn sequence SHALL escalate through
-multiple correction attempts (`MAX_NATIVE_REDIRECT_ATTEMPTS`) — each subsequent
-correction states its attempt number, still within the same neutral,
-transport-focused wording rules — before finally giving up and surfacing a stop
-message; the ceiling is intentionally high because surfacing that stop message is
-a last resort, not an expected outcome.
+the configured redirect-attempt budget — each subsequent correction states its
+attempt number, still within the same neutral, transport-focused wording rules —
+before finally giving up and surfacing a stop message; the ceiling is
+intentionally high because surfacing that stop message is a last resort, not an
+expected outcome.
 
 #### Scenario: Backend tries a native Rewst tool
 
@@ -234,7 +234,7 @@ a last resort, not an expected outcome.
 #### Scenario: A later correction attempt succeeds
 
 - **GIVEN** the backend has repeated a native Rewst tool attempt across several
-  corrections, still below `MAX_NATIVE_REDIRECT_ATTEMPTS`
+  corrections, still below the configured redirect-attempt budget
 - **WHEN** the backend finally follows a later correction and answers using the
   local tool protocol instead
 - **THEN** the final answer streams normally and no stop message is shown
@@ -242,7 +242,8 @@ a last resort, not an expected outcome.
 #### Scenario: The redirect ceiling is exhausted
 
 - **GIVEN** the backend has repeated a native Rewst tool attempt
-  `MAX_NATIVE_REDIRECT_ATTEMPTS` times despite escalating corrections
+  until the configured redirect-attempt budget is exhausted despite escalating
+  corrections
 - **WHEN** the native tool is attempted once more
 - **THEN** the extension gives up and shows the stop message asking the user to
   ask again, instead of attempting another correction

--- a/openspec/specs/ai-chat/spec.md
+++ b/openspec/specs/ai-chat/spec.md
@@ -55,6 +55,38 @@ so rolled-back turns are not reattached later.
 - **AND** the old backend conversation is forgotten so hidden rolled-back turns
   cannot leak into the new branch
 
+### Requirement: Cap and frame high-noise tool output in the stateless transcript
+
+When a fresh backend conversation is started with a stateless visible
+transcript, the system SHALL serialize editor tool results by tool name. A
+tool result whose tool name matches a terminal-reading tool (e.g.
+`run_in_terminal`, `get_terminal_output`) SHALL be capped far tighter than
+other tool results and prefixed with an explicit note that the content is raw
+terminal output likely unrelated to the current request, so leftover
+scrollback from an unrelated terminal session (a different Claude Code or CLI
+run in the same integrated terminal) is not treated by the backend as an
+implicit directive. Other tool results SHALL keep the standard, more generous
+per-entry cap.
+
+Source: `src/ui/chat/model/statelessTranscript.ts`.
+
+#### Scenario: Terminal tool output is capped and framed
+
+- **GIVEN** the visible chat history includes a terminal-reading tool's result
+  with output far longer than the terminal-specific cap
+- **WHEN** the stateless transcript is serialized
+- **THEN** that tool result is truncated to the tighter terminal cap
+- **AND** it is prefixed with a note marking it as likely-unrelated raw
+  terminal output
+
+#### Scenario: Non-terminal tool output is unaffected
+
+- **GIVEN** the visible chat history includes a non-terminal editor tool's
+  result (e.g. a file read)
+- **WHEN** the stateless transcript is serialized
+- **THEN** that tool result keeps the standard per-entry cap and is not
+  prefixed with the terminal-output note
+
 ### Requirement: Honor conversation type and custom instructions
 
 The system SHALL send the configured conversation type
@@ -169,7 +201,13 @@ When local Buddy tools are available, including when the external MCP bridge is
 disabled, the system SHALL prevent backend-native Rewst tool activity from being
 rendered as the final path. It SHALL interrupt the native attempt, send a neutral
 correction that names the local `vscode-tool` transport, carry through any
-resolved native tool arguments, and suppress abandoned native output.
+resolved native tool arguments, and suppress abandoned native output. A repeated
+native-tool attempt within the same backend turn sequence SHALL escalate through
+multiple correction attempts (`MAX_NATIVE_REDIRECT_ATTEMPTS`) — each subsequent
+correction states its attempt number, still within the same neutral,
+transport-focused wording rules — before finally giving up and surfacing a stop
+message; the ceiling is intentionally high because surfacing that stop message is
+a last resort, not an expected outcome.
 
 #### Scenario: Backend tries a native Rewst tool
 
@@ -192,6 +230,22 @@ resolved native tool arguments, and suppress abandoned native output.
 - **GIVEN** no Buddy tools are available locally
 - **WHEN** the backend emits native Rewst tool activity
 - **THEN** that native activity is allowed to stream normally
+
+#### Scenario: A later correction attempt succeeds
+
+- **GIVEN** the backend has repeated a native Rewst tool attempt across several
+  corrections, still below `MAX_NATIVE_REDIRECT_ATTEMPTS`
+- **WHEN** the backend finally follows a later correction and answers using the
+  local tool protocol instead
+- **THEN** the final answer streams normally and no stop message is shown
+
+#### Scenario: The redirect ceiling is exhausted
+
+- **GIVEN** the backend has repeated a native Rewst tool attempt
+  `MAX_NATIVE_REDIRECT_ATTEMPTS` times despite escalating corrections
+- **WHEN** the native tool is attempted once more
+- **THEN** the extension gives up and shows the stop message asking the user to
+  ask again, instead of attempting another correction
 
 ### Requirement: Surface sources and context usage
 

--- a/openspec/specs/jinja-preview/spec.md
+++ b/openspec/specs/jinja-preview/spec.md
@@ -38,7 +38,10 @@ for the same document reveals the existing panel instead of opening a duplicate.
 
 Picking a context SHALL: list workflows reachable from the file's org, list that workflow's recent
 executions, then fetch and merge that execution's context snapshots into one object held for the
-life of the picked context (re-fetched only on a new pick, never per keystroke).
+life of the picked context (re-fetched only on a new pick, never per keystroke). Rendering SHALL
+NOT be gated on a context having been picked: with no context picked, an unset merged context is
+treated as an empty object and the panel renders using only whatever overrides are present in the
+vars file, since Jinja resolves undefined variables per its own normal semantics server-side.
 
 #### Scenario: Pick context, then edit repeatedly
 
@@ -51,7 +54,8 @@ life of the picked context (re-fetched only on a new pick, never per keystroke).
 
 - **GIVEN** a Jinja Preview panel with no context picked
 - **WHEN** the panel is shown
-- **THEN** it displays a "Pick Jinja Preview Context" prompt and does not attempt to render
+- **THEN** it renders immediately using an empty base context merged with whatever overrides are in
+  the vars file, rather than blocking on a "Pick Jinja Preview Context" prompt
 
 ### Requirement: Last-picked context is remembered per template
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -796,38 +796,52 @@ from a cached error.
 ### Requirement: Reuse approvals only for reusable mutation scopes
 
 The system SHALL remember approval for mutation scopes that are safe to reuse
-within the current extension session, such as repeated writes to the same
-approved GraphQL scope or repeated auto-layouts of the same workflow, in a
-single process-global cache keyed by organization id and resource id. This
-cache is not transport-specific: it is shared by both the in-process Cage-Free
-Rewsty chat tool path and the external MCP transport, behind the one
+within the current extension session — a typed write capability (e.g. rename,
+update body, create) whose `scopeId` has been verified against a real fetched
+resource id, or a repeated auto-layout of the same workflow — in a single
+process-global cache keyed by organization id and resource id. This cache is
+not transport-specific: it is shared by both the in-process Cage-Free Rewsty
+chat tool path and the external MCP transport, behind the one
 mutation-approval modal both paths call — see ai-chat's `Run in-process Buddy
 tools with a per-response cap` requirement for the chat-side description of
 this same mechanism. The system SHALL still require fresh approval for
 operations whose execution itself is the risky action: running a workflow,
 editing a workflow's definition (each edit is a distinct graph change the user
-has not seen), and any delete-type mutation (delete template, delete tag,
-delete org variable, delete workflow) regardless of any prior non-delete
-approval already recorded for that same resource — the approval scope is keyed
-only by organization and resource id, with no operation-type component, so a
-delete sharing a resource's scope with an earlier rename/update approval must
-never silently reuse it (#177).
+has not seen), any delete-type mutation (delete template, delete tag, delete
+org variable, delete workflow) regardless of any prior non-delete approval
+already recorded for that same resource — the approval scope is keyed only by
+organization and resource id, with no operation-type component, so a delete
+sharing a resource's scope with an earlier rename/update approval must never
+silently reuse it (#177) — and `buddy_graphql_mutate`, whose caller supplies an
+arbitrary `scopeId` alongside an arbitrary mutation document with no
+verification that the two are related, so a scope-keyed approval there has no
+fixed relationship to what any given call actually does and MUST NOT be
+reused, even for a byte-identical repeat of the same query and scope (#177
+follow-up).
 
-#### Scenario: Reused raw GraphQL mutation approval
+#### Scenario: Reused mutation approval for a typed write capability
 
-- **GIVEN** a raw GraphQL mutation scope was approved for an org and resource
+- **GIVEN** a typed write capability's mutation scope (e.g. `buddy_update_org_variable`, `buddy_workflow_autolayout`) was approved for an org and resource
 - **WHEN** the same mutation scope is requested again in the same session
 - **THEN** the mutation can run without prompting again
 
 #### Scenario: Approval reuse crosses the chat/MCP transport boundary
 
-- **GIVEN** a mutation scope was approved through the in-process Cage-Free
-  Rewsty chat tool path
+- **GIVEN** a typed write capability's mutation scope was approved through the
+  in-process Cage-Free Rewsty chat tool path
 - **WHEN** the same org+resource scope is requested again through the external
   MCP transport in the same extension session
 - **THEN** the mutation can run without prompting again
 - **AND** the reverse also holds: a scope approved through the external MCP
   transport is reused for the in-process chat path
+
+#### Scenario: buddy_graphql_mutate never reuses a scope approval
+
+- **GIVEN** `buddy_graphql_mutate` was approved and run for a given org, scopeId,
+  and query
+- **WHEN** `buddy_graphql_mutate` is called again with the same org and scopeId,
+  whether the query is identical or different
+- **THEN** the user is prompted again before the mutation runs
 
 #### Scenario: Workflow run approval is always fresh
 

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -532,6 +532,23 @@ manual re-read, not fail the edit.
 - **THEN** it reports the applied operations and notes that the stored inputs
   could not be verified
 
+#### Scenario: A newly created task's packOverrides mode is self-corrected
+
+- **GIVEN** an `add_task` operation supplies `packOverrides` with a
+  `configSelectionMode`/`configFallbackMode` other than the default, and the
+  server stores `USE_DEFAULT` for that field on the same write that creates the
+  task (a known server-side quirk: the mode is honored on an update of an
+  already-existing task but not on the task's creation)
+- **WHEN** the verification read detects that divergence for a task the batch
+  itself created
+- **THEN** the tool automatically replays one corrective `updateWorkflow` call
+  resending that task's `packOverrides`, then re-verifies
+- **AND** if the replay's stored values now match what was sent, the tool
+  result omits the divergence warning and instead notes that the mode was
+  auto-corrected
+- **AND** if the replay still diverges, the original divergence warning is
+  kept and no further replay is attempted
+
 ### Requirement: Rate-limit, audit, and attribute tool calls
 
 The system SHALL rate-limit tool calls, audit every call (tool, org, outcome,
@@ -787,9 +804,14 @@ Rewsty chat tool path and the external MCP transport, behind the one
 mutation-approval modal both paths call — see ai-chat's `Run in-process Buddy
 tools with a per-response cap` requirement for the chat-side description of
 this same mechanism. The system SHALL still require fresh approval for
-operations whose execution itself is the risky action: running a workflow, and
+operations whose execution itself is the risky action: running a workflow,
 editing a workflow's definition (each edit is a distinct graph change the user
-has not seen).
+has not seen), and any delete-type mutation (delete template, delete tag,
+delete org variable, delete workflow) regardless of any prior non-delete
+approval already recorded for that same resource — the approval scope is keyed
+only by organization and resource id, with no operation-type component, so a
+delete sharing a resource's scope with an earlier rename/update approval must
+never silently reuse it (#177).
 
 #### Scenario: Reused raw GraphQL mutation approval
 
@@ -818,6 +840,14 @@ has not seen).
 - **GIVEN** a workflow edit was approved previously for a workflow
 - **WHEN** another edit to the same workflow is requested in the same session
 - **THEN** the user is prompted again before the edit is saved
+
+#### Scenario: Approving a non-delete mutation does not pre-approve a delete on the same resource
+
+- **GIVEN** a non-delete mutation (e.g. rename, update, or auto-layout) on a
+  resource was approved in the current session
+- **WHEN** a delete-type mutation is requested for that same org+resource
+- **THEN** the user is prompted again before the delete runs, rather than the
+  delete silently reusing the earlier approval
 
 ### Requirement: Diagnose a failed execution in one call
 

--- a/openspec/specs/template-linking/spec.md
+++ b/openspec/specs/template-linking/spec.md
@@ -87,6 +87,32 @@ scanning all links.
 - **THEN** it resolves them via the template-id index rather than filtering the
   full link collection
 
+### Requirement: Keep cached template metadata in sync after a remote rename
+
+Renaming a Rewst template via `buddy_rename_template` SHALL update the cached
+`template.name` on every local link for that template id and emit the same
+change event other link mutations emit, so surfaces that read the cached name
+(the status bar, the tree view) reflect the new name without a manual reload.
+Renaming a template with no local link SHALL be a no-op for the link cache,
+not an error.
+
+Source: `src/capabilities/templateMutateCapabilities.ts`.
+
+#### Scenario: Renaming a linked template refreshes the cached name
+
+- **GIVEN** a local file linked to a Rewst template
+- **WHEN** `buddy_rename_template` successfully renames that template
+- **THEN** the local link's cached `template.name` is updated to the new name
+- **AND** `onLinksSaved` fires so subscribed UI (status bar, tree view)
+  refreshes without a reload
+
+#### Scenario: Renaming an unlinked template does not error
+
+- **GIVEN** no local file is linked to a given template id
+- **WHEN** `buddy_rename_template` successfully renames that template
+- **THEN** the rename still succeeds and returns normally, with no local link
+  to update
+
 ### Requirement: Track file renames and moves
 
 The system SHALL follow links when their underlying files are renamed or moved,

--- a/openspec/specs/template-linking/spec.md
+++ b/openspec/specs/template-linking/spec.md
@@ -90,11 +90,14 @@ scanning all links.
 ### Requirement: Keep cached template metadata in sync after a remote rename
 
 Renaming a Rewst template via `buddy_rename_template` SHALL update the cached
-`template.name` on every local link for that template id and emit the same
-change event other link mutations emit, so surfaces that read the cached name
-(the status bar, the tree view) reflect the new name without a manual reload.
-Renaming a template with no local link SHALL be a no-op for the link cache,
-not an error.
+`template.name` and `template.updatedAt` on every local link for that template
+id and emit the same change event other link mutations emit, so surfaces that
+read the cached name (the status bar, the tree view) reflect the new name
+without a manual reload. `updatedAt` SHALL move forward to the value the rename
+mutation returned, not just the name: leaving it stale would make the next
+auto-fetch check see a provably-newer remote and needlessly re-fetch and
+re-save the unchanged body. Renaming a template with no local link SHALL be a
+no-op for the link cache, not an error.
 
 Source: `src/capabilities/templateMutateCapabilities.ts`.
 
@@ -102,7 +105,8 @@ Source: `src/capabilities/templateMutateCapabilities.ts`.
 
 - **GIVEN** a local file linked to a Rewst template
 - **WHEN** `buddy_rename_template` successfully renames that template
-- **THEN** the local link's cached `template.name` is updated to the new name
+- **THEN** the local link's cached `template.name` and `template.updatedAt` are
+  updated to the values the rename mutation returned
 - **AND** `onLinksSaved` fires so subscribed UI (status bar, tree view)
   refreshes without a reload
 

--- a/src/capabilities/graphqlMutateCapability.test.ts
+++ b/src/capabilities/graphqlMutateCapability.test.ts
@@ -1,0 +1,111 @@
+import type { Session } from '@sessions';
+import { initTestEnvironment } from '@test';
+import * as assert from 'assert';
+import * as Mocha from 'mocha';
+import { _resetApprovedMutationScopes, approveMutationScope, type MutationScope } from '../ui/chat/tools/graphqlTool';
+import type { CapabilityContext } from './Capability';
+import {
+	_resetMcpMutationApproverForTesting,
+	graphqlMutateCapability,
+	setMcpMutationApprover,
+} from './graphqlMutateCapability';
+
+const { suite, test, setup, teardown } = Mocha;
+
+function makeCtx(orgId = 'org-sandbox', orgName = 'Sandbox') {
+	const calls: { query: string; variables?: Record<string, unknown> }[] = [];
+	const session = {
+		profile: { org: { id: orgId, name: orgName }, allManagedOrgs: [{ id: orgId, name: orgName }] },
+		rawGraphql: async (query: string, variables?: Record<string, unknown>) => {
+			calls.push({ query, variables });
+			return { data: { deleteTemplate: { id: 't-1' } } };
+		},
+	} as unknown as Session;
+	const ctx: CapabilityContext = { session, orgId, sessions: [session] };
+	return { ctx, calls };
+}
+
+const DELETE_QUERY = 'mutation { deleteTemplate(id: "t-1") { id } }';
+
+suite('Unit: graphqlMutateCapability', () => {
+	setup(() => {
+		initTestEnvironment();
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	teardown(() => {
+		_resetApprovedMutationScopes();
+		_resetMcpMutationApproverForTesting();
+	});
+
+	test('runs the mutation when approved', async () => {
+		const { ctx, calls } = makeCtx();
+		setMcpMutationApprover(async () => true);
+
+		const output = await graphqlMutateCapability.run(
+			{ orgId: 'org-sandbox', query: DELETE_QUERY, scopeId: 't-1', scopeName: 'Doomed' },
+			ctx,
+		);
+
+		assert.strictEqual(calls.length, 1);
+		assert.match(output, /deleteTemplate/);
+	});
+
+	test('does not run when approval is denied', async () => {
+		const { ctx, calls } = makeCtx();
+		setMcpMutationApprover(async () => false);
+
+		const output = await graphqlMutateCapability.run(
+			{ orgId: 'org-sandbox', query: DELETE_QUERY, scopeId: 't-1', scopeName: 'Doomed' },
+			ctx,
+		);
+
+		assert.strictEqual(calls.length, 0);
+		assert.strictEqual(JSON.parse(output).status, 'approval_required');
+	});
+
+	test('always prompts, even when the scope was approved by an earlier mutation on the same resource (#177 gap)', async () => {
+		const { ctx, calls } = makeCtx();
+		// buddy_graphql_mutate lets the caller supply any scopeId for any query, so
+		// unlike the typed capabilities (where scopeId is verified against a
+		// fetched resource), reusing a scope-keyed approval here is unsound: a
+		// prior approval for a rename/update on this resource must not silently
+		// authorize an arbitrary later mutation (e.g. a delete) with the same
+		// scopeId.
+		const priorScope: MutationScope = {
+			scopeId: 't-1',
+			scopeName: 'Doomed',
+			orgId: 'org-sandbox',
+			orgName: 'Sandbox',
+		};
+		approveMutationScope(priorScope);
+
+		let approverCalled = false;
+		setMcpMutationApprover(async () => {
+			approverCalled = true;
+			return true;
+		});
+
+		await graphqlMutateCapability.run(
+			{ orgId: 'org-sandbox', query: DELETE_QUERY, scopeId: 't-1', scopeName: 'Doomed' },
+			ctx,
+		);
+
+		assert.ok(approverCalled, 'buddy_graphql_mutate must always prompt, never reuse a cached scope approval');
+		assert.strictEqual(calls.length, 1);
+	});
+
+	test('rejects a query operation', async () => {
+		const { ctx } = makeCtx();
+		setMcpMutationApprover(async () => true);
+		await assert.rejects(
+			() =>
+				graphqlMutateCapability.run(
+					{ orgId: 'org-sandbox', query: 'query { templates { id } }', scopeId: 't-1', scopeName: 'X' },
+					ctx,
+				),
+			/runs mutations only/,
+		);
+	});
+});

--- a/src/capabilities/graphqlMutateCapability.test.ts
+++ b/src/capabilities/graphqlMutateCapability.test.ts
@@ -96,6 +96,26 @@ suite('Unit: graphqlMutateCapability', () => {
 		assert.strictEqual(calls.length, 1);
 	});
 
+	test('does not run when denied, even if the scope was approved by an earlier mutation (#177)', async () => {
+		const { ctx, calls } = makeCtx();
+		const priorScope: MutationScope = {
+			scopeId: 't-1',
+			scopeName: 'Doomed',
+			orgId: 'org-sandbox',
+			orgName: 'Sandbox',
+		};
+		approveMutationScope(priorScope);
+		setMcpMutationApprover(async () => false);
+
+		const output = await graphqlMutateCapability.run(
+			{ orgId: 'org-sandbox', query: DELETE_QUERY, scopeId: 't-1', scopeName: 'Doomed' },
+			ctx,
+		);
+
+		assert.strictEqual(calls.length, 0);
+		assert.strictEqual(JSON.parse(output).status, 'approval_required');
+	});
+
 	test('rejects a query operation', async () => {
 		const { ctx } = makeCtx();
 		setMcpMutationApprover(async () => true);

--- a/src/capabilities/graphqlMutateCapability.ts
+++ b/src/capabilities/graphqlMutateCapability.ts
@@ -1,10 +1,4 @@
-import {
-	approveMutationScope,
-	detectOperationType,
-	isMutationScopeApproved,
-	runMutationGraphql,
-	type MutationScope,
-} from '../ui/chat/tools/graphqlTool';
+import { detectOperationType, runMutationGraphql, type MutationScope } from '../ui/chat/tools/graphqlTool';
 import type { ToolSpec } from '../ui/chat/tools/toolProtocol';
 import { currentApprovalOrigin, type ApprovalOrigin } from './approvalOrigin';
 import type { Capability, CapabilityContext } from './Capability';
@@ -99,15 +93,19 @@ async function runGraphqlMutate(input: Record<string, unknown>, ctx: CapabilityC
 	const variables = parseVariables(input, ctx);
 	const operation = formatOperationSummary(query, variables);
 
-	if (!isMutationScopeApproved(scope)) {
-		if (!(await requestMcpMutationApproval(scope, operation))) {
-			return JSON.stringify({
-				status: 'approval_required',
-				message:
-					'The mutation was not run; it needs approval in the VS Code window running Rewst Buddy. Focus that window to respond to the prompt, then retry. The prompt does not appear in the MCP client and cannot be approved if no VS Code window is open.',
-			});
-		}
-		approveMutationScope(scope);
+	// Always prompt, never reuse a scope-keyed approval: the caller supplies an
+	// arbitrary scopeId alongside an arbitrary mutation document, so unlike the
+	// typed write capabilities (where scopeId is verified against a fetched
+	// resource id before the scope is recorded) a scope here has no fixed
+	// relationship to what the query actually does. Reusing an approval recorded
+	// for one mutation would let a later, unrelated mutation on the same
+	// caller-chosen scopeId run unprompted (#177).
+	if (!(await requestMcpMutationApproval(scope, operation))) {
+		return JSON.stringify({
+			status: 'approval_required',
+			message:
+				'The mutation was not run; it needs approval in the VS Code window running Rewst Buddy. Focus that window to respond to the prompt, then retry. The prompt does not appear in the MCP client and cannot be approved if no VS Code window is open.',
+		});
 	}
 
 	return runMutationGraphql(query, variables, (q, v) => ctx.session.rawGraphql(q, v));

--- a/src/capabilities/mutationApproval.ts
+++ b/src/capabilities/mutationApproval.ts
@@ -33,8 +33,12 @@ export function orgDisplayName(ctx: CapabilityContext): string {
 
 /**
  * Runs a mutation behind the shared per-call approval flow. With alwaysPrompt
- * (e.g. workflow run/auto-layout) the prompt shows on every call and approval is
- * never remembered for the scope.
+ * (e.g. workflow run/edit) the prompt shows on every call and approval is never
+ * remembered for the scope. Every delete-type capability MUST set alwaysPrompt:
+ * approval scopes key only on [orgId, resourceId], with no operation-type
+ * component, so a resource's delete would otherwise silently reuse an approval
+ * given for an earlier non-delete mutation (rename, update) on that same
+ * resource (#177).
  */
 export async function withMutationApproval(
 	scope: MutationScope,

--- a/src/capabilities/orgVariableMutateCapabilities.test.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.test.ts
@@ -8,7 +8,7 @@ import type { Session } from '@sessions';
 import { initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import { _resetApprovedMutationScopes, approveMutationScope } from '../ui/chat/tools/graphqlTool';
 import { ORG_VARIABLE_MUTATE_CAPABILITIES } from './orgVariableMutateCapabilities';
 
 const { suite, test, setup, teardown } = Mocha;
@@ -299,6 +299,25 @@ suite('Unit: orgVariableMutateCapabilities', () => {
 
 			assert.strictEqual(callsFor(calls, 'delete').length, 0);
 			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+
+		test('still prompts even when a prior non-delete mutation on the same variable was approved (#177)', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow, delete: { data: { deleteOrgVariable: 'v1' } } });
+			// Simulate any earlier non-delete mutation (e.g. update) on this same
+			// variable having been approved this session — the scope key is only
+			// [orgId, variableId].
+			approveMutationScope({ scopeId: 'v1', scopeName: 'API_KEY', orgId: 'org-sandbox', orgName: 'Sandbox' });
+
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await cap('buddy_delete_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1' }, ctx);
+
+			assert.ok(approverCalled, 'delete must still prompt even though the shared scope was already approved');
+			assert.strictEqual(callsFor(calls, 'delete').length, 1);
 		});
 	});
 

--- a/src/capabilities/orgVariableMutateCapabilities.test.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.test.ts
@@ -319,6 +319,17 @@ suite('Unit: orgVariableMutateCapabilities', () => {
 			assert.ok(approverCalled, 'delete must still prompt even though the shared scope was already approved');
 			assert.strictEqual(callsFor(calls, 'delete').length, 1);
 		});
+
+		test('does not delete when denied, even if the variable scope was previously approved (#177)', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow });
+			approveMutationScope({ scopeId: 'v1', scopeName: 'API_KEY', orgId: 'org-sandbox', orgName: 'Sandbox' });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('buddy_delete_org_variable').run({ orgId: 'org-sandbox', variableId: 'v1' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
 	});
 
 	suite('error and empty-result branches', () => {

--- a/src/capabilities/orgVariableMutateCapabilities.ts
+++ b/src/capabilities/orgVariableMutateCapabilities.ts
@@ -181,12 +181,20 @@ async function runDeleteOrgVariable(input: Record<string, unknown>, ctx: Capabil
 	const name = current.name ?? '(unnamed)';
 	const scope: MutationScope = { scopeId: variableId, scopeName: name, orgId, orgName };
 	const summary = `Delete variable "${name}" (${variableId}) in org "${orgName}" (${orgId})`;
-	return withMutationApproval(scope, summary, async () => {
-		const data = await rawGraphqlOrThrow(ctx.session, DELETE_ORG_VARIABLE, { id: variableId });
-		const deletedId = (data as { deleteOrgVariable?: string | null } | undefined)?.deleteOrgVariable;
-		if (!deletedId) throw new Error('deleteOrgVariable returned no id; the mutation may have failed.');
-		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
-	});
+	// A delete always prompts fresh: approval scopes key only on [orgId, resourceId],
+	// so without this a prior non-delete approval for this same variable would
+	// otherwise silently pre-approve deleting it too (#177).
+	return withMutationApproval(
+		scope,
+		summary,
+		async () => {
+			const data = await rawGraphqlOrThrow(ctx.session, DELETE_ORG_VARIABLE, { id: variableId });
+			const deletedId = (data as { deleteOrgVariable?: string | null } | undefined)?.deleteOrgVariable;
+			if (!deletedId) throw new Error('deleteOrgVariable returned no id; the mutation may have failed.');
+			return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
+		},
+		{ alwaysPrompt: true },
+	);
 }
 
 export const ORG_VARIABLE_MUTATE_CAPABILITIES: Capability[] = [

--- a/src/capabilities/tagMutateCapabilities.test.ts
+++ b/src/capabilities/tagMutateCapabilities.test.ts
@@ -237,6 +237,17 @@ suite('Unit: tagMutateCapabilities', () => {
 			assert.ok(approverCalled, 'delete must still prompt even though the shared scope was already approved');
 			assert.strictEqual(callsFor(calls, 'delete').length, 1);
 		});
+
+		test('does not delete when denied, even if the tag scope was previously approved (#177)', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow });
+			approveMutationScope({ scopeId: 'g1', scopeName: 'old', orgId: 'org-sandbox', orgName: 'Sandbox' });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('buddy_delete_tag').run({ orgId: 'org-sandbox', tagId: 'g1' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
 	});
 
 	suite('error and empty-result branches', () => {

--- a/src/capabilities/tagMutateCapabilities.test.ts
+++ b/src/capabilities/tagMutateCapabilities.test.ts
@@ -8,7 +8,7 @@ import {
 	type CapabilityContext,
 } from '@capabilities';
 import type { Session } from '@sessions';
-import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import { _resetApprovedMutationScopes, approveMutationScope } from '../ui/chat/tools/graphqlTool';
 import { TAG_MUTATE_CAPABILITIES } from './tagMutateCapabilities';
 
 const { suite, test, setup, teardown } = Mocha;
@@ -218,6 +218,24 @@ suite('Unit: tagMutateCapabilities', () => {
 
 			assert.strictEqual(callsFor(calls, 'delete').length, 0);
 			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+
+		test('still prompts even when a prior non-delete mutation on the same tag was approved (#177)', async () => {
+			const { ctx, calls } = makeCtx({ byId: inOrgRow, delete: { data: { deleteTag: 'g1' } } });
+			// Simulate any earlier non-delete mutation (e.g. update) on this same tag
+			// having been approved this session — the scope key is only [orgId, tagId].
+			approveMutationScope({ scopeId: 'g1', scopeName: 'old', orgId: 'org-sandbox', orgName: 'Sandbox' });
+
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await cap('buddy_delete_tag').run({ orgId: 'org-sandbox', tagId: 'g1' }, ctx);
+
+			assert.ok(approverCalled, 'delete must still prompt even though the shared scope was already approved');
+			assert.strictEqual(callsFor(calls, 'delete').length, 1);
 		});
 	});
 

--- a/src/capabilities/tagMutateCapabilities.ts
+++ b/src/capabilities/tagMutateCapabilities.ts
@@ -167,12 +167,20 @@ async function runDeleteTag(input: Record<string, unknown>, ctx: CapabilityConte
 	const name = current.name ?? '(unnamed)';
 	const scope: MutationScope = { scopeId: tagId, scopeName: name, orgId, orgName };
 	const summary = `Delete tag "${name}" (${tagId}) in org "${orgName}" (${orgId})`;
-	return withMutationApproval(scope, summary, async () => {
-		const data = await rawGraphqlOrThrow(ctx.session, DELETE_TAG, { id: tagId });
-		const deletedId = (data as { deleteTag?: string | null } | undefined)?.deleteTag;
-		if (!deletedId) throw new Error('deleteTag returned no id; the mutation may have failed.');
-		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
-	});
+	// A delete always prompts fresh: approval scopes key only on [orgId, resourceId],
+	// so without this a prior non-delete approval for this same tag would otherwise
+	// silently pre-approve deleting it too (#177).
+	return withMutationApproval(
+		scope,
+		summary,
+		async () => {
+			const data = await rawGraphqlOrThrow(ctx.session, DELETE_TAG, { id: tagId });
+			const deletedId = (data as { deleteTag?: string | null } | undefined)?.deleteTag;
+			if (!deletedId) throw new Error('deleteTag returned no id; the mutation may have failed.');
+			return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
+		},
+		{ alwaysPrompt: true },
+	);
 }
 
 export const TAG_MUTATE_CAPABILITIES: Capability[] = [

--- a/src/capabilities/templateMutateCapabilities.test.ts
+++ b/src/capabilities/templateMutateCapabilities.test.ts
@@ -323,6 +323,7 @@ suite('Unit: templateMutateCapabilities', () => {
 
 		test('updates the local link cache and fires onLinksSaved when a linked template is renamed (#176)', async () => {
 			const { ctx, wrapper } = sandboxCtx();
+			const renamedUpdatedAt = '2026-01-02T00:00:00.000Z';
 			wrapper
 				.when('getTemplate', {
 					data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'Old Name' }),
@@ -330,7 +331,12 @@ suite('Unit: templateMutateCapabilities', () => {
 				.when('updateTemplateName', {
 					data: {
 						__typename: 'Mutation',
-						template: Fixtures.fullTemplate({ id: 't-1', orgId: 'org-sandbox', name: 'New Name' }),
+						template: Fixtures.fullTemplate({
+							id: 't-1',
+							orgId: 'org-sandbox',
+							name: 'New Name',
+							updatedAt: renamedUpdatedAt,
+						}),
 					},
 				});
 			setMcpMutationApprover(async () => true);
@@ -340,7 +346,12 @@ suite('Unit: templateMutateCapabilities', () => {
 				type: 'Template',
 				uriString: uri.toString(),
 				org: { id: 'org-sandbox', name: 'Sandbox' },
-				template: { id: 't-1', name: 'Old Name', updatedAt: '', orgId: 'org-sandbox' } as any,
+				template: {
+					id: 't-1',
+					name: 'Old Name',
+					updatedAt: '2026-01-01T00:00:00.000Z',
+					orgId: 'org-sandbox',
+				} as any,
 				bodyHash: 'hash',
 			};
 			LinkManager.addLink(link);
@@ -358,7 +369,13 @@ suite('Unit: templateMutateCapabilities', () => {
 				off.dispose();
 			}
 
-			assert.strictEqual(LinkManager.getTemplateLink(uri).template.name, 'New Name');
+			const cached = LinkManager.getTemplateLink(uri);
+			assert.strictEqual(cached.template.name, 'New Name');
+			assert.strictEqual(
+				cached.template.updatedAt,
+				renamedUpdatedAt,
+				'the cached updatedAt must move forward too, or the next auto-fetch check sees a stale timestamp and re-syncs needlessly (#176 follow-up)',
+			);
 			assert.ok(fired, 'onLinksSaved should fire so the status bar refreshes');
 		});
 

--- a/src/capabilities/templateMutateCapabilities.test.ts
+++ b/src/capabilities/templateMutateCapabilities.test.ts
@@ -4,10 +4,12 @@ import {
 	type Capability,
 	type CapabilityContext,
 } from '@capabilities';
+import { LinkManager, type TemplateLink } from '@models';
 import { createMockSession, Fixtures, initTestEnvironment } from '@test';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { _resetApprovedMutationScopes, type MutationScope } from '../ui/chat/tools/graphqlTool';
+import vscode from 'vscode';
+import { _resetApprovedMutationScopes, approveMutationScope, type MutationScope } from '../ui/chat/tools/graphqlTool';
 import { TEMPLATE_MUTATE_CAPABILITIES } from './templateMutateCapabilities';
 
 const { suite, test, setup, teardown } = Mocha;
@@ -30,11 +32,13 @@ suite('Unit: templateMutateCapabilities', () => {
 		initTestEnvironment();
 		_resetApprovedMutationScopes();
 		_resetMcpMutationApproverForTesting();
+		LinkManager._resetForTesting();
 	});
 
 	teardown(() => {
 		_resetApprovedMutationScopes();
 		_resetMcpMutationApproverForTesting();
+		LinkManager._resetForTesting();
 	});
 
 	suite('buddy_create_template', () => {
@@ -316,6 +320,69 @@ suite('Unit: templateMutateCapabilities', () => {
 			assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 0);
 			assert.strictEqual(wrapper.getCallsFor('updateTemplateName').length, 0);
 		});
+
+		test('updates the local link cache and fires onLinksSaved when a linked template is renamed (#176)', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper
+				.when('getTemplate', {
+					data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'Old Name' }),
+				})
+				.when('updateTemplateName', {
+					data: {
+						__typename: 'Mutation',
+						template: Fixtures.fullTemplate({ id: 't-1', orgId: 'org-sandbox', name: 'New Name' }),
+					},
+				});
+			setMcpMutationApprover(async () => true);
+
+			const uri = vscode.Uri.file('/tmp/rewst-buddy-rename-test/old-name.j2');
+			const link: TemplateLink = {
+				type: 'Template',
+				uriString: uri.toString(),
+				org: { id: 'org-sandbox', name: 'Sandbox' },
+				template: { id: 't-1', name: 'Old Name', updatedAt: '', orgId: 'org-sandbox' } as any,
+				bodyHash: 'hash',
+			};
+			LinkManager.addLink(link);
+
+			let fired = false;
+			const off = LinkManager.onLinksSaved(() => {
+				fired = true;
+			});
+			try {
+				await cap('buddy_rename_template').run(
+					{ orgId: 'org-sandbox', templateId: 't-1', name: 'New Name' },
+					ctx,
+				);
+			} finally {
+				off.dispose();
+			}
+
+			assert.strictEqual(LinkManager.getTemplateLink(uri).template.name, 'New Name');
+			assert.ok(fired, 'onLinksSaved should fire so the status bar refreshes');
+		});
+
+		test('does not throw when renaming a template with no local link', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper
+				.when('getTemplate', {
+					data: Fixtures.getTemplateQuery({ id: 't-unlinked', orgId: 'org-sandbox', name: 'Old Name' }),
+				})
+				.when('updateTemplateName', {
+					data: {
+						__typename: 'Mutation',
+						template: Fixtures.fullTemplate({ id: 't-unlinked', orgId: 'org-sandbox', name: 'New Name' }),
+					},
+				});
+			setMcpMutationApprover(async () => true);
+
+			const output = await cap('buddy_rename_template').run(
+				{ orgId: 'org-sandbox', templateId: 't-unlinked', name: 'New Name' },
+				ctx,
+			);
+
+			assert.strictEqual(JSON.parse(output).status, 'renamed');
+		});
 	});
 
 	suite('buddy_delete_template', () => {
@@ -390,6 +457,30 @@ suite('Unit: templateMutateCapabilities', () => {
 			assert.strictEqual(approverCalled, false);
 			assert.strictEqual(wrapper.getCallsFor('getTemplate').length, 0);
 			assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 0);
+		});
+
+		test('still prompts even when a prior non-delete mutation on the same template was approved (#177)', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper
+				.when('getTemplate', {
+					data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'Doomed' }),
+				})
+				.when('deleteTemplate', { data: { __typename: 'Mutation', deleteTemplate: 't-1' } });
+			// Simulate any earlier non-delete mutation (rename/update body/etc.) on this
+			// same template having been approved this session — the scope key is only
+			// [orgId, templateId], shared by every mutation on this resource.
+			approveMutationScope({ scopeId: 't-1', scopeName: 'Doomed', orgId: 'org-sandbox', orgName: 'Sandbox' });
+
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await cap('buddy_delete_template').run({ orgId: 'org-sandbox', templateId: 't-1' }, ctx);
+
+			assert.ok(approverCalled, 'delete must still prompt even though the shared scope was already approved');
+			assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 1);
 		});
 	});
 

--- a/src/capabilities/templateMutateCapabilities.test.ts
+++ b/src/capabilities/templateMutateCapabilities.test.ts
@@ -379,6 +379,59 @@ suite('Unit: templateMutateCapabilities', () => {
 			assert.ok(fired, 'onLinksSaved should fire so the status bar refreshes');
 		});
 
+		test('leaves the local link cache untouched when the rename mutation fails (#176)', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			const uri = vscode.Uri.file('/tmp/rewst-buddy-rename-test/failed-rename.j2');
+			const originalUpdatedAt = '2026-01-01T00:00:00.000Z';
+			wrapper
+				.when('getTemplate', {
+					data: Fixtures.getTemplateQuery({
+						id: 't-1',
+						orgId: 'org-sandbox',
+						name: 'Old Name',
+						updatedAt: originalUpdatedAt,
+					}),
+				})
+				.when('updateTemplateName', { error: new Error('rename failed') });
+			setMcpMutationApprover(async () => true);
+
+			const link: TemplateLink = {
+				type: 'Template',
+				uriString: uri.toString(),
+				org: { id: 'org-sandbox', name: 'Sandbox' },
+				template: {
+					id: 't-1',
+					name: 'Old Name',
+					updatedAt: originalUpdatedAt,
+					orgId: 'org-sandbox',
+				} as any,
+				bodyHash: 'hash',
+			};
+			LinkManager.addLink(link);
+
+			let fired = false;
+			const off = LinkManager.onLinksSaved(() => {
+				fired = true;
+			});
+			try {
+				await assert.rejects(
+					() =>
+						cap('buddy_rename_template').run(
+							{ orgId: 'org-sandbox', templateId: 't-1', name: 'New Name' },
+							ctx,
+						),
+					/rename failed/,
+				);
+			} finally {
+				off.dispose();
+			}
+
+			const cached = LinkManager.getTemplateLink(uri);
+			assert.strictEqual(cached.template.name, 'Old Name');
+			assert.strictEqual(cached.template.updatedAt, originalUpdatedAt);
+			assert.strictEqual(fired, false, 'failed rename must not emit a links-saved event');
+		});
+
 		test('does not throw when renaming a template with no local link', async () => {
 			const { ctx, wrapper } = sandboxCtx();
 			wrapper
@@ -498,6 +551,20 @@ suite('Unit: templateMutateCapabilities', () => {
 
 			assert.ok(approverCalled, 'delete must still prompt even though the shared scope was already approved');
 			assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 1);
+		});
+
+		test('does not delete when denied, even if the template scope was previously approved (#177)', async () => {
+			const { ctx, wrapper } = sandboxCtx();
+			wrapper.when('getTemplate', {
+				data: Fixtures.getTemplateQuery({ id: 't-1', orgId: 'org-sandbox', name: 'Doomed' }),
+			});
+			approveMutationScope({ scopeId: 't-1', scopeName: 'Doomed', orgId: 'org-sandbox', orgName: 'Sandbox' });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('buddy_delete_template').run({ orgId: 'org-sandbox', templateId: 't-1' }, ctx);
+
+			assert.strictEqual(wrapper.getCallsFor('deleteTemplate').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
 		});
 	});
 

--- a/src/capabilities/templateMutateCapabilities.ts
+++ b/src/capabilities/templateMutateCapabilities.ts
@@ -140,8 +140,14 @@ async function runRenameTemplate(input: Record<string, unknown>, ctx: Capability
 		const newName = template.name ?? name;
 		// Keep the local link cache (and its status bar / tree label) in sync — a
 		// rename otherwise leaves the cached name stale until the next sync (#176).
+		// updatedAt must move forward too: leaving it stale makes the next auto-fetch
+		// check see a provably-newer remote and needlessly re-fetch/re-save the
+		// unchanged body.
 		for (const link of LinkManager.getTemplateLinkFromId(templateId)) {
-			const updated: TemplateLink = { ...link, template: { ...link.template, name: newName } };
+			const updated: TemplateLink = {
+				...link,
+				template: { ...link.template, name: newName, updatedAt: template.updatedAt ?? link.template.updatedAt },
+			};
 			LinkManager.addLink(updated);
 		}
 		return JSON.stringify({ status: 'renamed', id: template.id, name: newName }, null, 2);

--- a/src/capabilities/templateMutateCapabilities.ts
+++ b/src/capabilities/templateMutateCapabilities.ts
@@ -1,3 +1,4 @@
+import { LinkManager, type TemplateLink } from '@models';
 import { z } from 'zod';
 import type { MutationScope } from '../ui/chat/tools/graphqlTool';
 import type { ToolSpecDefinition } from '../ui/chat/tools/toolProtocol';
@@ -136,7 +137,14 @@ async function runRenameTemplate(input: Record<string, unknown>, ctx: Capability
 		if (!template?.id) {
 			throw new Error('updateTemplateName returned no template; the mutation may have failed.');
 		}
-		return JSON.stringify({ status: 'renamed', id: template.id, name: template.name ?? name }, null, 2);
+		const newName = template.name ?? name;
+		// Keep the local link cache (and its status bar / tree label) in sync — a
+		// rename otherwise leaves the cached name stale until the next sync (#176).
+		for (const link of LinkManager.getTemplateLinkFromId(templateId)) {
+			const updated: TemplateLink = { ...link, template: { ...link.template, name: newName } };
+			LinkManager.addLink(updated);
+		}
+		return JSON.stringify({ status: 'renamed', id: template.id, name: newName }, null, 2);
 	});
 }
 
@@ -158,14 +166,22 @@ async function runDeleteTemplate(input: Record<string, unknown>, ctx: Capability
 	const { name } = await requireTemplateInOrg(ctx, templateId, orgId);
 	const scope: MutationScope = { scopeId: templateId, scopeName: name, orgId, orgName };
 	const summary = `Delete template "${name}" (${templateId}) in org "${orgName}" (${orgId})`;
-	return withMutationApproval(scope, summary, async () => {
-		const response = await ctx.session.sdk?.deleteTemplate({ id: templateId });
-		const deletedId = response?.deleteTemplate;
-		if (!deletedId) {
-			throw new Error('deleteTemplate returned no id; the mutation may have failed.');
-		}
-		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
-	});
+	// A delete always prompts fresh: approval scopes key only on [orgId, resourceId],
+	// so without this a prior non-delete approval for this same template (rename,
+	// body update) would otherwise silently pre-approve deleting it too (#177).
+	return withMutationApproval(
+		scope,
+		summary,
+		async () => {
+			const response = await ctx.session.sdk?.deleteTemplate({ id: templateId });
+			const deletedId = response?.deleteTemplate;
+			if (!deletedId) {
+				throw new Error('deleteTemplate returned no id; the mutation may have failed.');
+			}
+			return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
+		},
+		{ alwaysPrompt: true },
+	);
 }
 
 export const TEMPLATE_MUTATE_CAPABILITIES: Capability[] = [

--- a/src/capabilities/workflowCrudCapabilities.test.ts
+++ b/src/capabilities/workflowCrudCapabilities.test.ts
@@ -9,7 +9,7 @@ import { initTestEnvironment } from '@test';
 import { CRATE_REUSE_STEERING, WORKFLOW_START_STEERING } from '@workflow';
 import * as assert from 'assert';
 import * as Mocha from 'mocha';
-import { _resetApprovedMutationScopes } from '../ui/chat/tools/graphqlTool';
+import { _resetApprovedMutationScopes, approveMutationScope } from '../ui/chat/tools/graphqlTool';
 import { getCapability } from './registry';
 import { WORKFLOW_CRUD_CAPABILITIES } from './workflowCrudCapabilities';
 
@@ -199,6 +199,25 @@ suite('Unit: workflowCrudCapabilities', () => {
 
 			assert.strictEqual(callsFor(calls, 'delete').length, 0);
 			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
+
+		test('still prompts even when a prior non-delete mutation on the same workflow was approved (#177)', async () => {
+			const { ctx, calls } = makeCtx({ owner: inOrg, delete: { data: { deleteWorkflow: 'w1' } } });
+			// Simulate any earlier non-delete mutation on this same workflow (e.g. an
+			// auto-layout, which unlike run/edit is not always-prompt) having been
+			// approved this session — the scope key is only [orgId, workflowId].
+			approveMutationScope({ scopeId: 'w1', scopeName: 'Onboard', orgId: 'org-sandbox', orgName: 'Sandbox' });
+
+			let approverCalled = false;
+			setMcpMutationApprover(async () => {
+				approverCalled = true;
+				return true;
+			});
+
+			await cap('buddy_delete_workflow').run({ orgId: 'org-sandbox', workflowId: 'w1' }, ctx);
+
+			assert.ok(approverCalled, 'delete must still prompt even though the shared scope was already approved');
+			assert.strictEqual(callsFor(calls, 'delete').length, 1);
 		});
 	});
 

--- a/src/capabilities/workflowCrudCapabilities.test.ts
+++ b/src/capabilities/workflowCrudCapabilities.test.ts
@@ -219,6 +219,17 @@ suite('Unit: workflowCrudCapabilities', () => {
 			assert.ok(approverCalled, 'delete must still prompt even though the shared scope was already approved');
 			assert.strictEqual(callsFor(calls, 'delete').length, 1);
 		});
+
+		test('does not delete when denied, even if the workflow scope was previously approved (#177)', async () => {
+			const { ctx, calls } = makeCtx({ owner: inOrg });
+			approveMutationScope({ scopeId: 'w1', scopeName: 'Onboard', orgId: 'org-sandbox', orgName: 'Sandbox' });
+			setMcpMutationApprover(async () => false);
+
+			const output = await cap('buddy_delete_workflow').run({ orgId: 'org-sandbox', workflowId: 'w1' }, ctx);
+
+			assert.strictEqual(callsFor(calls, 'delete').length, 0);
+			assert.strictEqual(JSON.parse(output).status, 'approval_required');
+		});
 	});
 
 	suite('error and empty-result branches', () => {

--- a/src/capabilities/workflowCrudCapabilities.ts
+++ b/src/capabilities/workflowCrudCapabilities.ts
@@ -124,12 +124,21 @@ async function runDeleteWorkflow(input: Record<string, unknown>, ctx: Capability
 	const name = current.name ?? '(unnamed)';
 	const scope: MutationScope = { scopeId: workflowId, scopeName: name, orgId, orgName };
 	const summary = `Delete workflow "${name}" (${workflowId}) and its triggers, tasks, and history in org "${orgName}" (${orgId})`;
-	return withMutationApproval(scope, summary, async () => {
-		const data = await rawGraphqlOrThrow(ctx.session, DELETE_WORKFLOW, { id: workflowId });
-		const deletedId = (data as { deleteWorkflow?: string | null } | undefined)?.deleteWorkflow;
-		if (!deletedId) throw new Error('deleteWorkflow returned no id; the mutation may have failed.');
-		return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
-	});
+	// A delete always prompts fresh: approval scopes key only on [orgId, resourceId],
+	// so without this a prior non-delete approval for this same workflow (e.g. an
+	// auto-layout, which unlike run/edit is not always-prompt) would otherwise
+	// silently pre-approve deleting it too (#177).
+	return withMutationApproval(
+		scope,
+		summary,
+		async () => {
+			const data = await rawGraphqlOrThrow(ctx.session, DELETE_WORKFLOW, { id: workflowId });
+			const deletedId = (data as { deleteWorkflow?: string | null } | undefined)?.deleteWorkflow;
+			if (!deletedId) throw new Error('deleteWorkflow returned no id; the mutation may have failed.');
+			return JSON.stringify({ status: 'deleted', id: deletedId, name }, null, 2);
+		},
+		{ alwaysPrompt: true },
+	);
 }
 
 export const WORKFLOW_CRUD_CAPABILITIES: Capability[] = [

--- a/src/mcp/McpActions.test.ts
+++ b/src/mcp/McpActions.test.ts
@@ -1002,7 +1002,12 @@ suite('Unit: McpActions', () => {
 			assert.strictEqual(wrapper.getCallsFor('rawGraphql').length, 0);
 		});
 
-		test('buddy_graphql_mutate executes after approval and remembers the same scope', async () => {
+		test('buddy_graphql_mutate executes after approval and always prompts again for the same scope (#177)', async () => {
+			// Unlike the typed write capabilities, buddy_graphql_mutate lets the
+			// caller pick any scopeId for any query, so a scope-keyed approval here
+			// has no fixed relationship to what the mutation actually does — reusing
+			// it would let a later, unrelated mutation on the same caller-chosen
+			// scopeId run unprompted. It must always re-prompt.
 			const { session, wrapper } = useSession('org-1', 'Acme Org');
 			useRawGraphqlWrapper(session, wrapper);
 			wrapper.when('rawGraphql', { data: { data: { updateThing: { id: 'wf-1' } } } });
@@ -1033,7 +1038,7 @@ suite('Unit: McpActions', () => {
 			assert.ok(!second.isError);
 			const calls = wrapper.getCallsFor('rawGraphql');
 			assert.strictEqual(calls.length, 2);
-			assert.strictEqual(approvals, 1);
+			assert.strictEqual(approvals, 2, "the second call must prompt again, not reuse the first call's approval");
 			assert.deepStrictEqual(calls[0].variables.variables, { name: 'Renamed' });
 		});
 

--- a/src/test/integration/conversationLimitExplore.test.ts
+++ b/src/test/integration/conversationLimitExplore.test.ts
@@ -1,0 +1,127 @@
+import * as Mocha from 'mocha';
+import { askRewstAi, Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+
+const { suite, test, suiteSetup, suiteTeardown } = Mocha;
+
+/**
+ * EXPLORATION PROBE (not an assertion test): grows one RoboRewsty conversation
+ * turn-by-turn until the backend's new "conversation is getting long" buttons
+ * appear in the reply, dumping each turn's full reply + context usage so the
+ * length-limit marker can be identified and a detector written against it.
+ *
+ * Run only on demand:
+ *   unset REWST_TEST_TOKEN && npm run test:grep:integration -- "explore conversation length limit"
+ */
+suite('Integration: conversation length limit exploration', function () {
+	this.timeout(1_200_000);
+
+	let session: Session;
+
+	suiteSetup(async function () {
+		if (!hasTestToken()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		// getTestSession stores the validated cookie in secrets under user id,
+		// which is exactly the key askRewstAi.getCookies reads.
+		session = await getTestSession();
+	});
+
+	suiteTeardown(() => {
+		clearCachedSession();
+	});
+
+	// Heuristic markers that a reply is the length-limit / "start a new chat"
+	// prompt rather than a normal answer. Broad on purpose — the probe's job is
+	// to surface the real wording, not to be the final detector.
+	const SUSPECT =
+		/new (chat|conversation)|start(ing)? (a )?(new|fresh)|conversation is getting long|reached the (maximum|max|length|limit)|too long|start over|\[[^\]]+\]\(command:|button/i;
+
+	test('explore conversation length limit buttons', async function () {
+		if (!hasTestToken()) {
+			this.skip();
+			return;
+		}
+		const orgId = session.profile.org.id;
+		let conversationId: string | undefined;
+		const MAX_TURNS = 45;
+
+		// Big filler to ramp context fast if the limit is token-based (~30k
+		// tokens/turn ⇒ ~12 turns to a 350k window). Distinct per turn so the
+		// backend can't collapse it as a duplicate. If the backend instead
+		// summarizes and usage plateaus, the count-based limit still shows within
+		// MAX_TURNS.
+		const filler = (n: number): string =>
+			Array.from(
+				{ length: 2000 },
+				(_, i) => `context-line-${n}-${i} lorem ipsum dolor sit amet consectetur adipiscing elit sed`,
+			).join(' ');
+
+		let prevPercent = -1;
+		let plateauNoted = false;
+
+		for (let turnNo = 1; turnNo <= MAX_TURNS; turnNo++) {
+			const message =
+				`Turn ${turnNo}. Please reply with a short paragraph about Rewst workflows. ` +
+				`Here is some scratch context you can ignore: ${filler(turnNo)}`;
+
+			let content = '';
+			let usageLine = '(no usage reported)';
+			let percent = -1;
+			let errored: string | undefined;
+			for await (const event of askRewstAi({
+				session,
+				orgId,
+				message,
+				conversationId,
+				inactivityTimeoutMs: 180_000,
+			})) {
+				if (event.kind === 'conversation') conversationId = event.conversationId;
+				if (event.kind === 'usage') {
+					percent = event.percent;
+					usageLine = `usage ${event.totalTokens}/${event.maxTokens} (${event.percent}%)`;
+				}
+				if (event.kind === 'complete') {
+					content = event.content;
+					if (event.conversationId) conversationId = event.conversationId;
+				}
+				if (event.kind === 'approval') {
+					console.log(`\n>>> APPROVAL event on turn ${turnNo}:`, JSON.stringify(event.raw));
+				}
+				if (event.kind === 'error') errored = event.message;
+			}
+
+			console.log(`\n========== TURN ${turnNo} ========== ${usageLine} conv=${conversationId ?? '?'}`);
+			if (errored) {
+				console.log(`ERROR: ${errored}`);
+				// Retry a transient interruption once; otherwise stop.
+				if (/interrupted/i.test(errored)) {
+					await new Promise(r => setTimeout(r, 15_000));
+					continue;
+				}
+				break;
+			}
+			console.log(`REPLY (${content.length} chars):\n${content}`);
+
+			// If context stops climbing while we keep feeding big messages, the
+			// backend is summarizing — a token cap won't be reached, so the limit
+			// (if any) is count-based. Note it once so the run's shape is clear.
+			if (!plateauNoted && percent >= 0 && prevPercent >= 0 && percent <= prevPercent && turnNo > 3) {
+				console.log(
+					`>>> NOTE: context usage plateaued (${prevPercent}%→${percent}%) — backend is summarizing.`,
+				);
+				plateauNoted = true;
+			}
+			prevPercent = percent;
+
+			if (SUSPECT.test(content)) {
+				console.log(
+					`\n>>> SUSPECT length-limit marker detected on turn ${turnNo}. Full reply above. Stopping.`,
+				);
+				break;
+			}
+		}
+	});
+});

--- a/src/test/integration/conversationLimitExplore.test.ts
+++ b/src/test/integration/conversationLimitExplore.test.ts
@@ -4,14 +4,31 @@ import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment }
 
 const { suite, test, suiteSetup, suiteTeardown } = Mocha;
 
+const EXPLORE_OPT_IN_ENV = 'REWST_CONVERSATION_LIMIT_EXPLORE';
+const RAW_LOG_ENV = 'REWST_CONVERSATION_LIMIT_RAW_LOG';
+
+function envFlag(name: string): boolean {
+	return process.env[name] === '1';
+}
+
+function jsonSize(value: unknown): number {
+	return JSON.stringify(value ?? null).length;
+}
+
+function boundedText(value: unknown, max = 240): string {
+	const text = String(value ?? '');
+	return text.length > max ? `${text.slice(0, max)}...[truncated ${text.length - max} chars]` : text;
+}
+
 /**
  * EXPLORATION PROBE (not an assertion test): grows one RoboRewsty conversation
  * turn-by-turn until the backend's new "conversation is getting long" buttons
- * appear in the reply, dumping each turn's full reply + context usage so the
- * length-limit marker can be identified and a detector written against it.
+ * appear in the reply. Normal output is bounded/redacted; set
+ * REWST_CONVERSATION_LIMIT_RAW_LOG=1 only for a local diagnostic run that is
+ * allowed to print live conversation contents.
  *
  * Run only on demand:
- *   unset REWST_TEST_TOKEN && npm run test:grep:integration -- "explore conversation length limit"
+ *   REWST_CONVERSATION_LIMIT_EXPLORE=1 npm run test:grep:integration -- "explore conversation length limit"
  */
 suite('Integration: conversation length limit exploration', function () {
 	this.timeout(1_200_000);
@@ -19,7 +36,7 @@ suite('Integration: conversation length limit exploration', function () {
 	let session: Session;
 
 	suiteSetup(async function () {
-		if (!hasTestToken()) {
+		if (!hasTestToken() || !envFlag(EXPLORE_OPT_IN_ENV)) {
 			this.skip();
 			return;
 		}
@@ -40,7 +57,7 @@ suite('Integration: conversation length limit exploration', function () {
 		/new (chat|conversation)|start(ing)? (a )?(new|fresh)|conversation is getting long|reached the (maximum|max|length|limit)|too long|start over|\[[^\]]+\]\(command:|button/i;
 
 	test('explore conversation length limit buttons', async function () {
-		if (!hasTestToken()) {
+		if (!hasTestToken() || !envFlag(EXPLORE_OPT_IN_ENV)) {
 			this.skip();
 			return;
 		}
@@ -71,39 +88,58 @@ suite('Integration: conversation length limit exploration', function () {
 			let usageLine = '(no usage reported)';
 			let percent = -1;
 			let errored: string | undefined;
-			for await (const event of askRewstAi({
-				session,
-				orgId,
-				message,
-				conversationId,
-				inactivityTimeoutMs: 180_000,
-			})) {
-				if (event.kind === 'conversation') conversationId = event.conversationId;
-				if (event.kind === 'usage') {
-					percent = event.percent;
-					usageLine = `usage ${event.totalTokens}/${event.maxTokens} (${event.percent}%)`;
+			let attempts = 0;
+			for (let attempt = 1; attempt <= 2; attempt++) {
+				attempts = attempt;
+				content = '';
+				usageLine = '(no usage reported)';
+				percent = -1;
+				errored = undefined;
+				for await (const event of askRewstAi({
+					session,
+					orgId,
+					message,
+					conversationId,
+					inactivityTimeoutMs: 180_000,
+				})) {
+					if (event.kind === 'conversation') conversationId = event.conversationId;
+					if (event.kind === 'usage') {
+						percent = event.percent;
+						usageLine = `usage ${event.totalTokens}/${event.maxTokens} (${event.percent}%)`;
+					}
+					if (event.kind === 'complete') {
+						content = event.content;
+						if (event.conversationId) conversationId = event.conversationId;
+					}
+					if (event.kind === 'approval') {
+						if (envFlag(RAW_LOG_ENV)) {
+							console.log(`\n>>> APPROVAL event on turn ${turnNo}:`, JSON.stringify(event.raw));
+						} else {
+							console.log(`\n>>> APPROVAL event on turn ${turnNo}: rawBytes=${jsonSize(event.raw)}`);
+						}
+					}
+					if (event.kind === 'error') errored = event.message;
 				}
-				if (event.kind === 'complete') {
-					content = event.content;
-					if (event.conversationId) conversationId = event.conversationId;
-				}
-				if (event.kind === 'approval') {
-					console.log(`\n>>> APPROVAL event on turn ${turnNo}:`, JSON.stringify(event.raw));
-				}
-				if (event.kind === 'error') errored = event.message;
-			}
-
-			console.log(`\n========== TURN ${turnNo} ========== ${usageLine} conv=${conversationId ?? '?'}`);
-			if (errored) {
-				console.log(`ERROR: ${errored}`);
-				// Retry a transient interruption once; otherwise stop.
-				if (/interrupted/i.test(errored)) {
+				if (errored && /interrupted/i.test(errored) && attempt === 1) {
+					console.log(`\n>>> Turn ${turnNo} interrupted; retrying the same prompt once after delay.`);
 					await new Promise(r => setTimeout(r, 15_000));
 					continue;
 				}
 				break;
 			}
-			console.log(`REPLY (${content.length} chars):\n${content}`);
+
+			console.log(
+				`\n========== TURN ${turnNo} ========== ${usageLine} conv=${conversationId ?? '?'} attempts=${attempts}`,
+			);
+			if (errored) {
+				console.log(`ERROR: ${boundedText(errored)}`);
+				break;
+			}
+			if (envFlag(RAW_LOG_ENV)) {
+				console.log(`REPLY (${content.length} chars):\n${content}`);
+			} else {
+				console.log(`REPLY (${content.length} chars): [redacted; set ${RAW_LOG_ENV}=1 for local raw output]`);
+			}
 
 			// If context stops climbing while we keep feeding big messages, the
 			// backend is summarizing — a token cap won't be reached, so the limit
@@ -118,7 +154,7 @@ suite('Integration: conversation length limit exploration', function () {
 
 			if (SUSPECT.test(content)) {
 				console.log(
-					`\n>>> SUSPECT length-limit marker detected on turn ${turnNo}. Full reply above. Stopping.`,
+					`\n>>> SUSPECT length-limit marker detected on turn ${turnNo}; reply length=${content.length}. Stopping.`,
 				);
 				break;
 			}

--- a/src/test/integration/conversationLimitInspect.test.ts
+++ b/src/test/integration/conversationLimitInspect.test.ts
@@ -1,10 +1,9 @@
 import * as fs from 'fs';
 import * as Mocha from 'mocha';
+import * as os from 'os';
+import * as path from 'path';
 import { askRewstAi, Session } from '@sessions';
 import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
-
-const DUMP_DIR =
-	'/tmp/claude-1000/-home-jon-Documents-dev-rewst-buddy-full-rewst-buddy-vscode/caede6c9-7b18-4ffa-9c11-f454ffffef6f/scratchpad';
 
 const { suite, test, suiteSetup, suiteTeardown } = Mocha;
 
@@ -134,7 +133,10 @@ suite('Integration: conversation length limit inspection', function () {
 		console.log(`title: ${convo.title}  type: ${convo.type}  updatedAt: ${convo.updatedAt}`);
 		const meta = convo.metadata as Record<string, unknown> | null | undefined;
 		const metaJson = JSON.stringify(convo.metadata ?? null);
-		fs.writeFileSync(`${DUMP_DIR}/convo-metadata.json`, JSON.stringify(convo.metadata ?? null, null, 2));
+		const dumpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-conversation-limit-'));
+		const metadataDumpPath = path.join(dumpDir, 'convo-metadata.json');
+		fs.writeFileSync(metadataDumpPath, JSON.stringify(convo.metadata ?? null, null, 2));
+		console.log(`metadata dump: ${metadataDumpPath}`);
 		console.log(`conversation.metadata: ${metaJson.length} bytes, top-level keys:`);
 		console.log(`  [${meta && typeof meta === 'object' ? Object.keys(meta).join(', ') : typeof meta}]`);
 		// Scan the whole serialized metadata for length-limit signal words.

--- a/src/test/integration/conversationLimitInspect.test.ts
+++ b/src/test/integration/conversationLimitInspect.test.ts
@@ -1,0 +1,186 @@
+import * as fs from 'fs';
+import * as Mocha from 'mocha';
+import { askRewstAi, Session } from '@sessions';
+import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
+
+const DUMP_DIR =
+	'/tmp/claude-1000/-home-jon-Documents-dev-rewst-buddy-full-rewst-buddy-vscode/caede6c9-7b18-4ffa-9c11-f454ffffef6f/scratchpad';
+
+const { suite, test, suiteSetup, suiteTeardown } = Mocha;
+
+// The probe conversation that the web UI now shows the length-limit warning on.
+const FLAGGED_CONVERSATION_ID = '019f4856-cf9e-7391-82b9-cea2b8cb441d';
+
+/**
+ * INSPECTION PROBE (not an assertion test): fetches a conversation the web UI
+ * flags as length-limited and dumps conversation.metadata plus every message's
+ * metadata/role so the length-limit marker (a field our subscription mapper
+ * drops) can be identified.
+ *
+ *   unset REWST_TEST_TOKEN && npm run test:grep:integration -- "inspect flagged conversation metadata"
+ */
+suite('Integration: conversation length limit inspection', function () {
+	this.timeout(120_000);
+
+	let session: Session;
+
+	suiteSetup(async function () {
+		if (!hasTestToken()) {
+			this.skip();
+			return;
+		}
+		initTestEnvironment();
+		session = await getTestSession();
+	});
+
+	suiteTeardown(() => {
+		clearCachedSession();
+	});
+
+	test('reproduce a continuation error on the near-full conversation', async function () {
+		if (!hasTestToken()) {
+			this.skip();
+			return;
+		}
+		const orgId = session.profile.org.id;
+		// One more turn on the ~98%-full conversation, with a large payload, to see
+		// whether the backend errors and exactly what error text the provider gets.
+		const big = Array.from(
+			{ length: 4000 },
+			(_, i) => `payload-${i} lorem ipsum dolor sit amet consectetur adipiscing elit sed do eiusmod`,
+		).join(' ');
+		const message = `Please summarize everything discussed so far in detail. Extra context: ${big}`;
+
+		const kinds: string[] = [];
+		let errorMsg: string | undefined;
+		for await (const event of askRewstAi({
+			session,
+			orgId,
+			message,
+			conversationId: FLAGGED_CONVERSATION_ID,
+			inactivityTimeoutMs: 180_000,
+		})) {
+			kinds.push(event.kind);
+			if (event.kind === 'usage')
+				console.log(`  usage ${event.totalTokens}/${event.maxTokens} (${event.percent}%)`);
+			if (event.kind === 'error') errorMsg = event.message;
+		}
+		console.log(`\n===== continuation result =====`);
+		console.log(`event kinds: ${kinds.join(', ')}`);
+		console.log(`ERROR: ${errorMsg ?? '(none — completed normally)'}`);
+	});
+
+	test('find and inspect the azure-function conversation tail', async function () {
+		if (!hasTestToken()) {
+			this.skip();
+			return;
+		}
+		const sdk = session.sdk;
+		if (!sdk) throw new Error('no sdk on test session');
+
+		const list = await sdk.getConversations({
+			where: { orgId: session.profile.org.id, userId: session.profile.user.id },
+			limit: 50,
+			order: [['updatedAt', 'DESC']],
+		});
+		const convos = list.conversations ?? [];
+		console.log(`\n===== ${convos.length} recent conversations =====`);
+		convos.forEach(c => console.log(`  ${c.id}  type=${c.type}  title=${JSON.stringify(c.title)}`));
+
+		const azure = convos.find(c => /azure|function/i.test(c.title ?? ''));
+		if (!azure) {
+			console.log('\n>>> No azure/function conversation found in the most recent 50.');
+			return;
+		}
+		console.log(`\n>>> AZURE conversation: ${azure.id}  type=${azure.type}`);
+
+		const full = await sdk.getConversation({ id: azure.id });
+		const convo = full.conversation;
+		const messages = convo?.messages ?? [];
+		console.log(`messages: ${messages.length}`);
+		const rehydrated = (convo?.metadata as Record<string, unknown> | undefined)?.rehydratedConversation as
+			| Record<string, unknown>
+			| undefined;
+		console.log(`graphState: ${JSON.stringify(rehydrated?.graphState)}`);
+		console.log(
+			`internalMessages count: ${Array.isArray(rehydrated?.internalMessages) ? rehydrated.internalMessages.length : 'n/a'}`,
+		);
+
+		console.log(`\n===== last 6 messages (role, stopReason, metaKeys) =====`);
+		messages.slice(-6).forEach((m, i) => {
+			const meta = m.metadata as Record<string, unknown> | null | undefined;
+			console.log(
+				`[${messages.length - 6 + i}] role=${m.role} stopReason=${meta?.stopReason ?? '-'} metaKeys=[${meta && typeof meta === 'object' ? Object.keys(meta).join(',') : ''}] len=${(m.content ?? '').length}`,
+			);
+		});
+	});
+
+	test('inspect flagged conversation metadata', async function () {
+		if (!hasTestToken()) {
+			this.skip();
+			return;
+		}
+		const sdk = session.sdk;
+		if (!sdk) throw new Error('no sdk on test session');
+
+		const res = await sdk.getConversation({ id: FLAGGED_CONVERSATION_ID });
+		const convo = res.conversation;
+		if (!convo) {
+			console.log(`\n>>> conversation ${FLAGGED_CONVERSATION_ID} not found for this user.`);
+			return;
+		}
+
+		console.log(`\n===== CONVERSATION ${convo.id} =====`);
+		console.log(`title: ${convo.title}  type: ${convo.type}  updatedAt: ${convo.updatedAt}`);
+		const meta = convo.metadata as Record<string, unknown> | null | undefined;
+		const metaJson = JSON.stringify(convo.metadata ?? null);
+		fs.writeFileSync(`${DUMP_DIR}/convo-metadata.json`, JSON.stringify(convo.metadata ?? null, null, 2));
+		console.log(`conversation.metadata: ${metaJson.length} bytes, top-level keys:`);
+		console.log(`  [${meta && typeof meta === 'object' ? Object.keys(meta).join(', ') : typeof meta}]`);
+		// Scan the whole serialized metadata for length-limit signal words.
+		const NEEDLES = [
+			'limit',
+			'max',
+			'length',
+			'token',
+			'full',
+			'warning',
+			'exceed',
+			'fresh',
+			'new conversation',
+			'start a new',
+			'too long',
+			'truncat',
+			'summariz',
+			'closed',
+			'locked',
+			'button',
+		];
+		for (const needle of NEEDLES) {
+			const idx = metaJson.toLowerCase().indexOf(needle);
+			if (idx >= 0) {
+				console.log(`  HIT "${needle}" @${idx}: …${metaJson.slice(Math.max(0, idx - 60), idx + 120)}…`);
+			}
+		}
+
+		const messages = convo.messages ?? [];
+		console.log(`\n===== ${messages.length} MESSAGES (metadata + role) =====`);
+		messages.forEach((m, i) => {
+			const meta = m.metadata as Record<string, unknown> | null | undefined;
+			const metaKeys = meta && typeof meta === 'object' ? Object.keys(meta) : [];
+			console.log(
+				`\n[#${i}] role=${m.role} id=${m.id} metaKeys=[${metaKeys.join(', ')}] contentLen=${(m.content ?? '').length}`,
+			);
+			if (metaKeys.length > 0) console.log(`  metadata: ${JSON.stringify(meta)}`);
+		});
+
+		// The last assistant message is where a "conversation is full" flag or
+		// button payload would most plausibly live — dump it in full.
+		const lastAssistant = [...messages].reverse().find(m => m.role === 'ASSISTANT');
+		if (lastAssistant) {
+			console.log(`\n===== LAST ASSISTANT MESSAGE (full) =====`);
+			console.log(`content:\n${lastAssistant.content}`);
+			console.log(`metadata:\n${JSON.stringify(lastAssistant.metadata, null, 2)}`);
+		}
+	});
+});

--- a/src/test/integration/conversationLimitInspect.test.ts
+++ b/src/test/integration/conversationLimitInspect.test.ts
@@ -1,7 +1,4 @@
-import * as fs from 'fs';
 import * as Mocha from 'mocha';
-import * as os from 'os';
-import * as path from 'path';
 import { askRewstAi, Session } from '@sessions';
 import { clearCachedSession, getTestSession, hasTestToken, initTestEnvironment } from '@test';
 
@@ -9,14 +6,37 @@ const { suite, test, suiteSetup, suiteTeardown } = Mocha;
 
 // The probe conversation that the web UI now shows the length-limit warning on.
 const FLAGGED_CONVERSATION_ID = '019f4856-cf9e-7391-82b9-cea2b8cb441d';
+const INSPECT_OPT_IN_ENV = 'REWST_CONVERSATION_LIMIT_INSPECT';
+const CONTINUATION_OPT_IN_ENV = 'REWST_CONVERSATION_LIMIT_CONTINUATION';
+
+function envFlag(name: string): boolean {
+	return process.env[name] === '1';
+}
+
+function objectKeys(value: unknown): string[] {
+	return value && typeof value === 'object' && !Array.isArray(value)
+		? Object.keys(value as Record<string, unknown>)
+		: [];
+}
+
+function jsonSize(value: unknown): number {
+	return JSON.stringify(value ?? null).length;
+}
+
+function boundedText(value: unknown, max = 180): string {
+	const text = String(value ?? '');
+	return text.length > max ? `${text.slice(0, max)}...[truncated ${text.length - max} chars]` : text;
+}
 
 /**
  * INSPECTION PROBE (not an assertion test): fetches a conversation the web UI
- * flags as length-limited and dumps conversation.metadata plus every message's
- * metadata/role so the length-limit marker (a field our subscription mapper
- * drops) can be identified.
+ * flags as length-limited and prints bounded structural summaries of
+ * conversation metadata plus every message's metadata/role so the length-limit
+ * marker (a field our subscription mapper drops) can be identified without
+ * logging live content.
  *
- *   unset REWST_TEST_TOKEN && npm run test:grep:integration -- "inspect flagged conversation metadata"
+ *   REWST_CONVERSATION_LIMIT_INSPECT=1 npm run test:grep:integration -- "inspect flagged conversation metadata"
+ *   REWST_CONVERSATION_LIMIT_INSPECT=1 REWST_CONVERSATION_LIMIT_CONTINUATION=1 npm run test:grep:integration -- "reproduce a continuation error"
  */
 suite('Integration: conversation length limit inspection', function () {
 	this.timeout(120_000);
@@ -24,7 +44,7 @@ suite('Integration: conversation length limit inspection', function () {
 	let session: Session;
 
 	suiteSetup(async function () {
-		if (!hasTestToken()) {
+		if (!hasTestToken() || !envFlag(INSPECT_OPT_IN_ENV)) {
 			this.skip();
 			return;
 		}
@@ -37,7 +57,7 @@ suite('Integration: conversation length limit inspection', function () {
 	});
 
 	test('reproduce a continuation error on the near-full conversation', async function () {
-		if (!hasTestToken()) {
+		if (!hasTestToken() || !envFlag(INSPECT_OPT_IN_ENV) || !envFlag(CONTINUATION_OPT_IN_ENV)) {
 			this.skip();
 			return;
 		}
@@ -66,11 +86,11 @@ suite('Integration: conversation length limit inspection', function () {
 		}
 		console.log(`\n===== continuation result =====`);
 		console.log(`event kinds: ${kinds.join(', ')}`);
-		console.log(`ERROR: ${errorMsg ?? '(none — completed normally)'}`);
+		console.log(`ERROR: ${errorMsg ? boundedText(errorMsg) : '(none — completed normally)'}`);
 	});
 
 	test('find and inspect the azure-function conversation tail', async function () {
-		if (!hasTestToken()) {
+		if (!hasTestToken() || !envFlag(INSPECT_OPT_IN_ENV)) {
 			this.skip();
 			return;
 		}
@@ -84,7 +104,7 @@ suite('Integration: conversation length limit inspection', function () {
 		});
 		const convos = list.conversations ?? [];
 		console.log(`\n===== ${convos.length} recent conversations =====`);
-		convos.forEach(c => console.log(`  ${c.id}  type=${c.type}  title=${JSON.stringify(c.title)}`));
+		convos.forEach(c => console.log(`  ${c.id}  type=${c.type}  titleLen=${(c.title ?? '').length}`));
 
 		const azure = convos.find(c => /azure|function/i.test(c.title ?? ''));
 		if (!azure) {
@@ -100,7 +120,7 @@ suite('Integration: conversation length limit inspection', function () {
 		const rehydrated = (convo?.metadata as Record<string, unknown> | undefined)?.rehydratedConversation as
 			| Record<string, unknown>
 			| undefined;
-		console.log(`graphState: ${JSON.stringify(rehydrated?.graphState)}`);
+		console.log(`graphState keys: [${objectKeys(rehydrated?.graphState).join(',')}]`);
 		console.log(
 			`internalMessages count: ${Array.isArray(rehydrated?.internalMessages) ? rehydrated.internalMessages.length : 'n/a'}`,
 		);
@@ -109,13 +129,13 @@ suite('Integration: conversation length limit inspection', function () {
 		messages.slice(-6).forEach((m, i) => {
 			const meta = m.metadata as Record<string, unknown> | null | undefined;
 			console.log(
-				`[${messages.length - 6 + i}] role=${m.role} stopReason=${meta?.stopReason ?? '-'} metaKeys=[${meta && typeof meta === 'object' ? Object.keys(meta).join(',') : ''}] len=${(m.content ?? '').length}`,
+				`[${messages.length - 6 + i}] role=${m.role} stopReason=${boundedText(meta?.stopReason ?? '-', 80)} metaKeys=[${objectKeys(meta).join(',')}] metaBytes=${jsonSize(meta)} len=${(m.content ?? '').length}`,
 			);
 		});
 	});
 
 	test('inspect flagged conversation metadata', async function () {
-		if (!hasTestToken()) {
+		if (!hasTestToken() || !envFlag(INSPECT_OPT_IN_ENV)) {
 			this.skip();
 			return;
 		}
@@ -130,15 +150,11 @@ suite('Integration: conversation length limit inspection', function () {
 		}
 
 		console.log(`\n===== CONVERSATION ${convo.id} =====`);
-		console.log(`title: ${convo.title}  type: ${convo.type}  updatedAt: ${convo.updatedAt}`);
+		console.log(`titleLen: ${(convo.title ?? '').length}  type: ${convo.type}  updatedAt: ${convo.updatedAt}`);
 		const meta = convo.metadata as Record<string, unknown> | null | undefined;
 		const metaJson = JSON.stringify(convo.metadata ?? null);
-		const dumpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'rewst-buddy-conversation-limit-'));
-		const metadataDumpPath = path.join(dumpDir, 'convo-metadata.json');
-		fs.writeFileSync(metadataDumpPath, JSON.stringify(convo.metadata ?? null, null, 2));
-		console.log(`metadata dump: ${metadataDumpPath}`);
 		console.log(`conversation.metadata: ${metaJson.length} bytes, top-level keys:`);
-		console.log(`  [${meta && typeof meta === 'object' ? Object.keys(meta).join(', ') : typeof meta}]`);
+		console.log(`  [${objectKeys(meta).join(', ') || typeof meta}]`);
 		// Scan the whole serialized metadata for length-limit signal words.
 		const NEEDLES = [
 			'limit',
@@ -161,7 +177,7 @@ suite('Integration: conversation length limit inspection', function () {
 		for (const needle of NEEDLES) {
 			const idx = metaJson.toLowerCase().indexOf(needle);
 			if (idx >= 0) {
-				console.log(`  HIT "${needle}" @${idx}: …${metaJson.slice(Math.max(0, idx - 60), idx + 120)}…`);
+				console.log(`  HIT "${needle}" @${idx}`);
 			}
 		}
 
@@ -169,20 +185,19 @@ suite('Integration: conversation length limit inspection', function () {
 		console.log(`\n===== ${messages.length} MESSAGES (metadata + role) =====`);
 		messages.forEach((m, i) => {
 			const meta = m.metadata as Record<string, unknown> | null | undefined;
-			const metaKeys = meta && typeof meta === 'object' ? Object.keys(meta) : [];
 			console.log(
-				`\n[#${i}] role=${m.role} id=${m.id} metaKeys=[${metaKeys.join(', ')}] contentLen=${(m.content ?? '').length}`,
+				`\n[#${i}] role=${m.role} id=${m.id} metaKeys=[${objectKeys(meta).join(', ')}] metaBytes=${jsonSize(meta)} contentLen=${(m.content ?? '').length}`,
 			);
-			if (metaKeys.length > 0) console.log(`  metadata: ${JSON.stringify(meta)}`);
 		});
 
 		// The last assistant message is where a "conversation is full" flag or
-		// button payload would most plausibly live — dump it in full.
+		// button payload would most plausibly live — summarize it without content.
 		const lastAssistant = [...messages].reverse().find(m => m.role === 'ASSISTANT');
 		if (lastAssistant) {
-			console.log(`\n===== LAST ASSISTANT MESSAGE (full) =====`);
-			console.log(`content:\n${lastAssistant.content}`);
-			console.log(`metadata:\n${JSON.stringify(lastAssistant.metadata, null, 2)}`);
+			console.log(`\n===== LAST ASSISTANT MESSAGE (summary) =====`);
+			console.log(`contentLen: ${(lastAssistant.content ?? '').length}`);
+			console.log(`metadataKeys: [${objectKeys(lastAssistant.metadata).join(', ')}]`);
+			console.log(`metadataBytes: ${jsonSize(lastAssistant.metadata)}`);
 		}
 	});
 });

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.test.ts
@@ -8,6 +8,7 @@ import { onDidChangeContextUsage, type ContextUsage } from './contextUsage';
 import { conversationMap } from './conversationMap';
 import {
 	MAX_BUDDY_TOOL_ROUNDS,
+	MAX_NATIVE_REDIRECT_ATTEMPTS,
 	normalizeBuddyToolRounds,
 	RoboRewstyChatModelProvider,
 	truncateArgsLabel,
@@ -613,7 +614,7 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 		assert.ok(out.includes('Deploy.'), 'final answer from the Buddy path streams');
 	});
 
-	test('stops after a repeated native Rewst tool attempt while Buddy tools are enabled', async () => {
+	test('stops only after exhausting the escalating redirect ceiling', async () => {
 		const nativeAttempt: ConversationEvent[] = [
 			{ kind: 'conversation', conversationId: 'conv-1' },
 			{
@@ -626,7 +627,12 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 			{ kind: 'complete', content: 'ignored', sources: [], conversationId: 'conv-1' },
 		];
 		let buddyRan = false;
-		const harness = makeHarness([nativeAttempt, nativeAttempt, completeTurn('unreachable', 'conv-1')], {
+		// MAX_NATIVE_REDIRECT_ATTEMPTS corrections are attempted (each triggering one
+		// more backend turn), and the native tool is requested again on that final
+		// turn too — only then does the loop give up.
+		const turns = Array.from({ length: MAX_NATIVE_REDIRECT_ATTEMPTS + 1 }, () => nativeAttempt);
+		turns.push(completeTurn('unreachable', 'conv-1'));
+		const harness = makeHarness(turns, {
 			buddyToolSpecs: () => [BUDDY_GET_SPEC],
 			runBuddyTool: async () => {
 				buddyRan = true;
@@ -636,12 +642,54 @@ suite('Unit: RoboRewstyChatModelProvider', () => {
 
 		await harness.run([message(User, [text('look up workflow w1')])]);
 
-		assert.strictEqual(harness.captured.length, 2, 'one correction is attempted, then the loop stops');
+		assert.strictEqual(
+			harness.captured.length,
+			MAX_NATIVE_REDIRECT_ATTEMPTS + 1,
+			`${MAX_NATIVE_REDIRECT_ATTEMPTS} corrections are attempted (${MAX_NATIVE_REDIRECT_ATTEMPTS + 1} backend turns total), then the loop stops`,
+		);
 		assert.strictEqual(buddyRan, false, 'no local Buddy tool runs without a fenced Buddy request');
 		assert.strictEqual(callsOf(harness.parts).length, 0, 'no VS Code tool call is emitted for native activity');
 		const out = visibleText(harness.parts);
 		assert.ok(out.includes('Stopped after a server-side Rewst tool was requested again'), 'stop note is visible');
-		assert.ok(!out.includes('unreachable'), 'no third backend turn is started');
+		assert.ok(!out.includes('unreachable'), 'no turn beyond the ceiling is started');
+		const lastCorrection = harness.captured[harness.captured.length - 1];
+		assert.ok(
+			lastCorrection.message.includes(
+				`attempt ${MAX_NATIVE_REDIRECT_ATTEMPTS} of ${MAX_NATIVE_REDIRECT_ATTEMPTS}`,
+			),
+			`expected the final correction to name attempt ${MAX_NATIVE_REDIRECT_ATTEMPTS}, got: ${lastCorrection.message}`,
+		);
+	});
+
+	test('a redirect that succeeds on a later attempt reaches a final answer instead of stopping', async () => {
+		const nativeAttempt: ConversationEvent[] = [
+			{ kind: 'conversation', conversationId: 'conv-1' },
+			{
+				kind: 'status',
+				label: 'Running Rewst tool: listWorkflow…',
+				activity: true,
+				tool: { name: 'listWorkflow' },
+			},
+			{ kind: 'chunk', text: 'ignored' },
+			{ kind: 'complete', content: 'ignored', sources: [], conversationId: 'conv-1' },
+		];
+		// Three native-tool attempts (not just one) before the backend finally
+		// follows the correction and answers — this only succeeds if the ceiling
+		// is greater than 1.
+		const harness = makeHarness(
+			[nativeAttempt, nativeAttempt, nativeAttempt, completeTurn('Recovered on a later attempt.', 'conv-1')],
+			{ buddyToolSpecs: () => [BUDDY_GET_SPEC] },
+		);
+
+		await harness.run([message(User, [text('look up workflow w1')])]);
+
+		assert.strictEqual(harness.captured.length, 4, 'three corrections were attempted before the answer');
+		const out = visibleText(harness.parts);
+		assert.ok(out.includes('Recovered on a later attempt.'), 'the final answer streams after recovering');
+		assert.ok(
+			!out.includes('Stopped after a server-side Rewst tool was requested again'),
+			'the loop does not give up before reaching the ceiling',
+		);
 	});
 
 	test('a downgrade after a native-tool redirect resets the redirect budget for the fresh attempt', async () => {

--- a/src/ui/chat/model/RoboRewstyChatModelProvider.ts
+++ b/src/ui/chat/model/RoboRewstyChatModelProvider.ts
@@ -35,6 +35,10 @@ const FAMILY = 'roborewsty';
 // Backstop on in-process buddy tool rounds within one chat response, so a backend
 // that keeps requesting tools without ever answering can't loop indefinitely.
 export const MAX_BUDDY_TOOL_ROUNDS = 8;
+// Backstop on native-Rewst-tool redirect corrections within one backend attempt.
+// We pretty much never want the "stopped" message to actually surface, so this
+// escalates through many attempts before giving up (#175).
+export const MAX_NATIVE_REDIRECT_ATTEMPTS = 25;
 // The backend manages its own context window; these are picker-display
 // estimates, not enforced limits.
 const MAX_INPUT_TOKENS = 128_000;
@@ -113,10 +117,23 @@ function sanitizeArgsForPrompt(args: string): string {
 	return args.replace(/[`<>]/g, '').replace(/\s+/g, ' ').trim();
 }
 
-function buildNativeToBuddyCorrection(tool: NativeRewstToolStatus['tool'], buddySpecs: readonly ToolSpec[]): string {
+/** A stronger, still-neutral opening line once the first correction wasn't followed. */
+function escalationPrefix(attempt: number, maxAttempts: number): string[] {
+	return attempt > 1
+		? [`This is correction attempt ${attempt} of ${maxAttempts}; the previous transport note was not followed.`]
+		: [];
+}
+
+function buildNativeToBuddyCorrection(
+	tool: NativeRewstToolStatus['tool'],
+	buddySpecs: readonly ToolSpec[],
+	attempt: number,
+	maxAttempts: number,
+): string {
 	const names = formatBuddyToolList(buddySpecs);
 	const sanitizedArgs = tool.args ? sanitizeArgsForPrompt(tool.args) : '';
 	const lines = [
+		...escalationPrefix(attempt, maxAttempts),
 		`Transport note: the previous server-side Rewst tool status was for ${formatInlineName(tool.name)}.`,
 	];
 	if (sanitizedArgs) {
@@ -132,9 +149,14 @@ function buildNativeToBuddyCorrection(tool: NativeRewstToolStatus['tool'], buddy
 	return lines.join('\n');
 }
 
-function buildNativeToEditorCorrection(tool: NativeRewstToolStatus['tool']): string {
+function buildNativeToEditorCorrection(
+	tool: NativeRewstToolStatus['tool'],
+	attempt: number,
+	maxAttempts: number,
+): string {
 	const sanitizedArgs = tool.args ? sanitizeArgsForPrompt(tool.args) : '';
 	const lines = [
+		...escalationPrefix(attempt, maxAttempts),
 		`Transport note: the previous server-side Rewst tool status was for ${formatInlineName(tool.name)}, which is a VS Code editor tool that must never be invoked as a native Rewst function call.`,
 	];
 	if (sanitizedArgs) {
@@ -398,7 +420,7 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 				),
 			);
 		};
-		let redirectedNativeRewstTool = false;
+		let nativeRewstToolRedirectAttempts = 0;
 		// Outer loop: a reuse turn that the backend can't follow downgrades to
 		// a fresh, stateless turn ONCE. The first attempt reuses when recovery
 		// found a conversation; the retry always starts fresh.
@@ -444,7 +466,7 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 							break;
 						case 'status':
 							if (shouldRedirectNativeRewstTool(event)) {
-								if (redirectedNativeRewstTool) {
+								if (nativeRewstToolRedirectAttempts >= MAX_NATIVE_REDIRECT_ATTEMPTS) {
 									emitText(gate.push(''));
 									needsSeparator = true;
 									emitText(
@@ -454,10 +476,19 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 									emitBreadcrumb();
 									return;
 								}
-								redirectedNativeRewstTool = true;
+								nativeRewstToolRedirectAttempts++;
 								message = editorToolNames.has(event.tool.name)
-									? buildNativeToEditorCorrection(event.tool)
-									: buildNativeToBuddyCorrection(event.tool, allBuddySpecs);
+									? buildNativeToEditorCorrection(
+											event.tool,
+											nativeRewstToolRedirectAttempts,
+											MAX_NATIVE_REDIRECT_ATTEMPTS,
+										)
+									: buildNativeToBuddyCorrection(
+											event.tool,
+											allBuddySpecs,
+											nativeRewstToolRedirectAttempts,
+											MAX_NATIVE_REDIRECT_ATTEMPTS,
+										);
 								needsSeparator = true;
 								continue turns;
 							}
@@ -613,8 +644,8 @@ export class RoboRewstyChatModelProvider implements vscode.LanguageModelChatProv
 			needsSeparator = trailingResults !== undefined;
 			lastStatusLabel = undefined;
 			// The stateless retry is a fresh attempt, so its first native tool should
-			// get its own redirect rather than the abandoned reuse turn's stop.
-			redirectedNativeRewstTool = false;
+			// get its own redirect budget rather than the abandoned reuse turn's.
+			nativeRewstToolRedirectAttempts = 0;
 		}
 	}
 

--- a/src/ui/chat/model/statelessTranscript.test.ts
+++ b/src/ui/chat/model/statelessTranscript.test.ts
@@ -56,4 +56,45 @@ suite('Unit: statelessTranscript', () => {
 		assert.match(transcript, /Before\s+After/);
 		assert.ok(!transcript.includes('Searching documentation'));
 	});
+
+	test('caps and frames terminal tool output as likely-unrelated', () => {
+		const call = new vscode.LanguageModelToolCallPart('call-1', 'run_in_terminal', { command: 'ls' });
+		const longOutput = 'x'.repeat(5_000);
+		const result = new vscode.LanguageModelToolResultPart('call-1', [text(longOutput)]);
+		const transcript = serializeVisibleChat([
+			message(User, [text('what does the terminal say?')]),
+			message(Assistant, [text('Checking.'), call]),
+			message(User, [result]),
+		]);
+
+		assert.match(transcript, /Editor tool result: run_in_terminal/);
+		assert.match(
+			transcript,
+			/raw terminal output — likely unrelated to the current request unless the user explicitly asked about the terminal/,
+		);
+		assert.ok(
+			!transcript.includes(longOutput),
+			'the full 5,000-char terminal output should be capped, not included verbatim',
+		);
+	});
+
+	test('does not cap or frame non-terminal tool output beyond the default cap', () => {
+		const call = new vscode.LanguageModelToolCallPart('call-1', 'read_file', { path: 'a.txt' });
+		const longOutput = 'y'.repeat(5_000);
+		const result = new vscode.LanguageModelToolResultPart('call-1', [text(longOutput)]);
+		const transcript = serializeVisibleChat([
+			message(User, [text('check a.txt')]),
+			message(Assistant, [text('Looking.'), call]),
+			message(User, [result]),
+		]);
+
+		assert.ok(
+			!transcript.includes('raw terminal output'),
+			'non-terminal tool output is not framed as terminal output',
+		);
+		assert.ok(
+			transcript.includes(longOutput),
+			'non-terminal tool output is not capped by the tighter terminal limit',
+		);
+	});
 });

--- a/src/ui/chat/model/statelessTranscript.ts
+++ b/src/ui/chat/model/statelessTranscript.ts
@@ -2,6 +2,14 @@ import vscode from 'vscode';
 
 const MAX_ENTRY_CHARS = 8_000;
 const MAX_TOTAL_CHARS = 64_000;
+// Terminal-reading tools (VS Code agent mode's run_in_terminal, get_terminal_output,
+// etc.) can surface scrollback from an unrelated session in the same integrated
+// terminal. Cap and frame that output much tighter than other tool results so the
+// backend doesn't treat leftover terminal text as an implicit directive (#168).
+const TERMINAL_TOOL_NAME_PATTERN = /terminal/i;
+const MAX_TERMINAL_OUTPUT_CHARS = 2_000;
+const TERMINAL_OUTPUT_FRAME =
+	'(raw terminal output — likely unrelated to the current request unless the user explicitly asked about the terminal)';
 
 type RequestMessage = Pick<vscode.LanguageModelChatRequestMessage, 'role' | 'content'>;
 
@@ -75,8 +83,12 @@ function serializePart(part: unknown, calls: ReadonlyMap<string, ToolCallInfo>):
 		const call = calls.get(candidate.callId);
 		const name = call?.name ?? 'tool';
 		const args = call?.input === undefined ? '' : ` ${safeJson(call.input)}`;
-		const output = candidate.content.map(textOf).filter(Boolean).join('\n');
-		return `Editor tool result: ${name}${args}\n${output}`;
+		const rawOutput = candidate.content.map(textOf).filter(Boolean).join('\n');
+		if (TERMINAL_TOOL_NAME_PATTERN.test(name)) {
+			const output = truncate(rawOutput, MAX_TERMINAL_OUTPUT_CHARS);
+			return `Editor tool result: ${name}${args}\n${TERMINAL_OUTPUT_FRAME}\n${output}`;
+		}
+		return `Editor tool result: ${name}${args}\n${rawOutput}`;
 	}
 
 	return '';

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -2242,6 +2242,166 @@ suite('Unit: workflowTools', () => {
 			assert.match(output, /advanced configuration or field mapping/i);
 		});
 
+		test("buddy_workflow_edit self-heals a newly created task's packOverrides mode when the server defaults it on creation (#174)", async () => {
+			// Server-side quirk: updateWorkflow ignores configSelectionMode /
+			// configFallbackMode on the SAME write that creates a task, but honors
+			// them on a follow-up update of that now-existing task. The tool should
+			// detect and replay the corrective write itself, instead of surfacing
+			// only a warning and requiring the caller to redo it manually.
+			let gets = 0;
+			let updates = 0;
+			const sentOverrides = [
+				{
+					packId: 'pack-1',
+					packConfigId: 'cfg-1',
+					configSelectionMode: 'USE_SELECTED_ID',
+					configFallbackMode: 'FAIL_ACTION',
+				},
+			];
+			const defaultedOverrides = [
+				{
+					packId: 'pack-1',
+					packConfigId: 'cfg-1',
+					configSelectionMode: 'USE_DEFAULT',
+					configFallbackMode: 'USE_DEFAULT',
+				},
+			];
+			const execute: GraphqlToolDeps['execute'] = async query => {
+				if (query.includes('RewstBuddyActionSearch')) {
+					return { data: { actionsForOrg: [{ id: 'noop-id', ref: 'core.noop', name: 'noop' }] } };
+				}
+				if (query.includes('RewstBuddyWorkflowGet')) {
+					gets += 1;
+					const w = sampleWorkflow();
+					if (gets === 1) return { data: { workflow: w } }; // before the edit: task doesn't exist yet
+					const created = {
+						id: 'cc03',
+						name: 'notify',
+						actionId: 'noop-id',
+						action: { ref: 'core.noop' },
+						input: {},
+						metadata: { x: 0, y: 0 },
+						next: [],
+						packOverrides: updates >= 2 ? sentOverrides : defaultedOverrides,
+					};
+					w.tasks = [...sampleTasks(), created];
+					return { data: { workflow: w } };
+				}
+				if (query.includes('RewstBuddyWorkflowUpdate')) {
+					updates += 1;
+					return { data: { updateWorkflow: { id: 'wf-1', updatedAt: String(1000 + updates * 500) } } };
+				}
+				return { data: {} };
+			};
+			const deps: GraphqlToolDeps = { isEnabled: () => true, confirmMutation: async () => true, execute };
+
+			const output = await runWorkflowTool(
+				{
+					tool: 'buddy_workflow_edit',
+					args: {
+						workflowId: 'wf-1',
+						workflowName: 'Sample',
+						orgId: 'org-1',
+						orgName: 'Acme',
+						operations: [
+							{
+								op: 'add_task',
+								id: 'cc03',
+								name: 'notify',
+								action: 'core.noop',
+								packOverrides: sentOverrides,
+							},
+						],
+					},
+				},
+				deps,
+			);
+
+			assert.strictEqual(updates, 2, 'the save is replayed once to self-heal the packOverrides mode');
+			assert.match(output, /auto-corrected packOverrides/i);
+			assert.ok(
+				!/WARNING — the server did not store/i.test(output),
+				'the warning is dropped once the heal succeeds',
+			);
+		});
+
+		test('buddy_workflow_edit keeps the warning when the packOverrides self-heal replay still diverges (#174)', async () => {
+			let gets = 0;
+			let updates = 0;
+			const sentOverrides = [
+				{
+					packId: 'pack-1',
+					packConfigId: 'cfg-1',
+					configSelectionMode: 'USE_SELECTED_ID',
+					configFallbackMode: 'FAIL_ACTION',
+				},
+			];
+			const defaultedOverrides = [
+				{
+					packId: 'pack-1',
+					packConfigId: 'cfg-1',
+					configSelectionMode: 'USE_DEFAULT',
+					configFallbackMode: 'USE_DEFAULT',
+				},
+			];
+			const execute: GraphqlToolDeps['execute'] = async query => {
+				if (query.includes('RewstBuddyActionSearch')) {
+					return { data: { actionsForOrg: [{ id: 'noop-id', ref: 'core.noop', name: 'noop' }] } };
+				}
+				if (query.includes('RewstBuddyWorkflowGet')) {
+					gets += 1;
+					const w = sampleWorkflow();
+					if (gets === 1) return { data: { workflow: w } };
+					// The server keeps defaulting the mode even after the heal replay —
+					// the warning should survive rather than being dropped.
+					const created = {
+						id: 'cc03',
+						name: 'notify',
+						actionId: 'noop-id',
+						action: { ref: 'core.noop' },
+						input: {},
+						metadata: { x: 0, y: 0 },
+						next: [],
+						packOverrides: defaultedOverrides,
+					};
+					w.tasks = [...sampleTasks(), created];
+					return { data: { workflow: w } };
+				}
+				if (query.includes('RewstBuddyWorkflowUpdate')) {
+					updates += 1;
+					return { data: { updateWorkflow: { id: 'wf-1', updatedAt: String(1000 + updates * 500) } } };
+				}
+				return { data: {} };
+			};
+			const deps: GraphqlToolDeps = { isEnabled: () => true, confirmMutation: async () => true, execute };
+
+			const output = await runWorkflowTool(
+				{
+					tool: 'buddy_workflow_edit',
+					args: {
+						workflowId: 'wf-1',
+						workflowName: 'Sample',
+						orgId: 'org-1',
+						orgName: 'Acme',
+						operations: [
+							{
+								op: 'add_task',
+								id: 'cc03',
+								name: 'notify',
+								action: 'core.noop',
+								packOverrides: sentOverrides,
+							},
+						],
+					},
+				},
+				deps,
+			);
+
+			assert.strictEqual(updates, 2, 'exactly one heal replay is attempted, not a retry loop');
+			assert.match(output, /WARNING — the server did not store/i);
+			assert.match(output, /task "notify": packOverrides\.0\.configSelectionMode/);
+		});
+
 		test('buddy_workflow_edit skips the verification read when no operation carries input', async () => {
 			const { deps, calls } = makeDeps();
 			await runWorkflowTool(
@@ -3593,7 +3753,11 @@ suite('Unit: workflowTools', () => {
 						return {
 							data: {
 								taskLogs: [
-									{ originalWorkflowTaskName: 'root_task', status: 'succeeded', taskExecutionId: 'te-1' },
+									{
+										originalWorkflowTaskName: 'root_task',
+										status: 'succeeded',
+										taskExecutionId: 'te-1',
+									},
 								],
 							},
 						};
@@ -3710,7 +3874,11 @@ suite('Unit: workflowTools', () => {
 				inlinedSections <= 5 * 5,
 				`no more than MAX_INLINE_SUB_EXECUTIONS per level across up to 5 levels; got ${inlinedSections}`,
 			);
-			assert.match(output, /truncated at 25 fetches/, 'truncation is stated in the output when the budget is hit');
+			assert.match(
+				output,
+				/truncated at 25 fetches/,
+				'truncation is stated in the output when the budget is hit',
+			);
 			assert.match(
 				output,
 				/more sub-execution\(s\) not inlined/,
@@ -3727,7 +3895,11 @@ suite('Unit: workflowTools', () => {
 						return {
 							data: {
 								taskLogs: [
-									{ originalWorkflowTaskName: 'root_task', status: 'succeeded', taskExecutionId: 'te-1' },
+									{
+										originalWorkflowTaskName: 'root_task',
+										status: 'succeeded',
+										taskExecutionId: 'te-1',
+									},
 								],
 							},
 						};
@@ -3766,7 +3938,11 @@ suite('Unit: workflowTools', () => {
 				},
 				deps,
 			);
-			assert.match(output, /Sub-execution Child Flow \(exec-child, succeeded\):/, 'level 1 child is still inlined');
+			assert.match(
+				output,
+				/Sub-execution Child Flow \(exec-child, succeeded\):/,
+				'level 1 child is still inlined',
+			);
 			assert.match(
 				output,
 				/could not fetch children of sub-execution exec-child.*grandchild lookup boom/,
@@ -4813,12 +4989,16 @@ suite('Unit: workflowTools', () => {
 				deps,
 			);
 			assert.match(output, /Nested diagnosis \(level 1/, 'level 1 nested section present');
-			assert.match(output, /child_setup: succeeded/, "level 1 section includes the sibling task, not just child_task");
+			assert.match(
+				output,
+				/child_setup: succeeded/,
+				'level 1 section includes the sibling task, not just child_task',
+			);
 			assert.match(output, /Nested diagnosis \(level 2/, 'level 2 nested section present');
 			assert.match(
 				output,
 				/grand_setup: succeeded/,
-				"level 2 section includes the sibling task, not just grand_task",
+				'level 2 section includes the sibling task, not just grand_task',
 			);
 		});
 

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -2495,6 +2495,84 @@ suite('Unit: workflowTools', () => {
 			assert.match(output, /task "notify": packOverrides\.0\.configSelectionMode/);
 		});
 
+		test('buddy_workflow_edit keeps the packOverrides warning when self-heal verification cannot re-read (#174)', async () => {
+			let gets = 0;
+			let updates = 0;
+			const sentOverrides = [
+				{
+					packId: 'pack-1',
+					packConfigId: 'cfg-1',
+					configSelectionMode: 'USE_SELECTED_ID',
+					configFallbackMode: 'FAIL_ACTION',
+				},
+			];
+			const defaultedOverrides = [
+				{
+					packId: 'pack-1',
+					packConfigId: 'cfg-1',
+					configSelectionMode: 'USE_DEFAULT',
+					configFallbackMode: 'USE_DEFAULT',
+				},
+			];
+			const execute: GraphqlToolDeps['execute'] = async query => {
+				if (query.includes('RewstBuddyActionSearch')) {
+					return { data: { actionsForOrg: [{ id: 'noop-id', ref: 'core.noop', name: 'noop' }] } };
+				}
+				if (query.includes('RewstBuddyWorkflowGet')) {
+					gets += 1;
+					if (gets === 4) return { errors: [{ message: 'temporary read failure' }] };
+					const w = sampleWorkflow();
+					if (gets === 1) return { data: { workflow: w } };
+					const created = {
+						id: 'cc03',
+						name: 'notify',
+						actionId: 'noop-id',
+						action: { ref: 'core.noop' },
+						input: {},
+						metadata: { x: 0, y: 0 },
+						next: [],
+						packOverrides: defaultedOverrides,
+					};
+					w.tasks = [...sampleTasks(), created];
+					return { data: { workflow: w } };
+				}
+				if (query.includes('RewstBuddyWorkflowUpdate')) {
+					updates += 1;
+					return { data: { updateWorkflow: { id: 'wf-1', updatedAt: String(1000 + updates * 500) } } };
+				}
+				return { data: {} };
+			};
+			const deps: GraphqlToolDeps = { isEnabled: () => true, confirmMutation: async () => true, execute };
+
+			const output = await runWorkflowTool(
+				{
+					tool: 'buddy_workflow_edit',
+					args: {
+						workflowId: 'wf-1',
+						workflowName: 'Sample',
+						orgId: 'org-1',
+						orgName: 'Acme',
+						operations: [
+							{
+								op: 'add_task',
+								id: 'cc03',
+								name: 'notify',
+								action: 'core.noop',
+								packOverrides: sentOverrides,
+							},
+						],
+					},
+				},
+				deps,
+			);
+
+			assert.strictEqual(updates, 2, 'the self-heal write still succeeds before the verification read fails');
+			assert.strictEqual(gets, 4, 'the final verification read is attempted');
+			assert.match(output, /WARNING — the server did not store/i);
+			assert.match(output, /task "notify": packOverrides\.0\.configSelectionMode/);
+			assert.ok(!/auto-corrected packOverrides/i.test(output), 'failed verification must not claim success');
+		});
+
 		test('buddy_workflow_edit skips the verification read when no operation carries input', async () => {
 			const { deps, calls } = makeDeps();
 			await runWorkflowTool(

--- a/src/ui/chat/tools/workflowTools.test.ts
+++ b/src/ui/chat/tools/workflowTools.test.ts
@@ -2323,6 +2323,99 @@ suite('Unit: workflowTools', () => {
 				!/WARNING — the server did not store/i.test(output),
 				'the warning is dropped once the heal succeeds',
 			);
+			assert.match(
+				output,
+				/New version token: 2000/,
+				"the reported version token must be the heal write's own updatedAt, not the stale first-write token",
+			);
+		});
+
+		test("buddy_workflow_edit does not replay a heal write for a task whose own packOverrides did not diverge, even when another task's did (#174)", async () => {
+			// healable (created-task) packOverrides gating must be scoped per task —
+			// a divergence warning anywhere in the output must not trigger a heal
+			// replay for a created task whose own packOverrides already match.
+			let gets = 0;
+			let updates = 0;
+			const sentOverrides = [
+				{
+					packId: 'pack-1',
+					packConfigId: 'cfg-1',
+					configSelectionMode: 'USE_SELECTED_ID',
+					configFallbackMode: 'FAIL_ACTION',
+				},
+			];
+			const execute: GraphqlToolDeps['execute'] = async query => {
+				if (query.includes('RewstBuddyActionSearch')) {
+					return { data: { actionsForOrg: [{ id: 'noop-id', ref: 'core.noop', name: 'noop' }] } };
+				}
+				if (query.includes('RewstBuddyWorkflowGet')) {
+					gets += 1;
+					const w = sampleWorkflow();
+					if (gets === 1) return { data: { workflow: w } };
+					// 'notify' (newly created) already stored with the correct sent
+					// overrides — no divergence for it. 'start' (an existing, updated
+					// task, not created this batch) diverges on an unrelated field the
+					// server silently stripped.
+					const created = {
+						id: 'cc03',
+						name: 'notify',
+						actionId: 'noop-id',
+						action: { ref: 'core.noop' },
+						input: {},
+						metadata: { x: 0, y: 0 },
+						next: [],
+						packOverrides: sentOverrides,
+					};
+					w.tasks = sampleTasks().map(t =>
+						t.name === 'start'
+							? { ...t, packOverrides: [{ packId: 'pack-2', configSelectionMode: 'USE_DEFAULT' }] }
+							: t,
+					);
+					w.tasks.push(created);
+					return { data: { workflow: w } };
+				}
+				if (query.includes('RewstBuddyWorkflowUpdate')) {
+					updates += 1;
+					return { data: { updateWorkflow: { id: 'wf-1', updatedAt: String(1000 + updates * 500) } } };
+				}
+				return { data: {} };
+			};
+			const deps: GraphqlToolDeps = { isEnabled: () => true, confirmMutation: async () => true, execute };
+
+			const output = await runWorkflowTool(
+				{
+					tool: 'buddy_workflow_edit',
+					args: {
+						workflowId: 'wf-1',
+						workflowName: 'Sample',
+						orgId: 'org-1',
+						orgName: 'Acme',
+						operations: [
+							{
+								op: 'add_task',
+								id: 'cc03',
+								name: 'notify',
+								action: 'core.noop',
+								packOverrides: sentOverrides,
+							},
+							{
+								op: 'update_task',
+								name: 'start',
+								set: { packOverrides: [{ packId: 'pack-2', configSelectionMode: 'USE_SELECTED_ID' }] },
+							},
+						],
+					},
+				},
+				deps,
+			);
+
+			assert.strictEqual(updates, 1, 'no heal replay for a created task whose own packOverrides already matched');
+			assert.match(
+				output,
+				/WARNING — the server did not store/i,
+				'the unrelated divergence on "start" still warns',
+			);
+			assert.ok(!/auto-corrected packOverrides/i.test(output), 'nothing was actually healed');
 		});
 
 		test('buddy_workflow_edit keeps the warning when the packOverrides self-heal replay still diverges (#174)', async () => {

--- a/src/ui/jinja/JinjaPreviewSession.test.ts
+++ b/src/ui/jinja/JinjaPreviewSession.test.ts
@@ -242,6 +242,35 @@ suite('Unit: JinjaPreviewSession', () => {
 			}
 		});
 
+		test('renders immediately with no context picked, treating mergedVars as empty', async () => {
+			const uri = writeTemplateFile('t-no-context.j2', '{{ CTX }}');
+			const org = Fixtures.orgModel({ id: 'org-no-context', name: 'Org No Context' });
+			linkFile(uri, org.id, 'tpl-no-context');
+			const { restore } = stubShowTextDocument();
+
+			let renderCalled = false;
+			const fakeSession = fakeRenderSession(org.id, (query, vars) => {
+				assert.ok(query.includes('RewstBuddyRenderJinja'));
+				renderCalled = true;
+				return { data: { renderJinja: { result: vars?.vars } } };
+			});
+			const restoreGetSession = stub(SessionManager, 'getSessionForOrg', (async () => fakeSession) as any);
+
+			try {
+				const state = await JinjaPreviewSession.createOrShow(uri, extContext);
+				assert.strictEqual(state.mergedVars, undefined, 'no context was picked');
+
+				await JinjaPreviewSession._renderForTesting(uri);
+
+				assert.ok(renderCalled, 'render should proceed even with no context picked, using empty vars');
+				const rendered = JinjaRenderedContentProvider.provideTextDocumentContent(state.renderedUri);
+				assert.strictEqual(rendered, formatRenderedSuccess({}, false));
+			} finally {
+				restore();
+				restoreGetSession();
+			}
+		});
+
 		test('session-lookup failure shows a session error comment and never calls evaluateRenderJinja', async () => {
 			const uri = writeTemplateFile('t-session-err.j2', '{{ CTX }}');
 			const org = Fixtures.orgModel({ id: 'org-session-err', name: 'Org Session Err' });
@@ -351,6 +380,10 @@ suite('Unit: JinjaPreviewSession', () => {
 
 			try {
 				const state = await JinjaPreviewSession.createOrShow(uri, extContext);
+				// createOrShow itself now renders eagerly with the valid seed overrides
+				// (#173); reset the flag so this test only measures the invalid-JSON
+				// render attempted below.
+				renderCalled = false;
 				JinjaPreviewSession._setMergedVarsForTesting(uri, { a: 1 });
 
 				const overridesDoc = await vscode.workspace.openTextDocument(state.overridesUri);
@@ -512,7 +545,7 @@ suite('Unit: JinjaPreviewSession', () => {
 			}
 		});
 
-		test('pickContext cancel (user dismisses picker) exits without persisting context or rendering', async () => {
+		test('pickContext cancel (user dismisses picker) exits without persisting context or picking one', async () => {
 			const uri = writeTemplateFile('t-cancel.j2', '{{ CTX }}');
 			const org = Fixtures.orgModel({ id: 'org-cancel', name: 'Org Cancel' });
 			linkFile(uri, org.id, 'tpl-cancel');
@@ -546,7 +579,9 @@ suite('Unit: JinjaPreviewSession', () => {
 				// No context should have been saved
 				const remembered = getLastContext(extContext, 'tpl-cancel');
 				assert.strictEqual(remembered, undefined, 'should not persist context when picker is cancelled');
-				// mergedVars should remain unset (no render happened)
+				// mergedVars should remain unset — the picker was cancelled, so no context
+				// was merged in (a render still fires eagerly with empty vars, but that's
+				// covered by the "no context picked" render test, not this one)
 				const state = await JinjaPreviewSession.createOrShow(uri, extContext);
 				assert.strictEqual(state.mergedVars, undefined, 'mergedVars should be unset after cancel');
 			} finally {

--- a/src/ui/jinja/JinjaPreviewSession.ts
+++ b/src/ui/jinja/JinjaPreviewSession.ts
@@ -150,8 +150,10 @@ export const JinjaPreviewSession = new (class JinjaPreviewSessionImpl implements
 			if (isLive()) JinjaRenderedContentProvider.update(state.renderedUri, formatInvalidOverrides(parsed.error));
 			return;
 		}
-		if (!state.mergedVars) return; // no context picked yet — leave the placeholder up
 
+		// No execution context picked yet is not a reason to withhold a render —
+		// Jinja renders undefined variables per its normal semantics server-side, so
+		// render eagerly with whatever overrides are present (#173).
 		const vars = mergeVars(state.mergedVars, parsed.vars ?? {});
 
 		let freshSession: Awaited<ReturnType<typeof SessionManager.getSessionForOrg>>;
@@ -296,6 +298,11 @@ export const JinjaPreviewSession = new (class JinjaPreviewSessionImpl implements
 					formatRenderedError(`Could not load remembered context: ${errMsg(e)}`),
 				);
 			}
+		} else {
+			// No remembered context — still render immediately with empty/override-only
+			// vars instead of leaving the panel on a static placeholder until the first
+			// edit or context pick (#173).
+			await this.doRender(state);
 		}
 
 		return state;

--- a/src/workflow/graphMutations.ts
+++ b/src/workflow/graphMutations.ts
@@ -87,6 +87,7 @@ interface TaskVerifyFields {
 interface TaskVerification {
 	message: string;
 	readOk: boolean;
+	storedById?: Map<string, RawTask>;
 }
 
 // ---------------------------------------------------------------------------
@@ -852,6 +853,29 @@ export function sentValueDivergences(sent: unknown, stored: unknown, path: strin
 	return storedValueMatches(sent, stored) ? [] : [`${path}: sent ${briefValue(sent)}, stored ${briefValue(stored)}`];
 }
 
+type TaskVerifyFieldName = keyof TaskVerifyFields;
+
+function taskFieldDivergences(sent: RawTask, stored: RawTask, field: TaskVerifyFieldName): string[] {
+	switch (field) {
+		case 'input':
+			return sentValueDivergences(sent.input ?? {}, stored.input ?? {}, 'input');
+		case 'with':
+			return sentValueDivergences(sent.with ?? {}, stored.with ?? {}, 'with');
+		case 'runAsOrgId':
+			return sentValueDivergences(sent.runAsOrgId ?? null, stored.runAsOrgId ?? null, 'runAsOrgId');
+		case 'packOverrides':
+			return sentValueDivergences(sent.packOverrides ?? [], stored.packOverrides ?? [], 'packOverrides');
+		case 'isMocked':
+			return sentValueDivergences(sent.isMocked ?? null, stored.isMocked ?? null, 'isMocked');
+		case 'mockInput':
+			return sentValueDivergences(sent.mockInput ?? null, stored.mockInput ?? null, 'mockInput');
+	}
+}
+
+function hasTaskFieldDivergence(sent: RawTask, stored: RawTask, field: TaskVerifyFieldName): boolean {
+	return taskFieldDivergences(sent, stored, field).length > 0;
+}
+
 async function verifySavedTaskValues(
 	deps: GraphqlToolDeps,
 	workflowId: string,
@@ -869,30 +893,23 @@ async function verifySavedTaskValues(
 				continue;
 			}
 			const lines = [
-				...(fields.input ? sentValueDivergences(sent.input ?? {}, stored.input ?? {}, 'input') : []),
-				...(fields.with ? sentValueDivergences(sent.with ?? {}, stored.with ?? {}, 'with') : []),
-				...(fields.runAsOrgId
-					? sentValueDivergences(sent.runAsOrgId ?? null, stored.runAsOrgId ?? null, 'runAsOrgId')
-					: []),
-				...(fields.packOverrides
-					? sentValueDivergences(sent.packOverrides ?? [], stored.packOverrides ?? [], 'packOverrides')
-					: []),
-				...(fields.isMocked
-					? sentValueDivergences(sent.isMocked ?? null, stored.isMocked ?? null, 'isMocked')
-					: []),
-				...(fields.mockInput
-					? sentValueDivergences(sent.mockInput ?? null, stored.mockInput ?? null, 'mockInput')
-					: []),
+				...(fields.input ? taskFieldDivergences(sent, stored, 'input') : []),
+				...(fields.with ? taskFieldDivergences(sent, stored, 'with') : []),
+				...(fields.runAsOrgId ? taskFieldDivergences(sent, stored, 'runAsOrgId') : []),
+				...(fields.packOverrides ? taskFieldDivergences(sent, stored, 'packOverrides') : []),
+				...(fields.isMocked ? taskFieldDivergences(sent, stored, 'isMocked') : []),
+				...(fields.mockInput ? taskFieldDivergences(sent, stored, 'mockInput') : []),
 			];
 			problems.push(...lines.map(line => `- task "${sent.name}": ${line}`));
 		}
-		if (problems.length === 0) return { message: '', readOk: true };
+		if (problems.length === 0) return { message: '', readOk: true, storedById };
 		return {
 			message:
 				`\n\nWARNING — the server did not store some task values as sent. Rewst may filter task input against the action's inputSchema or normalize advanced task configuration such as org overrides, integration overrides, mocking, while the save still reports success.\n` +
 				`${problems.join('\n')}\n` +
 				`Check the action's accepted parameters, advanced configuration or field mapping with buddy_action_search describe mode, then re-apply with matching keys, types, and supported configuration values.`,
 			readOk: true,
+			storedById,
 		};
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
@@ -1007,9 +1024,16 @@ export async function applyWorkflowMutation(
 	// heal candidate — an unrelated task's divergence must never trigger a
 	// pointless corrective write for a created task that already matched.
 	const healable = toVerify
-		.filter(({ task, fields }) => fields.packOverrides && !originalTaskIds.has(task.id))
-		.map(({ task }) => task)
-		.filter(task => verification.message.includes(`task "${task.name}": packOverrides`));
+		.filter(({ task, fields }) => {
+			const stored = verification.storedById?.get(task.id);
+			return (
+				fields.packOverrides &&
+				!originalTaskIds.has(task.id) &&
+				!!stored &&
+				hasTaskFieldDivergence(task, stored, 'packOverrides')
+			);
+		})
+		.map(({ task }) => task);
 	if (healable.length > 0) {
 		const heal = await healCreatedTaskPackOverrides(deps, workflowId, orgId, healable, comment);
 		if (heal.ok) {

--- a/src/workflow/graphMutations.ts
+++ b/src/workflow/graphMutations.ts
@@ -902,6 +902,41 @@ async function verifySavedTaskValues(
  * workflow, apply operations to the whole graph, and save with the correct
  * openedAt token — retrying once on a version conflict.
  */
+/**
+ * Rewst's updateWorkflow resolver can silently default a newly created task's
+ * packOverrides configSelectionMode/configFallbackMode on the SAME write that
+ * creates the task, while honoring them on a follow-up update of that
+ * already-existing task (server-side quirk — #174). Re-sends just the healable
+ * tasks' packOverrides in one corrective updateWorkflow call, replaying the
+ * "call update_task a second time" workaround programmatically. Returns false
+ * (no self-heal attempted/succeeded) on any fetch or mutation error, leaving
+ * the original verification warning as the caller's fallback.
+ */
+async function healCreatedTaskPackOverrides(
+	deps: GraphqlToolDeps,
+	workflowId: string,
+	orgId: string,
+	healable: RawTask[],
+	comment: string,
+): Promise<boolean> {
+	try {
+		const fresh = await fetchWorkflow(deps, workflowId, orgId);
+		const byId = new Map(fresh.tasks.map(t => [t.id, t]));
+		for (const task of healable) {
+			const current = byId.get(task.id);
+			if (current) current.packOverrides = task.packOverrides;
+		}
+		const result = await deps.execute(WORKFLOW_UPDATE_MUTATION, {
+			workflow: workflowToInput(fresh, fresh.tasks, {}),
+			openedAt: fresh.updatedAt,
+			comment: `${comment} (auto-correct packOverrides mode on newly created task(s))`,
+		});
+		return !firstErrorMessage(result as ExecResult);
+	} catch {
+		return false;
+	}
+}
+
 export async function applyWorkflowMutation(
 	deps: GraphqlToolDeps,
 	workflowId: string,
@@ -913,6 +948,7 @@ export async function applyWorkflowMutation(
 	const apply = (source: RawWorkflow) => applyOperations(source.tasks, operations, actionIdByRef);
 
 	const workflow = await fetchWorkflow(deps, workflowId, orgId);
+	const originalTaskIds = new Set(workflow.tasks.map(t => t.id));
 	let { tasks, applied, workflow: overrides, verifyFields } = apply(workflow);
 	if (!(await deps.confirmMutation(`update workflow "${workflow.name}" (${applied.length} operation(s))`))) {
 		throw new Error('Workflow change was not confirmed.');
@@ -942,7 +978,21 @@ export async function applyWorkflowMutation(
 		const fields = verifyFields.get(task.id);
 		return fields ? [{ task, fields }] : [];
 	});
-	const verification = toVerify.length > 0 ? await verifySavedTaskValues(deps, workflowId, orgId, toVerify) : '';
+	let verification = toVerify.length > 0 ? await verifySavedTaskValues(deps, workflowId, orgId, toVerify) : '';
+
+	const healable = toVerify
+		.filter(({ task, fields }) => fields.packOverrides && !originalTaskIds.has(task.id))
+		.map(({ task }) => task);
+	if (healable.length > 0 && /packOverrides/.test(verification)) {
+		const healed = await healCreatedTaskPackOverrides(deps, workflowId, orgId, healable, comment);
+		if (healed) {
+			verification = await verifySavedTaskValues(deps, workflowId, orgId, toVerify);
+			if (!/packOverrides/.test(verification)) {
+				verification += `\n\nNote: auto-corrected packOverrides on ${healable.length} newly created task(s) — the server ignored the requested selection/fallback mode on creation but accepted it on this follow-up update.`;
+			}
+		}
+	}
+
 	return `Applied ${applied.length} operation(s) to "${workflow.name}":\n${applied.map(line => `- ${line}`).join('\n')}\n\nSaved. New version token: ${updated?.updatedAt ?? '(unknown)'}.${verification}`;
 }
 

--- a/src/workflow/graphMutations.ts
+++ b/src/workflow/graphMutations.ts
@@ -84,6 +84,11 @@ interface TaskVerifyFields {
 	mockInput?: boolean;
 }
 
+interface TaskVerification {
+	message: string;
+	readOk: boolean;
+}
+
 // ---------------------------------------------------------------------------
 // Fetch helpers
 // ---------------------------------------------------------------------------
@@ -852,7 +857,7 @@ async function verifySavedTaskValues(
 	workflowId: string,
 	orgId: string,
 	toVerify: { task: RawTask; fields: TaskVerifyFields }[],
-): Promise<string> {
+): Promise<TaskVerification> {
 	try {
 		const saved = await fetchWorkflow(deps, workflowId, orgId);
 		const storedById = new Map(saved.tasks.map(t => [t.id, t]));
@@ -881,15 +886,20 @@ async function verifySavedTaskValues(
 			];
 			problems.push(...lines.map(line => `- task "${sent.name}": ${line}`));
 		}
-		if (problems.length === 0) return '';
-		return (
-			`\n\nWARNING — the server did not store some task values as sent. Rewst may filter task input against the action's inputSchema or normalize advanced task configuration such as org overrides, integration overrides, mocking, while the save still reports success.\n` +
-			`${problems.join('\n')}\n` +
-			`Check the action's accepted parameters, advanced configuration or field mapping with buddy_action_search describe mode, then re-apply with matching keys, types, and supported configuration values.`
-		);
+		if (problems.length === 0) return { message: '', readOk: true };
+		return {
+			message:
+				`\n\nWARNING — the server did not store some task values as sent. Rewst may filter task input against the action's inputSchema or normalize advanced task configuration such as org overrides, integration overrides, mocking, while the save still reports success.\n` +
+				`${problems.join('\n')}\n` +
+				`Check the action's accepted parameters, advanced configuration or field mapping with buddy_action_search describe mode, then re-apply with matching keys, types, and supported configuration values.`,
+			readOk: true,
+		};
 	} catch (error) {
 		const message = error instanceof Error ? error.message : String(error);
-		return `\n\nNote: the edit saved, but the tool could not verify the stored task inputs (${message}); re-read with buddy_workflow_get to confirm.`;
+		return {
+			message: `\n\nNote: the edit saved, but the tool could not verify the stored task inputs (${message}); re-read with buddy_workflow_get to confirm.`,
+			readOk: false,
+		};
 	}
 }
 
@@ -987,7 +997,10 @@ export async function applyWorkflowMutation(
 		const fields = verifyFields.get(task.id);
 		return fields ? [{ task, fields }] : [];
 	});
-	let verification = toVerify.length > 0 ? await verifySavedTaskValues(deps, workflowId, orgId, toVerify) : '';
+	let verification: TaskVerification =
+		toVerify.length > 0
+			? await verifySavedTaskValues(deps, workflowId, orgId, toVerify)
+			: { message: '', readOk: true };
 
 	// Scoped per task (not just "does the warning mention packOverrides anywhere"):
 	// only a task this batch created, whose OWN divergence line is present, is a
@@ -996,19 +1009,30 @@ export async function applyWorkflowMutation(
 	const healable = toVerify
 		.filter(({ task, fields }) => fields.packOverrides && !originalTaskIds.has(task.id))
 		.map(({ task }) => task)
-		.filter(task => verification.includes(`task "${task.name}": packOverrides`));
+		.filter(task => verification.message.includes(`task "${task.name}": packOverrides`));
 	if (healable.length > 0) {
 		const heal = await healCreatedTaskPackOverrides(deps, workflowId, orgId, healable, comment);
 		if (heal.ok) {
 			if (heal.updatedAt) updated = { ...updated, updatedAt: heal.updatedAt };
-			verification = await verifySavedTaskValues(deps, workflowId, orgId, toVerify);
-			if (!/packOverrides/.test(verification)) {
-				verification += `\n\nNote: auto-corrected packOverrides on ${healable.length} newly created task(s) — the server ignored the requested selection/fallback mode on creation but accepted it on this follow-up update.`;
+			const originalVerification = verification;
+			const healedVerification = await verifySavedTaskValues(deps, workflowId, orgId, toVerify);
+			if (healedVerification.readOk) {
+				verification = healedVerification;
+				if (!/packOverrides/.test(verification.message)) {
+					verification = {
+						...verification,
+						message:
+							verification.message +
+							`\n\nNote: auto-corrected packOverrides on ${healable.length} newly created task(s) — the server ignored the requested selection/fallback mode on creation but accepted it on this follow-up update.`,
+					};
+				}
+			} else {
+				verification = originalVerification;
 			}
 		}
 	}
 
-	return `Applied ${applied.length} operation(s) to "${workflow.name}":\n${applied.map(line => `- ${line}`).join('\n')}\n\nSaved. New version token: ${updated?.updatedAt ?? '(unknown)'}.${verification}`;
+	return `Applied ${applied.length} operation(s) to "${workflow.name}":\n${applied.map(line => `- ${line}`).join('\n')}\n\nSaved. New version token: ${updated?.updatedAt ?? '(unknown)'}.${verification.message}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/workflow/graphMutations.ts
+++ b/src/workflow/graphMutations.ts
@@ -897,20 +897,17 @@ async function verifySavedTaskValues(
 // Shared write pipeline
 // ---------------------------------------------------------------------------
 
-/**
- * The shared workflow write pipeline: resolve action refs, read the current
- * workflow, apply operations to the whole graph, and save with the correct
- * openedAt token — retrying once on a version conflict.
- */
+type UpdateWorkflowResult = { updateWorkflow?: { name?: string; updatedAt?: string } } | undefined;
+
 /**
  * Rewst's updateWorkflow resolver can silently default a newly created task's
  * packOverrides configSelectionMode/configFallbackMode on the SAME write that
  * creates the task, while honoring them on a follow-up update of that
  * already-existing task (server-side quirk — #174). Re-sends just the healable
  * tasks' packOverrides in one corrective updateWorkflow call, replaying the
- * "call update_task a second time" workaround programmatically. Returns false
- * (no self-heal attempted/succeeded) on any fetch or mutation error, leaving
- * the original verification warning as the caller's fallback.
+ * "call update_task a second time" workaround programmatically. Returns
+ * `ok: false` (no self-heal attempted/succeeded) on any fetch or mutation
+ * error, leaving the original verification warning as the caller's fallback.
  */
 async function healCreatedTaskPackOverrides(
 	deps: GraphqlToolDeps,
@@ -918,7 +915,7 @@ async function healCreatedTaskPackOverrides(
 	orgId: string,
 	healable: RawTask[],
 	comment: string,
-): Promise<boolean> {
+): Promise<{ ok: boolean; updatedAt?: string }> {
 	try {
 		const fresh = await fetchWorkflow(deps, workflowId, orgId);
 		const byId = new Map(fresh.tasks.map(t => [t.id, t]));
@@ -931,12 +928,19 @@ async function healCreatedTaskPackOverrides(
 			openedAt: fresh.updatedAt,
 			comment: `${comment} (auto-correct packOverrides mode on newly created task(s))`,
 		});
-		return !firstErrorMessage(result as ExecResult);
+		if (firstErrorMessage(result as ExecResult)) return { ok: false };
+		const updated = (result.data as UpdateWorkflowResult)?.updateWorkflow;
+		return { ok: true, updatedAt: updated?.updatedAt };
 	} catch {
-		return false;
+		return { ok: false };
 	}
 }
 
+/**
+ * The shared workflow write pipeline: resolve action refs, read the current
+ * workflow, apply operations to the whole graph, and save with the correct
+ * openedAt token — retrying once on a version conflict.
+ */
 export async function applyWorkflowMutation(
 	deps: GraphqlToolDeps,
 	workflowId: string,
@@ -948,7 +952,12 @@ export async function applyWorkflowMutation(
 	const apply = (source: RawWorkflow) => applyOperations(source.tasks, operations, actionIdByRef);
 
 	const workflow = await fetchWorkflow(deps, workflowId, orgId);
-	const originalTaskIds = new Set(workflow.tasks.map(t => t.id));
+	// Tracks task ids that existed before this edit, so a task created by one of
+	// this batch's own add_task operations can be told apart from a pre-existing
+	// one for the packOverrides self-heal below. Recomputed from `fresh` on a
+	// version-conflict retry so a task another edit concurrently created between
+	// our read and write is never misclassified as "created by this batch".
+	let originalTaskIds = new Set(workflow.tasks.map(t => t.id));
 	let { tasks, applied, workflow: overrides, verifyFields } = apply(workflow);
 	if (!(await deps.confirmMutation(`update workflow "${workflow.name}" (${applied.length} operation(s))`))) {
 		throw new Error('Workflow change was not confirmed.');
@@ -962,6 +971,7 @@ export async function applyWorkflowMutation(
 	let error = firstErrorMessage(result as ExecResult);
 	if (error && /newer version/i.test(error)) {
 		const fresh = await fetchWorkflow(deps, workflowId, orgId);
+		originalTaskIds = new Set(fresh.tasks.map(t => t.id));
 		({ tasks, applied, workflow: overrides, verifyFields } = apply(fresh));
 		result = await deps.execute(WORKFLOW_UPDATE_MUTATION, {
 			workflow: workflowToInput(fresh, tasks, overrides),
@@ -972,20 +982,25 @@ export async function applyWorkflowMutation(
 	}
 	if (error) throw new Error(`updateWorkflow failed: ${error}`);
 
-	const updated = (result.data as { updateWorkflow?: { name?: string; updatedAt?: string } } | undefined)
-		?.updateWorkflow;
+	let updated = (result.data as UpdateWorkflowResult)?.updateWorkflow;
 	const toVerify = tasks.flatMap(task => {
 		const fields = verifyFields.get(task.id);
 		return fields ? [{ task, fields }] : [];
 	});
 	let verification = toVerify.length > 0 ? await verifySavedTaskValues(deps, workflowId, orgId, toVerify) : '';
 
+	// Scoped per task (not just "does the warning mention packOverrides anywhere"):
+	// only a task this batch created, whose OWN divergence line is present, is a
+	// heal candidate — an unrelated task's divergence must never trigger a
+	// pointless corrective write for a created task that already matched.
 	const healable = toVerify
 		.filter(({ task, fields }) => fields.packOverrides && !originalTaskIds.has(task.id))
-		.map(({ task }) => task);
-	if (healable.length > 0 && /packOverrides/.test(verification)) {
-		const healed = await healCreatedTaskPackOverrides(deps, workflowId, orgId, healable, comment);
-		if (healed) {
+		.map(({ task }) => task)
+		.filter(task => verification.includes(`task "${task.name}": packOverrides`));
+	if (healable.length > 0) {
+		const heal = await healCreatedTaskPackOverrides(deps, workflowId, orgId, healable, comment);
+		if (heal.ok) {
+			if (heal.updatedAt) updated = { ...updated, updatedAt: heal.updatedAt };
 			verification = await verifySavedTaskValues(deps, workflowId, orgId, toVerify);
 			if (!/packOverrides/.test(verification)) {
 				verification += `\n\nNote: auto-corrected packOverrides on ${healable.length} newly created task(s) — the server ignored the requested selection/fallback mode on creation but accepted it on this follow-up update.`;


### PR DESCRIPTION
## Summary

One batch PR covering six open issues, per repo convention of grouping closely related fixes into a single PR.

- **#168 — Chat forwards raw terminal info.** `statelessTranscript.ts` was forwarding raw terminal-tool output (e.g. `run_in_terminal`) to RoboRewsty verbatim with only a generic 8,000-char cap, so leftover scrollback from an unrelated terminal session could get treated as an implicit instruction. Terminal-tool output is now capped much tighter (2,000 chars) and explicitly framed as likely-unrelated raw output.

- **#173 — Jinja preview requires context.** `JinjaPreviewSession.doRender()` hard-blocked rendering until an execution context was picked, even though the backend already renders fine with empty vars (Jinja's normal undefined-variable semantics). It now renders immediately on open and on every edit, context or not.

- **#174 — packOverrides mode not sticking on `add_task`.** Investigation found this is *not* a client-side bug — `add_task`/`update_task` already forward `configSelectionMode`/`configFallbackMode` identically. The divergence is server-side: Rewst's `updateWorkflow` resolver honors those fields on a task *update* but defaults them on task *creation*. `applyWorkflowMutation` now detects that specific divergence for tasks created in the same edit and auto-replays one corrective update, instead of requiring the caller to redo it manually.

- **#175 — Resteer gives up too easily.** The native-Rewst-tool redirect only allowed one correction attempt before surfacing a "stopped" message. It now escalates through `MAX_NATIVE_REDIRECT_ATTEMPTS` (25) attempts, each naming its attempt number, before giving up — the stop message should now essentially never surface.

- **#176 — Stale template name after rename.** `buddy_rename_template` updated Rewst but never touched `LinkManager`'s cache, so the status bar/tree kept showing the old name until the next sync or reload. It now updates the cached link (name and `updatedAt`) and fires `onLinksSaved` immediately.

- **#177 — Delete confirmation gating gap.** This turned out to be a real gap, not just a missing modal: mutation-approval scopes keyed only on `[orgId, resourceId]` with no operation-type component, so approving a rename/update on a resource silently pre-approved a later **delete** of that same resource with zero prompt. Affected delete-template, delete-tag, delete-org-variable, and delete-workflow identically. All four now set `alwaysPrompt: true`, matching the existing pattern used for workflow run/edit. `buddy_graphql_mutate` (raw GraphQL mutations) closed the same class of gap: it also now always re-prompts, never reusing a scope-keyed approval, since its caller supplies an arbitrary scopeId alongside an arbitrary mutation with no verified relationship between the two.

Each fix follows the spec → test → code trio (`openspec/specs/`) and carries its own `changelog.d/` note. Also fixes an unrelated pre-existing type error in `conversationLimitInspect.test.ts` that was blocking the project-wide pre-commit type-check.

### Adversarial review pass

Ran an independent adversarial review against the branch (fresh model, told to assume bugs exist and find them, verify every claim against the actual code). It surfaced three real issues, all now fixed in a follow-up commit:

- **#177 bypass**: `buddy_graphql_mutate` shared the same scope-approval cache but wasn't marked always-prompt, leaving the exact vulnerability class #177 fixed open on that one path (gated behind the `enableDangerousGraphqlMutation` setting, off by default). Fixed: it now always re-prompts.
- **#176 follow-up**: rename updated the cached `name` but not `updatedAt`, which could cause a spurious auto-fetch/re-save cycle on next open. Fixed: `updatedAt` now moves forward too.
- **#174 edge cases**: the packOverrides self-heal gate could fire for a divergence on an unrelated (non-created) task; the reported version token after a heal was the stale pre-heal value; `originalTaskIds` wasn't recomputed on a version-conflict retry. All three tightened, each with new regression tests except the version-conflict-recompute case (a narrow concurrent-editing race that's difficult to construct a meaningful test for without an unrelated id-collision throw getting in the way — happy to add one if requested).

## Test plan

- [x] `npm run test:unit` — full suite green (vitest + vscode-test/mocha), including new regression tests for each fix and each adversarial-review follow-up
- [x] `npx tsc --noEmit` clean
- [x] Manually verified #173 (Jinja preview renders with no context picked)
- [ ] Reviewer: spot-check #175's escalating correction wording in a live chat session if convenient

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Chat now limits and labels raw terminal output to reduce unrelated context.
  - Chat retries incorrect tool requests more often before showing a stopped message.
  - Jinja Live Preview renders immediately, even before a context is selected.
  - Template renames now refresh linked template details instantly.
  - Workflow task settings are automatically corrected when not saved as selected.
  - Delete actions and raw GraphQL mutations always require fresh approval.
- **Documentation**
  - Updated feature guidance for immediate Jinja preview rendering and context selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->