### PR TITLE
Suggest safe Jinja retry-counter idiom in workflow lint

### DIFF
--- a/changelog.d/lint-retry-jinja-idiom.md
+++ b/changelog.d/lint-retry-jinja-idiom.md
@@ -1,0 +1,5 @@
+---
+category: Changed
+---
+
+- **Workflow lint now suggests a self-defaulting Jinja counter for manual retry loops.** The `task-retry-configured` finding shows the `CTX.retry|d|int` idiom so you don't need an extra task to initialize the counter before the loop starts.

--- a/changelog.d/lint-retry-jinja-idiom.md
+++ b/changelog.d/lint-retry-jinja-idiom.md
@@ -1,5 +1,6 @@
 ---
 category: Changed
+pr: 182
 ---
 
 - **Workflow lint now suggests a self-defaulting Jinja counter for manual retry loops.** The `task-retry-configured` finding shows the `CTX.retry|d|int` idiom so you don't need an extra task to initialize the counter before the loop starts.

--- a/openspec/specs/mcp-bridge/spec.md
+++ b/openspec/specs/mcp-bridge/spec.md
@@ -14,6 +14,7 @@ Source: `src/mcp/` (`McpServerController.ts`, `McpActions.ts`, `mcpServer.ts`,
 `instructions.ts`, `McpDefinitionProvider.ts`, `runtime.ts`, `settings.ts`, `throttle.ts`),
 `src/commands/mcp/`, `src/capabilities/*Capabilities.ts`,
 `src/capabilities/workflowImpactCapability.ts`,
+`src/capabilities/workflowLintCapability.ts`, `src/workflow/lint.ts`,
 `src/models/WorkingScopeManager.ts`, `src/ui/chat/tools/graphqlTool.ts`,
 `src/ui/chat/tools/workflowTools.ts`, `src/extension.ts`.
 
@@ -1357,3 +1358,19 @@ silently omitting levels. Per-node fetch errors SHALL degrade gracefully
 - **WHEN** `buddy_execution_logs` runs
 - **THEN** the error is appended as a note and the rest of the tree is still
   returned
+
+### Requirement: Guide safe retry-loop counters in lint findings (#180)
+
+When `buddy_workflow_lint` flags a task-level retry config
+(`task-retry-configured`), the finding message SHALL recommend a Jinja
+idiom for a manual retry-loop counter that defaults safely on first use,
+so authors do not need a separate task to initialize the counter before
+the loop starts.
+
+#### Scenario: Task-retry-configured finding recommends a self-defaulting counter
+
+- **GIVEN** a task has a non-null `retry` config
+- **WHEN** `buddy_workflow_lint` audits the workflow
+- **THEN** the `task-retry-configured` finding message includes a Jinja
+  default-then-cast pattern (`CTX.retry|d|int`) for tracking the retry
+  attempt count without a prior initialization task

--- a/src/workflow/lint.test.ts
+++ b/src/workflow/lint.test.ts
@@ -289,6 +289,7 @@ suite('Unit: workflowLint', () => {
 		assert.strictEqual(retryFindings[0].severity, 'warning');
 		assert.strictEqual(retryFindings[0].taskId, 't1');
 		assert.ok(retryFindings[0].message.includes('my_task'));
+		assert.ok(retryFindings[0].message.includes('CTX.retry|d|int'));
 	});
 
 	test('action-without-timeout no longer mentions retry', () => {

--- a/src/workflow/lint.ts
+++ b/src/workflow/lint.ts
@@ -160,7 +160,7 @@ export function lintWorkflow(workflow: RawWorkflow): LintFinding[] {
 				severity: 'warning',
 				taskId: task.id,
 				taskName: task.name,
-				message: `Task "${task.name}" (${task.id}) has a task-level retry config; the Rewst engine can fail to initialize such a task. Replace it with a loop: a sub-workflow wrapper with a delay task on the failure path.`,
+				message: `Task "${task.name}" (${task.id}) has a task-level retry config; the Rewst engine can fail to initialize such a task. Replace it with a loop: a sub-workflow wrapper with a delay task on the failure path. Track the attempt count with a CTX variable that defaults safely on first use, e.g. \`CTX.retry|d|int\` (an unset CTX.retry becomes '' via the bare \`d\` filter, then 0 via \`int\`) — no separate initialization task is needed. Increment it with \`CTX.retry|d|int + 1\` and gate the loop with a condition such as \`CTX.retry|d|int <= 3\`.`,
 			});
 		}
 


### PR DESCRIPTION
## Summary

The `task-retry-configured` workflow-lint finding already tells authors to replace an engine-breaking task-level retry with a manual delay-and-loop sub-workflow, but never showed how to safely initialize the loop counter. This adds the `CTX.retry|d|int` idiom to the finding message: an unset `CTX.retry` becomes `''` via the bare `d` filter, then `0` via `int`, so no separate initialization task is needed.

## Changes

- `src/workflow/lint.ts` — extend the `task-retry-configured` finding message with the self-defaulting `CTX.retry|d|int` idiom (increment + loop-gate examples).
- `src/workflow/lint.test.ts` — extend the existing `task-retry-configured` test to assert the message includes `CTX.retry|d|int`.
- `openspec/specs/mcp-bridge/spec.md` — add a requirement/scenario for the idiom and reference `workflowLintCapability.ts` / `lint.ts` in the Source line.
- `changelog.d/lint-retry-jinja-idiom.md` — changelog note.

Closes #180